### PR TITLE
Change error message from confirm_documentation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,8 @@ task confirm_documentation: :generate_cops_documentation do
     Open3.popen3('git diff --exit-code manual/')
 
   unless process.value.success?
-    raise 'manual is out of sync, please add manual/ to the commit'
+    raise 'Please run `rake generate_cops_documentation` ' \
+          'and add manual/ to the commit.'
   end
 end
 


### PR DESCRIPTION
When the `confirm_documentation` rake task fails on CI, it is helpful to know that `rake generate_cops_documentation` will create the changes that must be added to make the build pass.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
