### PR TITLE
Make LeadingSubject enforce subject to be above any examples or hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* `RSpec/LeadingSubject` now enforces subject to be before any examples, hooks or let declarations. ([@Darhazer][])
+
 ## 1.26.0 (2018-06-06)
 
 * Fix false positive in `RSpec/EmptyExampleGroup` cop when methods named like a RSpec method are used.  ([@Darhazer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -215,7 +215,7 @@ RSpec/ItBehavesLike:
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
 
 RSpec/LeadingSubject:
-  Description: Checks for `subject` definitions that come after `let` definitions.
+  Description: Enforce that subject is the first definition in the test.
   Enabled: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1230,31 +1230,34 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Checks for `subject` definitions that come after `let` definitions.
+Enforce that subject is the first definition in the test.
 
 ### Examples
 
 ```ruby
 # bad
-RSpec.describe User do
   let(:params) { blah }
   subject { described_class.new(params) }
 
-  it 'is valid' do
-    expect(subject.valid?).to be(true)
-  end
-end
+  before { do_something }
+  subject { described_class.new(params) }
+
+  it { expect_something }
+  subject { described_class.new(params) }
+  it { expect_something_else }
 
 # good
-RSpec.describe User do
   subject { described_class.new(params) }
-
   let(:params) { blah }
 
-  it 'is valid' do
-    expect(subject.valid?).to be(true)
-  end
-end
+# good
+  subject { described_class.new(params) }
+  before { do_something }
+
+# good
+  subject { described_class.new(params) }
+  it { expect_something }
+  it { expect_something_else }
 ```
 
 ### References

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
         let!(:params) { foo }
 
         subject { described_class.new }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let!` declarations.
       end
     RUBY
   end
@@ -63,8 +63,31 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
+  it 'checks subject below hook' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        before { allow(Foo).to receive(:bar) }
+
+        subject { described_class.new }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `before` declarations.
+      end
+    RUBY
+  end
+
+  it 'checks subject below example' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        it { is_expected.to be_present }
+
+        subject { described_class.new }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `it` declarations.
+      end
+    RUBY
+  end
+
   bad_code = <<-RUBY
     RSpec.describe User do
+      before { allow(Foo).to receive(:bar) }
       let(:params) { foo }
       let(:bar) { baz }
 
@@ -76,6 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   good_code = <<-RUBY
     RSpec.describe User do
       subject { described_class.new }
+      before { allow(Foo).to receive(:bar) }
       let(:params) { foo }
       let(:bar) { baz }
 


### PR DESCRIPTION
Fixes #616 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-rspec/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
