### PR TITLE
Fix Layout/EmptyLineAfterGuardClause offenses

### DIFF
--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -56,6 +56,7 @@ module RuboCop
         def joined_prefixes
           quoted = prefixes.map { |prefix| "'#{prefix}'" }
           return quoted.first if quoted.size == 1
+
           quoted << "or #{quoted.pop}"
           quoted.join(', ')
         end

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -79,6 +79,7 @@ module RuboCop
 
         def rspec_pattern_config?
           return unless all_cops_config.key?('RSpec')
+
           all_cops_config.fetch('RSpec').key?('Patterns')
         end
 

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -73,6 +73,7 @@ module RuboCop
           def on_block(node)
             factory_attributes(node).to_a.flatten.each do |attribute|
               next if proc?(attribute) || association?(attribute)
+
               add_offense(attribute, location: :expression)
             end
           end

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -139,6 +139,7 @@ module RuboCop
 
           def format_receiver(receiver)
             return '' unless receiver
+
             "#{receiver.source}."
           end
         end

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -57,6 +57,7 @@ module RuboCop
 
         def valid_usage?(node)
           return false unless style == :single_line_only
+
           example = node.ancestors.find { |parent| example?(parent) }
           example && example.single_line?
         end

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -72,6 +72,7 @@ module RuboCop
 
           node.each_child_node do |child|
             next if child.sibling_index < first_example.sibling_index
+
             add_offense(child, location: :expression) if let?(child)
           end
         end

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -58,6 +58,7 @@ module RuboCop
 
         def common_setup?(node)
           return false unless setup?(node)
+
           # Search only for setup with basic_literal arguments (e.g. :sym, :str)
           # or no arguments at all.
           node.send_node.arguments.all?(&:basic_literal?)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -145,6 +145,7 @@ module RuboCop
           end
 
           return if part_of_ignored_node?(node)
+
           predicate_matcher?(node) do |_actual, matcher|
             add_offense(
               node,
@@ -337,6 +338,7 @@ module RuboCop
         def block_loc(send_node)
           parent = send_node.parent
           return unless parent.block_type?
+
           range_between(
             send_node.loc.expression.end_pos,
             parent.loc.expression.end_pos

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -41,6 +41,7 @@ module RuboCop
             http_status(node) do |ast_node|
               checker = checker_class.new(ast_node)
               return unless checker.offensive?
+
               add_offense(checker.node, message: checker.message)
             end
           end

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -43,6 +43,7 @@ module RuboCop
           first_let = lets.first
           lets.each_with_index do |node, idx|
             next if node.sibling_index == first_let.sibling_index + idx
+
             add_offense(node, location: :expression)
           end
         end

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -72,6 +72,7 @@ module RuboCop
 
         def expectation?(node)
           return if all_matcher?(node)
+
           receive_message?(node)
         end
 

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -25,11 +25,13 @@ module RuboCop
 
         def on_send(node)
           return unless expect?(node)
+
           check_expect(node)
         end
 
         def on_block(node)
           return unless expect_block?(node)
+
           check_expect(node)
         end
 
@@ -37,6 +39,7 @@ module RuboCop
 
         def check_expect(node)
           return unless void?(node)
+
           add_offense(node, location: :expression)
         end
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -156,6 +156,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       cop.to_s.start_with?('RuboCop::Cop::RSpec')
     end
     return if selected_cops.empty?
+
     content = "# #{department}\n".dup
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
@@ -195,6 +196,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       cop.to_s.start_with?('RuboCop::Cop::RSpec')
     end
     return if selected_cops.empty?
+
     type_title = department[0].upcase + department[1..-1]
     filename = "cops_#{department.downcase}.md"
     content = "#### Department [#{type_title}](#{filename})\n\n".dup
@@ -259,8 +261,10 @@ task documentation_syntax_check: :yard_for_generate_documentation do
   cops = RuboCop::Cop::Cop.registry
   cops.each do |cop|
     next unless %i[RSpec Capybara FactoryBot].include?(cop.department)
+
     examples = YARD::Registry.all(:class).find do |code_object|
       next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge
+
       break code_object.tags('example')
     end
 


### PR DESCRIPTION
RuboCop v0.59.0 introduced a Layout/EmptyLineAfterGuardClause cop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).