### PR TITLE
Highlight selector in RSpec/NotToNot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * `RSpec/LeadingSubject` now enforces subject to be before any examples, hooks or let declarations. ([@Darhazer][])
+* Fix `RSpec/NotToNot` to highlight only the selector (`not_to` or `to_not`), so it works also on `expect { ... }` blocks. ([@bquorning][])
 
 ## 1.26.0 (2018-06-06)
 

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         def on_send(node)
           not_to_not_offense(node, alternative_style) do
-            add_offense(node, location: :expression)
+            add_offense(node, location: :selector)
           end
         end
 

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -7,7 +7,16 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     it 'detects the `to_not` offense' do
       expect_offense(<<-RUBY)
         it { expect(false).to_not be_true }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to` over `to_not`.
+                           ^^^^^^ Prefer `not_to` over `to_not`.
+      RUBY
+    end
+
+    it 'detects the `to_not` offense on an expect block' do
+      expect_offense(<<-RUBY)
+        expect {
+          2 + 2
+        }.to_not raise_error
+          ^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
     end
 
@@ -20,6 +29,18 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     include_examples 'autocorrect',
                      'it { expect(0).to_not equal 1 }',
                      'it { expect(0).not_to equal 1 }'
+
+    original = <<-RUBY
+      expect {
+        2 + 2
+      }.to_not raise_error
+    RUBY
+    corrected = <<-RUBY
+      expect {
+        2 + 2
+      }.not_to raise_error
+    RUBY
+    include_examples 'autocorrect', original, corrected
   end
 
   context 'when AcceptedMethod is `to_not`' do
@@ -28,7 +49,16 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     it 'detects the `not_to` offense' do
       expect_offense(<<-RUBY)
         it { expect(false).not_to be_true }
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `to_not` over `not_to`.
+                           ^^^^^^ Prefer `to_not` over `not_to`.
+      RUBY
+    end
+
+    it 'detects the `not_to` offense on an expect block' do
+      expect_offense(<<-RUBY)
+        expect {
+          2 + 2
+        }.not_to raise_error
+          ^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
     end
 
@@ -41,5 +71,17 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
     include_examples 'autocorrect',
                      'it { expect(0).not_to equal 1 }',
                      'it { expect(0).to_not equal 1 }'
+
+    original = <<-RUBY
+      expect {
+        2 + 2
+      }.not_to raise_error
+    RUBY
+    corrected = <<-RUBY
+      expect {
+        2 + 2
+      }.to_not raise_error
+    RUBY
+    include_examples 'autocorrect', original, corrected
   end
 end


### PR DESCRIPTION
Fix `RSpec/NotToNot` to highlight only the selector (`not_to` or `to_not`), so it works also on `expect { ... }` blocks.

In other words, for this block:

```rb
expect {
  2 + 2
}.not_to raise_error
```
Instead of seeing this:
```
expect {
^^^^^^^^ Prefer `to_not` over `not_to`.
```
we will now see this:
```
  2 + 2
}.not_to raise_error
  ^^^^^^ Prefer `to_not` over `not_to`.
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
