### PR TITLE
Add config/ to gemspec

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
   spec.files = Dir[
-    '{lib,spec}/**/*',
+    '{config,lib,spec}/**/*',
     '*.md',
     '*.gemspec',
     'Gemfile',


### PR DESCRIPTION
The config directory is missing from the gemspec, and as such, the config
directory is missing when you install rubocop-rspec. This results in errors:

```
Running RuboCop...
No such file or directory @ rb_sysopen - /Users/pstengel/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/rubocop-rspec-1.0/config/default.yml
```
