### PR TITLE
Fix "new cop generator" rake task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `RSpec/EmptyLineAfterHook` cop. ([@bquorning][])
 * Add `RSpec/EmptyLineAfterExampleGroup` cop to check that there is an empty line after example group blocks. ([@bquorning][])
 * Fix `RSpec/DescribeClass` crashing on `RSpec.describe` without arguments. ([@Darhazer][])
+* Bump RuboCop requirement to v0.56.0. ([@bquorning][])
 
 ## 1.26.0 (2018-06-06)
 

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,10 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  generator = RuboCop::Cop::Generator.new(cop_name)
+  github_user = `git config github.user`.chop
+  github_user = 'your_id' if github_user.empty?
+
+  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
 
   generator.write_source
   generator.write_spec

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.53.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.56.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
The `RuboCop::Cop::Generator.initialize` API was changed in https://github.com/rubocop-hq/rubocop/commit/488c6dee600f4b23326fa862a66e8e16783 which was released with RuboCop v0.56.0.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
