### PR TITLE
Change organization URL to rubocop-hq

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/8ffaabf633c968c22bdd/maintainability)](https://codeclimate.com/github/rubocop-hq/rubocop-rspec/maintainability)
 
 RSpec-specific analysis for your projects, as an extension to
-[RuboCop](https://github.com/bbatsov/rubocop).
+[RuboCop](https://github.com/rubocop-hq/rubocop).
 
 ## Installation
 

--- a/manual/index.md
+++ b/manual/index.md
@@ -1,2 +1,2 @@
 RSpec-specific analysis for your projects, as an extension to
-[RuboCop](https://github.com/bbatsov/rubocop).
+[RuboCop](https://github.com/rubocop-hq/rubocop).


### PR DESCRIPTION
Follow up of #621.

Change organization URL from https://github.com/bbatsov/rubocop to https://github.com/rubocop-hq/rubocop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
