### PR TITLE
Remove duplicate `simplecov` gem specification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :test do
-  gem 'simplecov', require: false
-end
-
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)


### PR DESCRIPTION
- Removes warning bundler emits when installing. Since this is in the gemspec already, I can't see any reason to keep this around.

---

Before submitting the PR make sure the following are checked:

* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).