### PR TITLE
Extract common RSpec matchers into NodePattern

### DIFF
--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -21,8 +21,6 @@ module RuboCop
 
         MSG = 'Add an empty line after the last `let` block.'.freeze
 
-        def_node_matcher :let?, Helpers::ALL.block_pattern
-
         def on_block(node)
           return unless example_group_with_body?(node)
 

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -38,8 +38,6 @@ module RuboCop
 
         MSG = 'Add an empty line after `%<hook>s`.'.freeze
 
-        def_node_matcher :hook?, Hooks::ALL.block_pattern
-
         def on_block(node)
           return unless hook?(node)
           return if last_child?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -19,8 +19,6 @@ module RuboCop
 
         MSG = 'Add empty line after `subject`.'.freeze
 
-        def_node_matcher :subject?, Subject::ALL.block_pattern
-
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)
           return if last_child?(node)

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -54,15 +54,14 @@ module RuboCop
                                'have auto-generated description.'.freeze
         MSG_ADD_DESCRIPTION  = 'Add a description.'.freeze
 
-        def_node_matcher :example?, Examples::ALL.send_pattern
         def_node_matcher :example_description, '(send nil? _ $(str $_))'
 
-        def on_send(node)
+        def on_block(node)
           return unless example?(node)
 
-          check_example_without_description(node)
+          check_example_without_description(node.send_node)
 
-          example_description(node) do |message_node, message|
+          example_description(node.send_node) do |message_node, message|
             return unless message.to_s.empty?
 
             add_offense(message_node, message: MSG_DEFAULT_ARGUMENT)

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -18,8 +18,6 @@ module RuboCop
         MSG = 'Use `expect { ... }.to output(...).to_%<name>s` '\
               'instead of mutating $%<name>s.'.freeze
 
-        def_node_matcher :hook?, Hooks::ALL.block_pattern
-
         def on_gvasgn(node)
           return unless inside_example_scope?(node)
 

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -22,8 +22,6 @@ module RuboCop
         MSG = 'Use `instance_spy` when you check your double '\
               'with `have_received`.'.freeze
 
-        def_node_matcher :example?, Examples::ALL.block_pattern
-
         def_node_search :null_double, <<-PATTERN
           (lvasgn $_
             (send

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -37,11 +37,6 @@ module RuboCop
         MSG = 'Declare `subject` above any other `%<offending>s` ' \
           'declarations.'.freeze
 
-        def_node_matcher :subject?, Subject::ALL.block_pattern
-        def_node_matcher :let?, Helpers::ALL.block_pattern
-        def_node_matcher :hook?, Hooks::ALL.block_pattern
-        def_node_matcher :example?, Examples::ALL.block_pattern
-
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)
 
@@ -88,7 +83,7 @@ module RuboCop
 
         def in_spec_block?(node)
           node.each_ancestor(:block).any? do |ancestor|
-            Examples::ALL.include?(ancestor.method_name)
+            example?(ancestor)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -36,8 +36,6 @@ module RuboCop
 
         MSG = 'Move `let` before the examples in the group.'.freeze
 
-        def_node_matcher :let?, Helpers::ALL.block_pattern
-
         def_node_matcher :example_or_group?, <<-PATTERN
           {
             #{(Examples::ALL + ExampleGroups::ALL).block_pattern}

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -36,10 +36,6 @@ module RuboCop
       class MultipleSubjects < Cop
         MSG = 'Do not set more than one subject per example group'.freeze
 
-        def_node_matcher :named_subject?, <<-PATTERN
-          (block (send nil? :subject $sym) args ...)
-        PATTERN
-
         def on_block(node)
           return unless example_group?(node)
 
@@ -61,6 +57,10 @@ module RuboCop
         end
 
         private
+
+        def named_subject?(node)
+          node.send_node.arguments?
+        end
 
         def rename_autocorrect(node)
           lambda do |corrector|

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -29,8 +29,6 @@ module RuboCop
       class ScatteredLet < Cop
         MSG = 'Group all let/let! blocks in the example group together.'.freeze
 
-        def_node_matcher :let?, Helpers::ALL.block_pattern
-
         def on_block(node)
           return unless example_group_with_body?(node)
 

--- a/lib/rubocop/rspec/align_let_brace.rb
+++ b/lib/rubocop/rspec/align_let_brace.rb
@@ -4,9 +4,7 @@ module RuboCop
   module RSpec
     # Shared behavior for aligning braces for single line lets
     class AlignLetBrace
-      extend NodePattern::Macros
-
-      def_node_matcher :let?, Language::Helpers::ALL.block_pattern
+      include RuboCop::RSpec::Language::NodePattern
 
       def initialize(root, token)
         @root  = root

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -14,13 +14,6 @@ module RuboCop
         ExampleGroups::ALL + SharedGroups::ALL + Includes::ALL
       ).block_pattern
 
-      # @!method hook?(node)
-      #
-      #   Detect if node is `before`, `after`, `around`
-      def_node_matcher :hook?, Hooks::ALL.block_pattern
-
-      def_node_matcher :subject?, Subject::ALL.block_pattern
-
       def subjects
         subjects_in_scope(node)
       end

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -14,6 +14,12 @@ module RuboCop
         PATTERN
 
         def_node_matcher :example?, Examples::ALL.block_pattern
+
+        def_node_matcher :hook?, Hooks::ALL.block_pattern
+
+        def_node_matcher :let?, Helpers::ALL.block_pattern
+
+        def_node_matcher :subject?, Subject::ALL.block_pattern
       end
     end
   end


### PR DESCRIPTION
hook?, let? and subject? are found in multiple cops and we already have a place to define common matchers.

Also some of the cops used over-complicated matchers that I've simplified
