### PR TITLE
Implement autocorrect for Capybara/CurrentPathExpectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `IgnoreSharedExamples` option for `RSpec/NamedSubject`. ([@RST-J][])
+* Add autocorrect support for `Capybara/CurrentPathExpectation` cop. ([@ypresto][])
 
 ## 1.30.1 (2018-11-01)
 
@@ -392,3 +393,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@BrentWheeldon]: https://github.com/BrentWheeldon
 [@daveworth]: https://github.com/daveworth
 [@RST-J]: https://github.com/RST-J
+[@ypresto]: https://github.com/ypresto

--- a/manual/cops_capybara.md
+++ b/manual/cops_capybara.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 Checks that no expectations are set on Capybara's `current_path`.
 

--- a/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
@@ -26,4 +26,38 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation do
       current_path = WalkingRoute.last.path
     RUBY
   end
+
+  include_examples 'autocorrect',
+                   'expect(current_path).to eq expected_path',
+                   'expect(page).to have_current_path expected_path'
+
+  include_examples 'autocorrect',
+                   'expect(page.current_path).to eq(foo(bar).path)',
+                   'expect(page).to have_current_path(foo(bar).path)'
+
+  include_examples 'autocorrect',
+                   'expect(current_path).not_to eq expected_path',
+                   'expect(page).to have_no_current_path expected_path'
+
+  include_examples 'autocorrect',
+                   'expect(current_path).to_not eq expected_path',
+                   'expect(page).to have_no_current_path expected_path'
+
+  include_examples 'autocorrect',
+                   'expect(page.current_path).to match(/regexp/i)',
+                   'expect(page).to have_current_path(/regexp/i)'
+
+  include_examples 'autocorrect',
+                   'expect(page.current_path).to match("string/")',
+                   'expect(page).to have_current_path(/string\//)'
+
+  # Unsupported, no change.
+  include_examples 'autocorrect',
+                   'expect(page.current_path).to match(variable)',
+                   'expect(page.current_path).to match(variable)'
+
+  # Unsupported, no change.
+  include_examples 'autocorrect',
+                   'expect(page.current_path)',
+                   'expect(page.current_path)'
 end


### PR DESCRIPTION
Capybara/CurrentPathExpectation did not have autocorrect so I implemented it!

Note that `match(variable)` is not supported due to ambiguous replacement:

- If `variable` returns string, it should be replaced with `have_current_path(/#{variable}/)`.
- If `variable` returns regexp, it should be replaced with `have_current_path(variable)`.

ref: #470

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).