### PR TITLE
Only check method_name on nodes that define it

### DIFF
--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -115,7 +115,7 @@ module RuboCop
           if style == :described_class
             node.eql?(@described_class)
           else
-            node.method_name == :described_class
+            node.send_type? && node.method_name == :described_class
           end
         end
       end


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/pull/6198 removed the generic #method_name matcher from Node.
Now it's defined only for block and method dispatch nodes

This change makes rubocop-rspec compatible with both 0.58.2 and master

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
