### PR TITLE
Add smoke tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,11 @@ require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.1
+  Exclude:
+    - 'vendor/**/*'
+    - 'spec/fixtures/**/*'
+    - 'tmp/**/*'
+    - 'spec/smoke_tests/**/*.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -86,11 +86,6 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
     RUBY
   end
 
-  it 'does not encounter an error when handling an empty describe' do
-    expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
-      .not_to raise_error
-  end
-
   bad_code = <<-RUBY
     RSpec.describe User do
       include_examples('should be after let')

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -86,9 +86,4 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
       end
     RUBY
   end
-
-  it 'does not encounter an error when handling an empty describe' do
-    expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
-      .not_to raise_error
-  end
 end

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -23,9 +23,4 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
   end
-
-  it 'does not encounter an error when handling an empty describe' do
-    expect { inspect_source('RSpec.describe(User) do end', 'a_spec.rb') }
-      .not_to raise_error
-  end
 end

--- a/spec/shared/smoke_test_examples.rb
+++ b/spec/shared/smoke_test_examples.rb
@@ -1,0 +1,25 @@
+RSpec.shared_examples 'smoke test', type: :cop_spec do
+  context 'with default configuration' do
+    # This is overridden to avoid a number of specs that define `cop_config`
+    # (so it is referenced in the 'config' shared context) but do not define
+    # all of the dependent configuration options until inside of a context
+    # that is out of scope, causing a NameError.
+    let(:cop_config) { {} }
+
+    stress_tests = Pathname.glob('spec/smoke_tests/*.rb')
+
+    raise 'No smoke tests could be found!' if stress_tests.empty?
+
+    stress_tests.each do |path|
+      it "does not crash on smoke test: #{path}" do
+        source    = path.read
+        file_name = path.to_s
+
+        aggregate_failures do
+          expect { inspect_source(source, file_name) }.not_to raise_error
+          expect { autocorrect_source(source, file_name) }.not_to raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/smoke_tests/factory_bot_spec.rb
+++ b/spec/smoke_tests/factory_bot_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Since FactoryBot is not a dependency, none of this should be executed. We just
+# need the AST to exist.
+if false
+  FactoryBot.define do
+    factory :foo do
+      bar {}
+    end
+  end
+end

--- a/spec/smoke_tests/no_tests_spec.rb
+++ b/spec/smoke_tests/no_tests_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal:
+
+# This is sort of a test, but there's no rspec to see here.
+raise 'Uh oh, the Party seems to have gotten into ruby.' if 2 + 2 == 5

--- a/spec/smoke_tests/weird_rspec_spec.rb
+++ b/spec/smoke_tests/weird_rspec_spec.rb
@@ -1,0 +1,233 @@
+RSpec.describe 'Weirdness' do
+  subject! { nil }
+  subject { nil }
+  subject(:foo) { nil }
+  subject!(:foo) { nil }
+
+  subject! (:foo) { |something| nil }
+  subject  :foo  do end
+
+  let(:foo) { |something| something }
+  let (:foo) { 1 }
+  let!   (:bar){}
+
+  let :a do end
+
+  let(:bar) { <<-HEREDOC }
+    What a pain.
+  HEREDOC
+
+  let(:bar) { <<-'HEREDOC' }
+    Even odder.
+  HEREDOC
+
+  let(:baz) do
+    <<-INSIDE
+      Hi. I'm in your lets.
+    INSIDE
+  end
+
+  let(:hi)      {}
+  let(:bye) do
+  end
+
+  let(:doop) { foo; 1 }
+
+  it {}
+  specify {}
+
+  it 'works', metadata: true do
+  end
+
+  describe {}
+  context {}
+
+  describe '#nothing' do
+  end
+
+  it 'is empty' do
+  end
+
+  it '' do end
+  describe do end
+  context do end
+  shared_examples 'a' do end
+
+  describe 'things' do
+    context 'with context' do
+    end
+  end
+
+  shared_examples 'weird rspec' do
+  end
+
+  shared_examples :something do
+  end
+
+  context 'test' do
+    include_examples 'weird rspec'
+    include_examples('weird rspec', serious: true) do
+      it_behaves_like :something
+    end
+  end
+
+  it_behaves_like :something
+  it_should_behave_like :something
+
+  it_behaves_like :something do
+    let(:foo) { 'bar' }
+  end
+
+  it_behaves_like(:something) do |arg, *args, &block|
+  end
+
+  before {}
+  context 'never run' do
+    around {}
+  end
+  after {}
+
+  before { <<-DOC }
+   Eh, what's up?
+  DOC
+
+  around { |test| test.run; <<-DOC }
+   Eh, what's up?
+  DOC
+
+  after { <<-DOC }
+   Eh, what's up?
+  DOC
+
+  around do |test|
+    test.run
+  end
+
+  it 'is expecting you' do
+    expect('you').to eql('you')
+  end
+
+  it 'is expecting you not to raise an error' do
+    expect { 'you' }.not_to raise_error
+  end
+
+  it 'has chained expectations' do
+    expect('you').to eql('you').and(match(/y/))
+  end
+
+  %w[who likes dynamic examples].each do |word|
+    let(word) { word }
+
+    describe "#{word}" do
+      context "#{word}" do
+        it "lets the word '#{word}' be '#{word}'" do
+          expect(send(word)).to eql(word)
+        end
+      end
+    end
+  end
+
+  it { foo; 1 && 2}
+  it('has a description too') { foo; 1 && 2}
+
+  it %{quotes a string weird} do
+  end
+
+  it((' '.strip! ; 1 && 'isnt a simple string')) do
+    expect(nil).to be(nil)
+  end
+
+  it((' '.strip! ; 1 && 'isnt a simple string')) do
+    double = double(:foo)
+
+    allow(double).to receive(:oogabooga).with(nil).and_return(nil)
+
+    expect(double.oogabooga(nil)).to be(nil)
+
+    expect(double).to have_received(:oogabooga).once
+  end
+
+  it 'uses a matcher' do
+    expect([].empty?).to be(true)
+    expect([]).to be_empty
+  end
+
+  let(:klass) do
+    Class.new do
+      def initialize(thing)
+        @thing = thing
+      end
+
+      def announce
+        'wooo, so dynamic!'
+      end
+    end
+  end
+
+  it 'it does a thing' do
+  end
+
+  it 'It does a thing' do
+  end
+
+  it 'should not do the thing' do
+  end
+
+  specify do
+    foo = double(:bar)
+    allow(foo).to receive_message_chain(bar: 42, baz: 42)
+    allow(foo).to receive(:bar)
+    allow(foo).to receive_messages(bar: 42, baz: 42)
+  end
+end
+
+RSpec.describe {}
+RSpec.shared_examples('pointless') {}
+RSpec.shared_context('even pointless-er') {}
+RSpec.describe do end
+RSpec.shared_examples('pointless2') do end
+RSpec.shared_context('even pointless-er2') do end
+
+class Broken
+end
+
+RSpec.describe Broken do
+end
+
+RSpec.describe 'RubocopBug' do
+  subject { true }
+
+  before do
+    each_row = allow(double(:exporter)).to receive(:each_row)
+
+    [1, 2].each do |sig|
+      each_row = each_row.and_yield(sig)
+    end
+  end
+
+  it 'has a single example' do
+    expect(subject).to be_truthy
+  end
+
+  it 'has an expectation' do
+    stats = double(event: nil)
+
+    stats.event('tada!')
+
+    expect(stats)
+      .to have_received(:event)
+      .with('tada!')
+  end
+end
+
+RSpec.describe do
+  let(:uh_oh) { <<-HERE.strip + ", #{<<-THERE.strip}" }
+      Seriously
+  HERE
+      who designed these things?
+  THERE
+
+  it 'is insane' do
+    expect(uh_oh).to eql('Seriously, who designed these things?')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ spec_helper_glob = File.expand_path('{support,shared}/*.rb', __dir__)
 Dir.glob(spec_helper_glob).map(&method(:require))
 
 RSpec.configure do |config|
+  config.define_derived_metadata(file_path: %r{/spec/rubocop/cop/}) do |meta|
+    meta[:type] = :cop_spec
+  end
+
   config.order = :random
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
- Closes #388
- Adds a handful of rspec files that will stress our cops. These will be
  run with our normal tests (though the assertions are pointless) to
  audit whether the rspec is valid / close to valid. In the future I
  want to develop a corpus test from real ruby projects, but this is a
  good sanity check and includes a number of cases that have previously
  caused bugs.
- Shared example is automatically added to all cop specs based on our
  existing directory structure.
- Removed a few examples which just asserted no error (now covered by
  the smoke test).
- I jumped back 25 commits, cherry-picked the changes, and it caught at
  least two separate bugs that we've already fixed. I think this will
  definitely help us catch some things early.
- ~Also adds default file names to the various source inspection helpers.
  I was tearing my hair out for about an hour trying to figure out why
  in the heck my smoke tests were producing no smoke... only to very
  gradually remember that we filter based on filename and not realizing
  the default was `nil`.~
- Note: This will falsely inflate our coverage metrics a bit because it
  is more likely to arbitrarily exercise the various branches of new
  cops but assert nothing more than it didn't crash. We could account
  for this in a few ways (mutation testing, for instance, is unaffected
  by these changes) if we really wanted to, but I mainly just want
  for us maintainers to be aware that it can happen.
- Note: This is just a starting place for random RSpec usage, largely
  stream of consciousness, though i did mine our issues for cases that
  previously caused bugs. The file can grow with time when anyone
  thinks of something they could imagine raising an error.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).