### PR TITLE
JRuby build image needs `make` installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,15 @@ jobs:
       - image: circleci/jruby:9.1
     steps:
       - checkout
+      - run: sudo apt-get install -y make
       - run: bundle lock
       - restore_cache:
           keys:
-            - bundle-v1-{{ checksum "Gemfile.lock" }}
-            - bundle-v1-
+            - bundle-v2-{{ checksum "Gemfile.lock" }}
+            - bundle-v2-
       - run: bundle install --path vendor/bundle
       - save_cache:
-          key: bundle-v1-{{ checksum "Gemfile.lock" }}
+          key: bundle-v2-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run: rake internal_investigation spec


### PR DESCRIPTION
The `jaro_winkler` gem cannot be installed on jruby unless the command `make` is available. So I ~made a docker image~ added a `run` step that installs `make`, and for some reason I had to also bump the CircleCI bundle cache.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
