### PR TITLE
Unify empty line cop logic

### DIFF
--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -20,6 +20,7 @@ require_relative 'rubocop/cop/rspec/cop'
 require_relative 'rubocop/rspec/align_let_brace'
 require_relative 'rubocop/rspec/capybara'
 require_relative 'rubocop/rspec/factory_bot'
+require_relative 'rubocop/rspec/final_end_location'
 
 RuboCop::RSpec::Inject.defaults!
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -21,6 +21,7 @@ require_relative 'rubocop/rspec/align_let_brace'
 require_relative 'rubocop/rspec/capybara'
 require_relative 'rubocop/rspec/factory_bot'
 require_relative 'rubocop/rspec/final_end_location'
+require_relative 'rubocop/rspec/blank_line_separation'
 
 RuboCop::RSpec::Inject.defaults!
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -24,6 +24,8 @@ module RuboCop
       #   end
       #
       class EmptyLineAfterExampleGroup < Cop
+        include RuboCop::RSpec::BlankLineSeparation
+
         MSG = 'Add an empty line after `%<example_group>s`.'.freeze
 
         def_node_matcher :example_group, ExampleGroups::ALL.block_pattern
@@ -32,24 +34,13 @@ module RuboCop
           return unless example_group(node)
           return if node.parent && node.equal?(node.parent.children.last)
 
-          return if next_line(node).blank?
-
-          add_offense(
-            node,
-            location: node.loc.end,
-            message: format(MSG, example_group: node.method_name)
-          )
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.insert_after(node.loc.end, "\n") }
-        end
-
-        private
-
-        def next_line(node)
-          send_line = node.loc.end.line
-          processed_source[send_line]
+          missing_separating_line(node) do |location|
+            add_offense(
+              node,
+              location: location,
+              message: format(MSG, example_group: node.method_name)
+            )
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   it { does_something }
       class EmptyLineAfterFinalLet < Cop
         include RangeHelp
+        include RuboCop::RSpec::FinalEndLocation
 
         MSG = 'Add an empty line after the last `let` block.'.freeze
 
@@ -47,26 +48,11 @@ module RuboCop
         private
 
         def no_new_line_after(node)
-          loc = last_node_loc(node)
-          line = loc.line
+          line = final_end_location(node).line
           line += 1 while comment_line?(processed_source[line])
 
           return if processed_source[line].blank?
           yield offending_loc(node, line)
-        end
-
-        def last_node_loc(node)
-          last_line = node.loc.end.line
-          heredoc_line(node) do |loc|
-            return loc if loc.line > last_line
-          end
-          node.loc.end
-        end
-
-        def heredoc_line(node, &block)
-          yield node.loc.heredoc_end if node.loc.respond_to?(:heredoc_end)
-
-          node.each_child_node { |child| heredoc_line(child, &block) }
         end
 
         def offending_loc(node, last_line)

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -17,8 +17,7 @@ module RuboCop
       #
       #   it { does_something }
       class EmptyLineAfterFinalLet < Cop
-        include RangeHelp
-        include RuboCop::RSpec::FinalEndLocation
+        include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add an empty line after the last `let` block.'.freeze
 
@@ -32,37 +31,8 @@ module RuboCop
           return if latest_let.nil?
           return if latest_let.equal?(node.body.children.last)
 
-          no_new_line_after(latest_let) do |location|
+          missing_separating_line(latest_let) do |location|
             add_offense(latest_let, location: location)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            no_new_line_after(node) do |location|
-              corrector.insert_after(location.end, "\n")
-            end
-          end
-        end
-
-        private
-
-        def no_new_line_after(node)
-          line = final_end_location(node).line
-          line += 1 while comment_line?(processed_source[line])
-
-          return if processed_source[line].blank?
-          yield offending_loc(node, line)
-        end
-
-        def offending_loc(node, last_line)
-          offending_line = processed_source[last_line - 1]
-          if comment_line?(offending_line)
-            start = offending_line.index('#')
-            length = offending_line.length - start
-            source_range(processed_source.buffer, last_line, start, length)
-          else
-            node.loc.expression
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -34,6 +34,8 @@ module RuboCop
       #   it { does_something }
       #
       class EmptyLineAfterHook < Cop
+        include RuboCop::RSpec::BlankLineSeparation
+
         MSG = 'Add an empty line after `%<hook>s`.'.freeze
 
         def_node_matcher :hook?, Hooks::ALL.block_pattern
@@ -42,24 +44,13 @@ module RuboCop
           return unless hook?(node)
           return if node.equal?(node.parent.children.last)
 
-          return if next_line(node).blank?
-
-          add_offense(
-            node,
-            location: :expression,
-            message: format(MSG, hook: node.method_name)
-          )
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.insert_after(node.loc.end, "\n") }
-        end
-
-        private
-
-        def next_line(node)
-          send_line = node.loc.end.line
-          processed_source[send_line]
+          missing_separating_line(node) do |location|
+            add_offense(
+              node,
+              location: location,
+              message: format(MSG, hook: node.method_name)
+            )
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -15,6 +15,8 @@ module RuboCop
       #
       #   let(:foo) { bar }
       class EmptyLineAfterSubject < Cop
+        include RuboCop::RSpec::BlankLineSeparation
+
         MSG = 'Add empty line after `subject`.'.freeze
 
         def_node_matcher :subject?, Subject::ALL.block_pattern
@@ -23,15 +25,9 @@ module RuboCop
           return unless subject?(node) && !in_spec_block?(node)
           return if node.equal?(node.parent.children.last)
 
-          send_line = node.loc.end.line
-          next_line = processed_source[send_line]
-          return if next_line.blank?
-
-          add_offense(node, location: :expression, message: MSG)
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.insert_after(node.loc.end, "\n") }
+          missing_separating_line(node) do |location|
+            add_offense(node, location: location, message: MSG)
+          end
         end
 
         private

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -32,6 +32,7 @@ module RuboCop
       #   end
       class LetBeforeExamples < Cop
         include RangeHelp
+        include RuboCop::RSpec::FinalEndLocation
 
         MSG = 'Move `let` before the examples in the group.'.freeze
 
@@ -91,21 +92,10 @@ module RuboCop
         end
 
         def node_range(node)
-          range_between(node.loc.expression.begin_pos, last_node_loc(node))
-        end
-
-        def last_node_loc(node)
-          heredoc = heredoc_lines(node).last
-
-          if heredoc
-            heredoc.loc.heredoc_end.end_pos
-          else
-            node.loc.end.end_pos
-          end
-        end
-
-        def heredoc_lines(node)
-          node.body.child_nodes.select { |n| n.loc.respond_to?(:heredoc_end) }
+          range_between(
+            node.loc.expression.begin_pos,
+            final_end_location(node).end_pos
+          )
         end
       end
     end

--- a/lib/rubocop/rspec/blank_line_separation.rb
+++ b/lib/rubocop/rspec/blank_line_separation.rb
@@ -1,0 +1,37 @@
+module RuboCop
+  module RSpec
+    # Helps determine the offending location if there is not a blank line
+    # following the node. Allows comments to follow directly after.
+    module BlankLineSeparation
+      include FinalEndLocation
+      include RuboCop::Cop::RangeHelp
+
+      def missing_separating_line(node)
+        line = final_end_location(node).line
+
+        line += 1 while comment_line?(processed_source[line])
+
+        return if processed_source[line].blank?
+
+        yield offending_loc(line)
+      end
+
+      def offending_loc(last_line)
+        offending_line = processed_source[last_line - 1]
+
+        content_length = offending_line.lstrip.length
+        start          = offending_line.length - content_length
+
+        source_range(processed_source.buffer, last_line, start, content_length)
+      end
+
+      def autocorrect(node)
+        lambda do |corrector|
+          missing_separating_line(node) do |location|
+            corrector.insert_after(location.end, "\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/rspec/final_end_location.rb
+++ b/lib/rubocop/rspec/final_end_location.rb
@@ -1,0 +1,15 @@
+module RuboCop
+  module RSpec
+    # Helps find the true end location of nodes which might contain heredocs.
+    module FinalEndLocation
+      def final_end_location(start_node)
+        heredoc_endings =
+          start_node.each_node(:str, :dstr, :xstr)
+            .select(&:heredoc?)
+            .map { |node| node.loc.heredoc_end }
+
+        [start_node.loc.end, *heredoc_endings].max_by(&:line)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
     RUBY
   end
 
+  it 'highlights single line formulations correctly' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        describe('#bar') { }
+        ^^^^^^^^^^^^^^^^^^^^ Add an empty line after `describe`.
+        describe '#baz' do
+        end
+      end
+    RUBY
+  end
+
   it 'checks for empty line after context' do
     expect_offense(<<-RUBY)
       RSpec.context 'foo' do

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       RSpec.describe User do
         let(:a) { a }
         let!(:b) do
-        ^^^^^^^^^^^ Add an empty line after the last `let` block.
           b
         end
+        ^^^ Add an empty line after the last `let` block.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -143,6 +143,21 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
+  it 'handles silly HEREDOC offense' do
+    expect_offense(<<-RUBY)
+      RSpec.describe 'silly heredoc syntax' do
+        let(:foo) { <<-BAR }
+        hello
+        world
+        BAR
+        ^^^ Add an empty line after the last `let` block.
+        it 'has tricky syntax' do
+          expect(foo).to eql("  hello\n  world\n")
+        end
+      end
+    RUBY
+  end
+
   bad_example = <<-RUBY
   RSpec.describe User do
     let(:params) { foo }
@@ -179,6 +194,31 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     let(:params) { foo }
     # a multiline comment marking
     # the end of setup
+
+    it 'has a new line' do
+    end
+  end
+  RUBY
+
+  include_examples 'autocorrect',
+                   bad_example,
+                   good_example
+
+  bad_example = <<-RUBY
+  RSpec.describe User do
+    let(:params) { <<-DOC }
+     I'm super annoying!
+    DOC
+    it 'has a new line' do
+    end
+  end
+  RUBY
+
+  good_example = <<-RUBY
+  RSpec.describe User do
+    let(:params) { <<-DOC }
+     I'm super annoying!
+    DOC
 
     it 'has a new line' do
     end


### PR DESCRIPTION
Resolves https://github.com/rubocop-hq/rubocop-rspec/pull/632#issuecomment-396821220 and unblocks #640 by:

- Adding the FinalEndLocation mixin
  * This mixin DRYs up the logic for determining the true end location of a node, including when it contains a heredoc.
- Unifying the empty line cops
    * DRYs things up a bit.
    * Ensures each cop correctly handles heredocs.
    * Unifies highlighting format.
      - Note: It was very hard to find some sort of unified way to highlight
        the different possible node endings, so I just went with
        highlighting the lowest offending line starting right of any
        whitespace.
    * Ensures each cop allows comments immediately following the offending
      line, notably to provide support for rubocop:disable directives
      (especially disable/enable pairs that might surround the block).
---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. (note: changes are probably too subtle to merit documentation)
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
