### PR TITLE
Use build in node matchers

### DIFF
--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -27,7 +27,7 @@ module RuboCop
 
         def on_top_level_describe(_node, (_, second_arg))
           return unless second_arg && second_arg.str_type?
-          return if METHOD_STRING_MATCHER =~ one(second_arg.children)
+          return if METHOD_STRING_MATCHER =~ second_arg.str_content
 
           add_offense(second_arg, location: :expression)
         end

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -70,7 +70,7 @@ module RuboCop
         def on_block(node)
           return unless example_group?(node) && !contains_example?(node)
 
-          add_offense(node.children.first, location: :expression)
+          add_offense(node.send_node, location: :expression)
         end
 
         private

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -32,7 +32,7 @@ module RuboCop
         def on_block(node)
           each?(node) do |arg, body|
             if single_expectation?(body, arg) || only_expectations?(body, arg)
-              add_offense(node.children.first, location: :expression)
+              add_offense(node.send_node, location: :expression)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -77,7 +77,7 @@ module RuboCop
         private
 
         def example_with_aggregated_failures?(node)
-          example = node.children.first
+          example = node.send_node
 
           (aggregated_failures_by_default? ||
             with_aggregated_failures?(example)) &&

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -104,7 +104,7 @@ module RuboCop
           find_nested_contexts(node.parent) do |context, nesting|
             self.max = nesting
             add_offense(
-              context.children.first,
+              context.send_node,
               location: :expression,
               message: message(nesting)
             )

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -68,11 +68,11 @@ module RuboCop
 
         def on_block(node)
           context_with_only_examples(node) do
-            add_shared_item_offense(node, MSG_EXAMPLES)
+            add_shared_item_offense(node.send_node, MSG_EXAMPLES)
           end
 
           examples_with_only_context(node) do
-            add_shared_item_offense(node, MSG_CONTEXT)
+            add_shared_item_offense(node.send_node, MSG_CONTEXT)
           end
         end
 
@@ -100,7 +100,7 @@ module RuboCop
 
         def add_shared_item_offense(node, message)
           add_offense(
-            node.children.first,
+            node,
             location: :expression,
             message: message
           )

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -44,7 +44,7 @@ module RuboCop
           parent = expect.parent
           return true unless parent
           return true if parent.begin_type?
-          return true if parent.block_type? && parent.children[2] == expect
+          return true if parent.block_type? && parent.body == expect
         end
       end
     end


### PR DESCRIPTION
the content of a str_node can be retrieved with `str_content`.
This was the last place in code the `one()` util is actually used, so I think we should remove this method.

Regarding block nodes, send_node, arguments and body are retrieved by block's methods that access the children[0], children[1] and children[2] respectively, and it's more readable to use those named methods instead.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
