### PR TITLE
FactoryBot cops should check the default paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix false negative in `FactoryBot/AttributeDefinedStatically` when attribute is defined on `self`. ([@Darhazer][])
+* `RSpec/FactoryBot` cops will now also inspect the `spec/factories.rb` path by default. ([@bquorning][])
 
 ## 1.29.0 (2018-08-25)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ AllCops:
     - "(?:^|/)spec/"
   RSpec/FactoryBot:
     Patterns:
+    - spec/factories.rb
     - spec/factories/**/*.rb
     - features/support/factories/**/*.rb
 


### PR DESCRIPTION
https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md says

> Factories can be defined anywhere, but will be automatically loaded after calling `FactoryBot.find_definitions` if factories are defined in files at the following locations:
>```
>test/factories.rb
>spec/factories.rb
>test/factories/*.rb
>spec/factories/*.rb
>```

In this project we don't care about the `test/` locations, but we should inspect the `spec/factories.rb` file, if it exists.

/cc @jonatas re. #409

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
