### PR TITLE
Fix `FactoryBot/AttributeDefinedStatically` not working when there is a non-symbol key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `FactoryBot/AttributeDefinedStatically` not working when there is a non-symbol key. ([@vzvu3k6k][])
+
 ## 1.29.1 (2018-09-01)
 
 * Fix false negative in `FactoryBot/AttributeDefinedStatically` when attribute is defined on `self`. ([@Darhazer][])
@@ -374,3 +376,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@tdeo]: https://github.com/tdeo
 [@composerinteralia]: https://github.com/composerinteralia
 [@seanpdoyle]: https://github.com/seanpdoyle
+[@vzvu3k6k]: https://github.com/vzvu3k6k

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -97,7 +97,7 @@ module RuboCop
           end
 
           def factory_key?(hash_node)
-            hash_node.keys.any? { |key| key.value == :factory }
+            hash_node.keys.any? { |key| key.sym_type? && key.value == :factory }
           end
 
           def autocorrect_replacing_parens(node)

--- a/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do # 
         meta_tags(foo: Time.current)
         other_tags({ foo: Time.current })
         options color: :blue
+        other_options Tag::MAGIC => :magic
         self.end Date.tomorrow
 
         trait :old do
@@ -157,6 +158,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do # 
         meta_tags { { foo: Time.current } }
         other_tags { { foo: Time.current } }
         options { { color: :blue } }
+        other_options { { Tag::MAGIC => :magic } }
         self.end { Date.tomorrow }
 
         trait :old do


### PR DESCRIPTION
When processing the following code,

```rb
FactoryBot.define do
  factory :post do
    options Tag::MAGIC => :magic
  end
end
```

`FactoryBot/AttributeDefinedStatically` raises `NoMethodError` because the node of `Tag::MAGIC` does not respond to `value`.

```
Failure/Error: hash_node.keys.any? { |key| key.value == :factory }

NoMethodError:
  undefined method `value' for "s(:const,\n  s(:const, nil, :Tag), :MAGIC)":RuboCop::AST::Node
Shared Example Group: "autocorrect" called from ./spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb:171
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:100:in `block in factory_key?'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:100:in `any?'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:100:in `factory_key?'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:96:in `association?'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:75:in `block in on_block'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:74:in `each'
# ./lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb:74:in `on_block'
# ./spec/shared/autocorrect_behavior.rb:3:in `block (2 levels) in <top (required)>'
```

It seems that the `association` method decides whether the method call is for association or not as [factory_bot/definition_proxy.rb](https://github.com/thoughtbot/factory_bot/blob/4888e1d4ac839229a77343f314b2a2ed3f1cd5c2/lib/factory_bot/definition_proxy.rb#L100-L101) does, and we can safely ignore keys other than symbols. So this PR just adds a check for node types.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
    * The build was failed by offences about `Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.`. This cop is enabled by default since [Rubocop 0.59.0 (2018-09-09)](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0590-2018-09-09).
    * #684 will fix these offences.