### PR TITLE
[Fix #624] Don't check let declarations with dynamic arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `RSpec/EmptyLineAfterExampleGroup` cop to check that there is an empty line after example group blocks. ([@bquorning][])
 * Fix `RSpec/DescribeClass` crashing on `RSpec.describe` without arguments. ([@Darhazer][])
 * Bump RuboCop requirement to v0.56.0. ([@bquorning][])
+* Fix `RSpec/OverwritingSetup` crashing if a variable is used as an argument for `let`. ([@Darhazer][])
 
 ## 1.26.0 (2018-06-06)
 

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -46,7 +46,7 @@ module RuboCop
             next unless common_setup?(child)
 
             name = if child.send_node.arguments?
-                     child.send_node.first_argument.value
+                     child.send_node.first_argument.to_a.first.to_sym
                    else
                      :subject
                    end

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -25,6 +25,7 @@ module RuboCop
         MSG = '`%<name>s` is already defined.'.freeze
 
         def_node_matcher :setup?, (Helpers::ALL + Subject::ALL).block_pattern
+        def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'
 
         def on_block(node)
           return unless example_group_with_body?(node)
@@ -46,7 +47,7 @@ module RuboCop
             next unless common_setup?(child)
 
             name = if child.send_node.arguments?
-                     child.send_node.first_argument.to_a.first.to_sym
+                     first_argument_name(child.send_node).to_sym
                    else
                      :subject
                    end

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
+  it 'handles dynamic names for `let`' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe User do
+        subject(:name) { a }
+
+        let(name) { b }
+      end
+    RUBY
+  end
+
   it 'does not encounter an error when handling an empty describe' do
     expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
       .not_to raise_error

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
+  it 'handles string arguments' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        subject(:name) { a }
+
+        let("name") { b }
+        ^^^^^^^^^^^^^^^^^ `name` is already defined.
+      end
+    RUBY
+  end
+
   it 'does not encounter an error when handling an empty describe' do
     expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
       .not_to raise_error


### PR DESCRIPTION
Only basic_literals define `#value` method.

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

