### PR TITLE
Add an option to allow enforcement of verified doubles in nameless doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Add config to `RSpec/VerifiedDoubles` to enforcement of verification on unnamed doubles. ([@BrentWheeldon][])
 * Fix `FactoryBot/AttributeDefinedStatically` not working when there is a non-symbol key. ([@vzvu3k6k][])
 * Fix false positive in `RSpec/ImplicitSubject` when `is_expected` is used inside `its()` block. ([@Darhazer][])
 * Add `single_statement_only` style to  `RSpec/ImplicitSubject` as a more relaxed alternative to `single_line_only`. ([@Darhazer][])
@@ -379,3 +380,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@composerinteralia]: https://github.com/composerinteralia
 [@seanpdoyle]: https://github.com/seanpdoyle
 [@vzvu3k6k]: https://github.com/vzvu3k6k
+[@BrentWheeldon]: https://github.com/BrentWheeldon

--- a/config/default.yml
+++ b/config/default.yml
@@ -402,6 +402,7 @@ RSpec/PredicateMatcher:
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
   Enabled: true
+  IgnoreNameless: true
   IgnoreSymbolicNames: false
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -26,15 +26,22 @@ module RuboCop
         MSG = 'Prefer using verifying doubles over normal doubles.'.freeze
 
         def_node_matcher :unverified_double, <<-PATTERN
-          {(send nil? {:double :spy} $_ ...) }
+          {(send nil? {:double :spy} $...)}
         PATTERN
 
         def on_send(node)
-          unverified_double(node) do |name|
-            return if name.sym_type? && cop_config['IgnoreSymbolicNames']
+          unverified_double(node) do |name, *_args|
+            return if name.nil? && cop_config['IgnoreNameless']
+            return if symbol?(name) && cop_config['IgnoreSymbolicNames']
 
             add_offense(node, location: :expression)
           end
+        end
+
+        private
+
+        def symbol?(name)
+          name && name.sym_type?
         end
       end
     end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2494,6 +2494,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
+IgnoreNameless | `true` | Boolean
 IgnoreSymbolicNames | `false` | Boolean
 
 ### References

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -53,12 +53,25 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     end
   end
 
-  it 'ignores doubles without a name' do
-    expect_no_offenses(<<-RUBY)
+  it 'doubles that have no name specified' do
+    expect_offense(<<-RUBY)
       it do
         foo = double
+              ^^^^^^ Prefer using verifying doubles over normal doubles.
       end
     RUBY
+  end
+
+  context 'when configured to ignore nameless doubles' do
+    let(:cop_config) { { 'IgnoreNameless' => true } }
+
+    it 'ignores doubles that have no name specified' do
+      expect_no_offenses(<<-RUBY)
+        it do
+          foo = double
+        end
+      RUBY
+    end
   end
 
   it 'ignores instance_doubles' do


### PR DESCRIPTION
Currently if you have a double/spy with no name (or default stubs) it will never cause a violation according to the `RSpec/VerifiedDoubles` cop. This adds an optional configuration to allow violations to be added for code that looks like:

```
foo = double
allow(foo).to receive(:bar) do |arg1|
  “#{arg1} based result”
end
```

I left the default configuration not enforcing this cop on nameless doubles so as to make this a non-breaking change.