### PR TITLE
Use jruby:9 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
   # JRuby
   jruby:
     docker:
-      - image: circleci/jruby:9.1
+      - image: circleci/jruby:9
     steps:
       - checkout
       - run: sudo apt-get install -y make


### PR DESCRIPTION
circleci/jruby:9.1 was removed from dockerhub, which broke the jruby build.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
