### PR TITLE
Update RuboCop module name (v0.23.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rubocop --require rubocop-rspec
 ### Rake task
 
 ```ruby
-Rubocop::RakeTask.new do |task|
+RuboCop::RakeTask.new do |task|
   task.requires << 'rubocop-rspec'
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ desc 'Run RuboCop over this gem'
 task :internal_investigation do
   require 'rubocop-rspec'
 
-  result = Rubocop::CLI.new.run
+  result = RuboCop::CLI.new.run
   abort('RuboCop failed!') unless result == 0
 end
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -6,7 +6,7 @@ require 'rubocop/rspec/version'
 require 'rubocop/rspec/inject'
 require 'rubocop/rspec/top_level_describe'
 
-Rubocop::RSpec::Inject.defaults!
+RuboCop::RSpec::Inject.defaults!
 
 # cops
 require 'rubocop/cop/rspec_describe_class'

--- a/lib/rubocop/cop/rspec_describe_class.rb
+++ b/lib/rubocop/cop/rspec_describe_class.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # Check that the first argument to the top level describe is the tested
     # class or module.

--- a/lib/rubocop/cop/rspec_describe_method.rb
+++ b/lib/rubocop/cop/rspec_describe_method.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # Checks that the second argument to the top level describe is the tested
     # method name.

--- a/lib/rubocop/cop/rspec_described_class.rb
+++ b/lib/rubocop/cop/rspec_described_class.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # If the first argument of describe is a class, the class is exposed to
     # each example via described_class - this should be used instead of

--- a/lib/rubocop/cop/rspec_example_wording.rb
+++ b/lib/rubocop/cop/rspec_example_wording.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # Do not use should when describing your tests.
     # see: http://betterspecs.org/#should

--- a/lib/rubocop/cop/rspec_file_name.rb
+++ b/lib/rubocop/cop/rspec_file_name.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # Checks the path of the spec file and enforces that it reflects the
     # described class/module and its optionally called out method.

--- a/lib/rubocop/cop/rspec_instance_variable.rb
+++ b/lib/rubocop/cop/rspec_instance_variable.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # When you have to assign a variable instead of using an instance variable,
     # use let.

--- a/lib/rubocop/cop/rspec_multiple_describes.rb
+++ b/lib/rubocop/cop/rspec_multiple_describes.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module Cop
     # Checks for multiple top level describes. They should be nested if it is
     # for the same class or module or seperated into different files.

--- a/lib/rubocop/rspec/inject.rb
+++ b/lib/rubocop/rspec/inject.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 
-module Rubocop
+module RuboCop
   module RSpec
     # Because RuboCop doesn't yet support plugins, we have to monkey patch in a
     # bit of our configuration.

--- a/lib/rubocop/rspec/top_level_describe.rb
+++ b/lib/rubocop/rspec/top_level_describe.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module RSpec
     # Helper methods for top level describe cops
     module TopLevelDescribe

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-module Rubocop
+module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.email = ['ian@nevir.net', 'git@nilsgemeinhardt.de']
   spec.licenses = ['MIT']
 
-  spec.version = Rubocop::RSpec::Version::STRING
+  spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
   spec.required_ruby_version = '>= 1.9.2'
 
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^spec\//)
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
-  spec.add_runtime_dependency('rubocop', '~> 0.19', '>= 0.19')
+  spec.add_runtime_dependency('rubocop', '~> 0.23.0')
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -15,7 +15,7 @@ describe 'RuboCop Project' do # rubocop:disable RSpecDescribeClass
     end
 
     subject(:default_config) do
-      Rubocop::ConfigLoader.load_file('config/default.yml')
+      RuboCop::ConfigLoader.load_file('config/default.yml')
     end
 
     it 'has configuration for all cops' do

--- a/spec/rubocop/cop/rspec_describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec_describe_class_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecDescribeClass do
+describe RuboCop::Cop::RSpecDescribeClass do
   subject(:cop) { described_class.new }
 
   it 'checks first-line describe statements' do

--- a/spec/rubocop/cop/rspec_describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec_describe_method_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecDescribeMethod do
+describe RuboCop::Cop::RSpecDescribeMethod do
   subject(:cop) { described_class.new }
 
   it 'enforces non-method names' do

--- a/spec/rubocop/cop/rspec_described_class_spec.rb
+++ b/spec/rubocop/cop/rspec_described_class_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecDescribedClass do
+describe RuboCop::Cop::RSpecDescribedClass do
   subject(:cop) { described_class.new }
 
   it 'checks for the use of the described class' do

--- a/spec/rubocop/cop/rspec_example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec_example_wording_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecExampleWording do
+describe RuboCop::Cop::RSpecExampleWording do
   subject(:cop) { described_class.new }
 
   it 'finds description with `should` at the beginning' do

--- a/spec/rubocop/cop/rspec_file_name_spec.rb
+++ b/spec/rubocop/cop/rspec_file_name_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecFileName do
+describe RuboCop::Cop::RSpecFileName do
   subject(:cop) { described_class.new }
 
   it 'checks the path' do

--- a/spec/rubocop/cop/rspec_instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec_instance_variable_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecInstanceVariable do
+describe RuboCop::Cop::RSpecInstanceVariable do
   subject(:cop) { described_class.new }
 
   it 'finds an instance variable inside a describe' do

--- a/spec/rubocop/cop/rspec_multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec_multiple_describes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Rubocop::Cop::RSpecMultipleDescribes do
+describe RuboCop::Cop::RSpecMultipleDescribes do
   subject(:cop) { described_class.new }
 
   it 'finds multiple top level describes with class and method' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,12 +15,12 @@ require 'rubocop-rspec'
 def parse_source(source, file = nil)
   source = source.join($RS) if source.is_a?(Array)
   if file.is_a? String
-    Rubocop::SourceParser.parse(source, file)
+    RuboCop::SourceParser.parse(source, file)
   elsif file
     file.write(source)
     file.rewind
-    Rubocop::SourceParser.parse(source, file.path)
+    RuboCop::SourceParser.parse(source, file.path)
   else
-    Rubocop::SourceParser.parse(source)
+    RuboCop::SourceParser.parse(source)
   end
 end


### PR DESCRIPTION
RuboCop changed it's module name on version **0.23.0**:

https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes
