### PR TITLE
Enforce dynamic attributes with explicit receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
+* Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])
 
 ## 1.32.0 (2019-01-27)
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -18,6 +18,7 @@ require_relative 'rubocop/rspec/example'
 require_relative 'rubocop/rspec/hook'
 require_relative 'rubocop/cop/rspec/cop'
 require_relative 'rubocop/rspec/align_let_brace'
+require_relative 'rubocop/rspec/factory_bot'
 require_relative 'rubocop/rspec/final_end_location'
 require_relative 'rubocop/rspec/blank_line_separation'
 

--- a/lib/rubocop/rspec/factory_bot.rb
+++ b/lib/rubocop/rspec/factory_bot.rb
@@ -1,0 +1,56 @@
+module RuboCop
+  module RSpec
+    # RuboCop FactoryBot project namespace
+    module FactoryBot
+      ATTRIBUTE_DEFINING_METHODS = %i[factory trait transient ignore].freeze
+
+      UNPROXIED_METHODS = %i[
+        __send__
+        __id__
+        nil?
+        send
+        object_id
+        extend
+        instance_eval
+        initialize
+        block_given?
+        raise
+        caller
+        method
+      ].freeze
+
+      DEFINITION_PROXY_METHODS = %i[
+        add_attribute
+        after
+        association
+        before
+        callback
+        ignore
+        initialize_with
+        sequence
+        skip_create
+        to_create
+      ].freeze
+
+      RESERVED_METHODS =
+        DEFINITION_PROXY_METHODS +
+        UNPROXIED_METHODS +
+        ATTRIBUTE_DEFINING_METHODS
+
+      private_constant(
+        :ATTRIBUTE_DEFINING_METHODS,
+        :UNPROXIED_METHODS,
+        :DEFINITION_PROXY_METHODS,
+        :RESERVED_METHODS
+      )
+
+      def self.attribute_defining_methods
+        ATTRIBUTE_DEFINING_METHODS
+      end
+
+      def self.reserved_methods
+        RESERVED_METHODS
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
@@ -66,6 +66,21 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do # 
     RUBY
   end
 
+  it 'registers an offense for attributes defined on explicit receiver' do
+    expect_offense(<<-RUBY)
+      FactoryBot.define do
+        factory :post do |post_definition|
+          post_definition.end Date.tomorrow
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to declare attribute values.
+          post_definition.trait :published do |published_definition|
+            published_definition.published_at 1.day.from_now
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a block to declare attribute values.
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'accepts valid factory definitions' do
     expect_no_offenses(<<-RUBY)
       FactoryBot.define do
@@ -95,6 +110,27 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do # 
       created_at 1.day.ago
       update_times [Time.current]
       meta_tags(foo: Time.current)
+    RUBY
+  end
+
+  it 'does not add offense if method called on another object' do
+    expect_no_offenses(<<-RUBY)
+      FactoryBot.define do
+        factory :post do |post_definition|
+          Registrar.register :post_factory
+        end
+      end
+    RUBY
+  end
+
+  it 'does not add offense if method called on a local variable' do
+    expect_no_offenses(<<-RUBY)
+      FactoryBot.define do
+        factory :post do |post_definition|
+          local = Registrar
+          local.register :post_factory
+        end
+      end
     RUBY
   end
 


### PR DESCRIPTION
Fixes #687

factory_bot allows you to define attributes on an explicit receiver by
passing in the definition proxy as the first argument to the block.

This is not quite ready to be merged, but I wanted to get some feedback before going any further. Does this approach make sense to you?

The class is too big, so I will have to move some things around to get the build to pass. Any advice on the best way to break this up?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
