### PR TITLE
Add `FirstArgumentRequired` option to `RSpec/DescribeClass`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/ReceiveNever` cop enforcing usage of `not_to receive` instead of `never` matcher. ([@Darhazer][])
+* Add `FirstArgumentRequired` option to `RSpec/DescribeClass`. ([@geniou][])
 
 ## 1.27.0 (2018-06-14)
 

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::RSpec::DescribeClass, :config do
+  subject(:cop) { described_class.new(config) }
 
   it 'checks first-line describe statements' do
     expect_offense(<<-RUBY)
@@ -101,6 +101,26 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
       describe do
       end
     RUBY
+  end
+
+  context 'when first argument is required' do
+    let(:cop_config) { { 'FirstArgumentRequired' => true } }
+
+    it 'flags empty describe' do
+      expect_offense(<<-RUBY)
+        describe do
+        ^^^^^^^^ The first argument to describe is required.
+        end
+      RUBY
+    end
+
+    it 'flags empty RSpec.describe' do
+      expect_offense(<<-RUBY)
+        RSpec.describe do
+        ^^^^^^^^^^^^^^ The first argument to describe is required.
+        end
+      RUBY
+    end
   end
 
   it 'ignores routing specs' do


### PR DESCRIPTION
See #635 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).