### PR TITLE
Use String#start_with? instead of Regexp

### DIFF
--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -23,11 +23,9 @@ module RuboCop
         MSG = 'The second argument to describe should be the method '\
               "being tested. '#instance' or '.class'.".freeze
 
-        METHOD_STRING_MATCHER = /\A[\#\.].+/
-
         def on_top_level_describe(_node, (_, second_arg))
           return unless second_arg && second_arg.str_type?
-          return if METHOD_STRING_MATCHER =~ second_arg.str_content
+          return if second_arg.str_content.start_with?('#', '.')
 
           add_offense(second_arg, location: :expression)
         end


### PR DESCRIPTION
While `String#start_with?` actually *is* faster than `Regexp#=~`, I prefer using `start_with?` because I find it *much* easier to read. Regular expressions are great and all, but they do require some extra brain power when reading the code.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
