### PR TITLE
Add autocorrect to RSpec::ExampleWording cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Drop support of ruby `1.9.2`. ([@geniou][])
 * Update to RuboCop `~> 0.24`. ([@geniou][])
+* Add `autocorrect` to `RSpec::ExampleWording`. This experimental - use with care and check the changes. ([@geniou][])
 
 ## 1.1.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -13,6 +13,12 @@ RSpec/DescribeMethod:
 RSpec/ExampleWording:
   Description: 'Do not use should when describing your tests.'
   Enabled: true
+  CustomTransform:
+    be: is
+    have: has
+    not: does not
+  IgnoredWords: []
+
 
 RSpec/MultipleDescribes:
   Description: 'Checks for multiple top level describes.'

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -6,6 +6,9 @@ module RuboCop
       # Do not use should when describing your tests.
       # see: http://betterspecs.org/#should
       #
+      # The autocorrect is experimental - use with care! It can be configured
+      # with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
+      #
       # @example
       #   # bad
       #   it 'should find nothing' do
@@ -27,7 +30,57 @@ module RuboCop
           message = arguments.first.to_s
           return unless message.start_with?('should')
 
-          add_offense(method, :selector, MSG)
+          arg1 = args.first.loc.expression
+          message = Parser::Source::Range
+            .new(arg1.source_buffer, arg1.begin_pos + 1, arg1.end_pos - 1)
+
+          add_offense(message, message, MSG)
+        end
+
+        def autocorrect(range)
+          @corrections << lambda do |corrector|
+            corrector.replace(range, corrected_message(range))
+          end
+        end
+
+        private
+
+        def corrected_message(range)
+          range.source.split(' ').tap do |words|
+            first_word = words.shift
+            words.unshift('not') if first_word == "shouldn't"
+
+            words.each_with_index do |value, key|
+              next if ignored_words.include?(value)
+              words[key] = simple_present(words[key])
+              break
+            end
+          end.join(' ')
+        end
+
+        def simple_present(word)
+          return custom_transform[word] if custom_transform[word]
+
+          # ends with o s x ch sh or ss
+          if %w(o s x]).include?(word[-1]) ||
+            %w(ch sh ss]).include?(word[-2..-1])
+            return "#{word}es"
+          end
+
+          # ends with y
+          if word[-1] == 'y' && !%w(a u i o e).include?(word[-2])
+            return "#{word[0..-2]}ies"
+          end
+
+          "#{word}s"
+        end
+
+        def custom_transform
+          cop_config['CustomTransform'] || []
+        end
+
+        def ignored_words
+          cop_config['IgnoredWords'] || []
         end
       end
     end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -2,8 +2,14 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::RSpec::ExampleWording do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::RSpec::ExampleWording, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) do
+    {
+      'CustomTransform' => { 'have' => 'has', 'not' => 'does not' },
+      'IgnoredWords' => %w(only realy)
+    }
+  end
 
   it 'finds description with `should` at the beginning' do
     inspect_source(cop, ["it 'should do something' do", 'end'])
@@ -11,7 +17,16 @@ describe RuboCop::Cop::RSpec::ExampleWording do
     expect(cop.offenses.map(&:line).sort).to eq([1])
     expect(cop.messages)
       .to eq(['Do not use should when describing your tests.'])
-    expect(cop.highlights).to eq(['it'])
+    expect(cop.highlights).to eq(['should do something'])
+  end
+
+  it 'finds description with `shouldn\'t` at the beginning' do
+    inspect_source(cop, ['it "shouldn\'t do something" do', 'end'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.offenses.map(&:line).sort).to eq([1])
+    expect(cop.messages)
+      .to eq(['Do not use should when describing your tests.'])
+    expect(cop.highlights).to eq(['shouldn\'t do something'])
   end
 
   it 'skips descriptions without `should` at the beginning' do
@@ -19,5 +34,27 @@ describe RuboCop::Cop::RSpec::ExampleWording do
                          "   'here' do",
                          'end'])
     expect(cop.offenses).to be_empty
+  end
+
+  {
+    'should return something' => 'returns something',
+    'should not return something' => 'does not return something',
+    'should do nothing' => 'does nothing',
+    'should have sweets' => 'has sweets',
+    'should worry about the future' => 'worries about the future',
+    'should pay for pizza' => 'pays for pizza',
+    'should miss me' => 'misses me',
+    'should realy only return one item' => 'realy only returns one item'
+  }.each do |old, new|
+    it 'autocorrects an offenses' do
+      new_source = autocorrect_source(cop, ["it '#{old}' do", 'end'])
+      expect(new_source).to eq("it '#{new}' do\nend")
+    end
+  end
+
+  it "autocorrects shouldn't" do
+    new_source =
+      autocorrect_source(cop, 'it "shouldn\'t return something" do; end')
+    expect(new_source).to eq('it "does not return something" do; end')
   end
 end


### PR DESCRIPTION
@nevir could you have a look?

I'm trying to implement an `autocorrect` for the `RSpec::ExampleWording` cop. The idea is to change something like `it 'should use tool'` to `it 'uses tool'`.

I'm going to improve it the next days so if you have any hint let me know.
