### PR TITLE
Upgrade RuboCop dependency to >= v0.58.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,6 @@ jobs:
       - run: bundle install
       - run: rake confirm_config documentation_syntax_check confirm_documentation
 
-  # Ruby 2.1
-  ruby-2.1-rspec:
-    docker:
-      - image: circleci/ruby:2.1
-    <<: *rspec
-  ruby-2.1-rubocop:
-    docker:
-      - image: circleci/ruby:2.1
-    <<: *rubocop
-
   # Ruby 2.2
   ruby-2.2-rspec:
     docker:
@@ -115,10 +105,6 @@ workflows:
       - confirm_config_and_documentation
 
       # Use `requires: [confirm_config_and_documentation]` to trick Circle CI into starting the slow jruby job early.
-      - ruby-2.1-rspec:
-          requires: [confirm_config_and_documentation]
-      - ruby-2.1-rubocop:
-          requires: [confirm_config_and_documentation]
       - ruby-2.2-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.2-rubocop:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.2
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `RSpec/ReceiveNever` cop enforcing usage of `not_to receive` instead of `never` matcher. ([@Darhazer][])
 * Fix false positive in `RSpec/EmptyLineAfterExampleGroup` cop when example is inside `if`. ([@Darhazer][])
 * Add `RSpec/MissingExampleGroupArgument` to enforce first argument for an example group. ([@geniou][])
+* Drop support for ruby `2.1`. ([@bquorning][])
 
 ## 1.27.0 (2018-06-14)
 

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def skip_symbol?(symbol_node)
-          symbol_node == SKIP_SYMBOL || symbol_node == PENDING_SYMBOL
+          [SKIP_SYMBOL, PENDING_SYMBOL].include?(symbol_node)
         end
       end
     end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.56.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.58.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
This new version or RuboCop drops support for Ruby v2.1, so we have to do the same. See https://github.com/rubocop-hq/rubocop/pull/5990

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
