### PR TITLE
Add missing regression test for 'its' in a multiline spec

### DIFF
--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
       RUBY
     end
 
+    it 'allows `is_expected` inside `its` block, in multi-line examples' do
+      expect_no_offenses(<<-RUBY)
+        its(:quality) do
+          is_expected.to be :high
+        end
+      RUBY
+    end
+
     it 'flags `should` in multi-line examples' do
       expect_offense(<<-RUBY)
         it 'expect subject to be used' do


### PR DESCRIPTION
[This commit](https://github.com/rubocop-hq/rubocop-rspec/commit/f86d37a490b8ecc8cb9e8cc24f892fca78daf64f) correctly fixed https://github.com/rubocop-hq/rubocop-rspec/issues/682.

However, I noticed that one key branch of the behaviour was untested.

So here is a test for it, as regression.