### PR TITLE
Use location#dot instead of fixed offset

### DIFF
--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -76,7 +76,7 @@ module RuboCop
 
         def range(node, offending_node)
           range_between(
-            offending_node.loc.selector.begin_pos - 1, # match the dot as well
+            offending_node.loc.dot.begin_pos,
             node.loc.expression.end_pos
           )
         end


### PR DESCRIPTION
> Just a thought: How does this work if the dot is the last character on the preceding line?

Nice question. Turns out Rubocop have a method to give you the location of a dot.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] ~Added tests.~
* [ ] ~Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

