### PR TITLE
InstanceVariable: Also recommend local variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* `RSpec/InstanceVariable` - Recommend local variables in addition to `let`. ([@jaredbeck][])
+
 ## 1.28.0 (2018-08-14)
 
 * Add `RSpec/ReceiveNever` cop enforcing usage of `not_to receive` instead of `never` matcher. ([@Darhazer][])
@@ -328,6 +330,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@bquorning]: https://github.com/bquorning
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@geniou]: https://github.com/geniou
+[@jaredbeck]: https://github.com/jaredbeck
 [@jawshooah]: https://github.com/jawshooah
 [@nevir]: https://github.com/nevir
 [@nijikon]: https://github.com/nijikon

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -47,7 +47,7 @@ module RuboCop
       #   end
       #
       class InstanceVariable < Cop
-        MSG = 'Use `let` instead of an instance variable.'.freeze
+        MSG = 'Replace instance variable with local variable or `let`.'.freeze
 
         EXAMPLE_GROUP_METHODS = ExampleGroups::ALL + SharedGroups::ALL
 

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
       describe MyClass do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
-                    ^^^^ Use `let` instead of an instance variable.
+                    ^^^^ Replace instance variable with local variable or `let`.
       end
     RUBY
   end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     expect_offense(<<-RUBY)
       shared_examples 'shared example' do
         it { expect(@foo).to be_empty }
-                    ^^^^ Use `let` instead of an instance variable.
+                    ^^^^ Replace instance variable with local variable or `let`.
       end
     RUBY
   end
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
         describe MyClass do
           before { @foo = [] }
           it { expect(@foo).to be_empty }
-                      ^^^^ Use `let` instead of an instance variable.
+                      ^^^^ Replace instance variable with local variable or `let`.
         end
       RUBY
     end


### PR DESCRIPTION
Often, a local variable is a better choice than a `let`. For example,
an object that will only be used in a single example.

When we use too many `let`s, examples become hard to understand, because
it is not clear which are applicable to a given example.

So, we should recommend both local variables and `let`s.

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
