### PR TITLE
[Fix #623] Allow describe without argument and with explicit receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix `RSpec/NotToNot` to highlight only the selector (`not_to` or `to_not`), so it works also on `expect { ... }` blocks. ([@bquorning][])
 * Add `RSpec/EmptyLineAfterHook` cop. ([@bquorning][])
 * Add `RSpec/EmptyLineAfterExampleGroup` cop to check that there is an empty line after example group blocks. ([@bquorning][])
+* Fix `RSpec/DescribeClass` crashing on `RSpec.describe` without arguments. ([@Darhazer][])
 
 ## 1.26.0 (2018-06-06)
 

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -23,7 +23,10 @@ module RuboCop
               'the class or module being tested.'.freeze
 
         def_node_matcher :valid_describe?, <<-PATTERN
-          {(send {(const nil? :RSpec) nil?} :describe const ...) (send nil? :describe)}
+          {
+            (send {(const nil? :RSpec) nil?} :describe const ...)
+            (send {(const nil? :RSpec) nil?} :describe)
+          }
         PATTERN
 
         def_node_matcher :describe_with_metadata, <<-PATTERN

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -95,6 +95,9 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
 
   it 'ignores an empty describe' do
     expect_no_offenses(<<-RUBY)
+      RSpec.describe do
+      end
+
       describe do
       end
     RUBY


### PR DESCRIPTION
The cop was checking for describe without arguments in its `valid_describe?` matcher, but unlike the check for consts, the check for no arguments was only with implicit receiver

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
