### PR TITLE
move predicate matcher to alphabetical position

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -330,6 +330,16 @@ RSpec/Pending:
   Description: Checks for any pending or skipped examples.
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
 
+RSpec/PredicateMatcher:
+  Description: Prefer using predicate matcher over using predicate method directly.
+  Enabled: true
+  Strict: true
+  EnforcedStyle: inflected
+  SupportedStyles:
+  - inflected
+  - explicit
+  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
+
 RSpec/ReceiveCounts:
   Enabled: true
   Description: Check for `once` and `twice` receive counts matchers usage.
@@ -388,16 +398,6 @@ RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
   Enabled: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
-
-RSpec/PredicateMatcher:
-  Description: Prefer using predicate matcher over using predicate method directly.
-  Enabled: true
-  Strict: true
-  EnforcedStyle: inflected
-  SupportedStyles:
-  - inflected
-  - explicit
-  StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.


### PR DESCRIPTION
Specifically the docs ask that `default.yml` be alphabetically ordered
but while adding the UnspecifiedException cop I found the PredicateMatcher
exactly where I wanted to add my configuration.  Fixed.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
