### PR TITLE
Bump version to 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.28.0 (2018-08-14)
+
 * Add `RSpec/ReceiveNever` cop enforcing usage of `not_to receive` instead of `never` matcher. ([@Darhazer][])
 * Fix false positive in `RSpec/EmptyLineAfterExampleGroup` cop when example is inside `if`. ([@Darhazer][])
 * Add `RSpec/MissingExampleGroupArgument` to enforce first argument for an example group. ([@geniou][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.27.0'.freeze
+      STRING = '1.28.0'.freeze
     end
   end
 end


### PR DESCRIPTION
Two months have passed. Let’s release.

Main question is whether it’s ok to release the new cop introduced in #666 (`FactoryBot/AttributeDefinedStatically`) without FactoryBot having released a new version? The deprecation is merged into master, and the cop’s recommendation is backwards compatible, so I think it’s ok to release now.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
