### PR TITLE
Fix false positive when the node is the only one inside of if/else branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/ReceiveNever` cop enforcing usage of `not_to receive` instead of `never` matcher. ([@Darhazer][])
+* Fix false positive in `RSpec/EmptyLineAfterExampleGroup` cop when example is inside `if`. ([@Darhazer][])
 
 ## 1.27.0 (2018-06-14)
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -28,11 +28,11 @@ module RuboCop
 
         MSG = 'Add an empty line after `%<example_group>s`.'.freeze
 
-        def_node_matcher :example_group, ExampleGroups::ALL.block_pattern
+        def_node_matcher :example_group?, ExampleGroups::ALL.block_pattern
 
         def on_block(node)
-          return unless example_group(node)
-          return if node.parent && node.equal?(node.parent.children.last)
+          return unless example_group?(node)
+          return if last_child?(node)
 
           missing_separating_line(node) do |location|
             add_offense(

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -29,7 +29,7 @@ module RuboCop
           latest_let = node.body.child_nodes.select { |child| let?(child) }.last
 
           return if latest_let.nil?
-          return if latest_let.equal?(node.body.children.last)
+          return if last_child?(latest_let)
 
           missing_separating_line(latest_let) do |location|
             add_offense(latest_let, location: location)

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         def on_block(node)
           return unless hook?(node)
-          return if node.equal?(node.parent.children.last)
+          return if last_child?(node)
 
           missing_separating_line(node) do |location|
             add_offense(

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)
-          return if node.equal?(node.parent.children.last)
+          return if last_child?(node)
 
           missing_separating_line(node) do |location|
             add_offense(node, location: location, message: MSG)

--- a/lib/rubocop/rspec/blank_line_separation.rb
+++ b/lib/rubocop/rspec/blank_line_separation.rb
@@ -25,6 +25,12 @@ module RuboCop
         source_range(processed_source.buffer, last_line, start, content_length)
       end
 
+      def last_child?(node)
+        return true unless node.parent && node.parent.begin_type?
+
+        node.equal?(node.parent.children.last)
+      end
+
       def autocorrect(node)
         lambda do |corrector|
           missing_separating_line(node) do |location|

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
     RUBY
   end
 
+  it 'handles describes in an if block' do
+    expect_offense(<<-RUBY)
+      if RUBY_VERSION < 2.3
+        describe 'skips checks under old ruby' do
+        end
+      else
+        describe 'first check' do
+        end
+        ^^^ Add an empty line after `describe`.
+        describe 'second check' do
+        end
+      end
+    RUBY
+  end
+
   bad_example = <<-RUBY
     RSpec.describe Foo do
       describe '#bar' do


### PR DESCRIPTION
Fixes #648

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
