### PR TITLE
Fix ImplicitSubject cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `FactoryBot/AttributeDefinedStatically` not working when there is a non-symbol key. ([@vzvu3k6k][])
+* Fix false positive in `RSpec/ImplicitSubject` when `is_expected` is used inside `its()` block. ([@Darhazer][])
 
 ## 1.29.1 (2018-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `FactoryBot/AttributeDefinedStatically` not working when there is a non-symbol key. ([@vzvu3k6k][])
 * Fix false positive in `RSpec/ImplicitSubject` when `is_expected` is used inside `its()` block. ([@Darhazer][])
+* Add `single_statement_only` style to  `RSpec/ImplicitSubject` as a more relaxed alternative to `single_line_only`. ([@Darhazer][])
 
 ## 1.29.1 (2018-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -211,6 +211,7 @@ RSpec/ImplicitSubject:
   EnforcedStyle: single_line_only
   SupportedStyles:
   - single_line_only
+  - single_statement_only
   - disallow
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
 

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -59,10 +59,14 @@ module RuboCop
           example = node.ancestors.find { |parent| example?(parent) }
           return false if example.nil?
 
-          if example.method_name == :its
-            true
-          elsif style == :single_line_only
+          example.method_name == :its || allowed_by_style?(example)
+        end
+
+        def allowed_by_style?(example)
+          if style == :single_line_only
             example.single_line?
+          elsif style == :single_statement_only
+            !example.body.begin_type?
           else
             false
           end

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -56,10 +56,16 @@ module RuboCop
         private
 
         def valid_usage?(node)
-          return false unless style == :single_line_only
-
           example = node.ancestors.find { |parent| example?(parent) }
-          example && example.single_line?
+          return false if example.nil?
+
+          if example.method_name == :its
+            true
+          elsif style == :single_line_only
+            example.single_line?
+          else
+            false
+          end
         end
       end
     end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1192,7 +1192,7 @@ it { expect(subject).to be_truthy }
 
 Name | Default value | Configurable values
 --- | --- | ---
-EnforcedStyle | `single_line_only` | `single_line_only`, `disallow`
+EnforcedStyle | `single_line_only` | `single_line_only`, `single_statement_only`, `disallow`
 
 ### References
 

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -127,6 +127,12 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
       RUBY
     end
 
+    it 'allows `is_expected` inside `its` block' do
+      expect_no_offenses(<<-RUBY)
+        its(:quality) { is_expected.to be :high }
+      RUBY
+    end
+
     include_examples 'autocorrect',
                      'it { is_expected.to be_truthy }',
                      'it { expect(subject).to be_truthy }'

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -92,6 +92,50 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
                      good_code
   end
 
+  context 'with EnforcedStyle `single_statement_only`' do
+    let(:enforced_style) { 'single_statement_only' }
+
+    it 'allows `is_expected` in multi-line example with single statement' do
+      expect_no_offenses(<<-RUBY)
+        it 'expect subject to be used' do
+          is_expected.to be_good
+        end
+      RUBY
+    end
+
+    it 'flags `is_expected` in multi-statement examples' do
+      expect_offense(<<-RUBY)
+        it 'expect subject to be used' do
+          subject.age = 18
+          is_expected.to be_valid
+          ^^^^^^^^^^^ Don't use implicit subject.
+        end
+      RUBY
+    end
+
+    bad_code = <<-RUBY
+      it 'is valid' do
+        subject.age = 18
+        is_expected.to be_valid
+      end
+    RUBY
+
+    good_code = <<-RUBY
+      it 'is valid' do
+        subject.age = 18
+        expect(subject).to be_valid
+      end
+    RUBY
+
+    include_examples 'autocorrect',
+                     bad_code,
+                     good_code
+
+    include_examples 'autocorrect',
+                     bad_code,
+                     good_code
+  end
+
   context 'with EnforcedStyle `disallow`' do
     let(:enforced_style) { 'disallow' }
 


### PR DESCRIPTION
* is_expected is not an alias for subject inside `its` block, so ignore `its`
* Added new config to allow using is_expected in multi-line blocks that have a single statement

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
