### PR TITLE
Fix #702: don't flag n.times block with an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* `FactoryBot/CreateList` now ignores `times` blocks with an argument. ([@Darhazer][])
+
 ## 1.30.0 (2018-10-08)
 
 * Add config to `RSpec/VerifiedDoubles` to enforcement of verification on unnamed doubles. ([@BrentWheeldon][])

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -30,9 +30,10 @@ module RuboCop
           MSG_CREATE_LIST = 'Prefer create_list.'.freeze
           MSG_N_TIMES = 'Prefer %<number>s.times.'.freeze
 
-          def_node_matcher :n_times_block?, <<-PATTERN
+          def_node_matcher :n_times_block_without_arg?, <<-PATTERN
             (block
               (send (int _) :times)
+              (args)
               ...
             )
           PATTERN
@@ -47,7 +48,7 @@ module RuboCop
 
           def on_block(node)
             return unless style == :create_list
-            return unless n_times_block?(node)
+            return unless n_times_block_without_arg?(node)
             return unless contains_only_factory?(node.body)
 
             add_offense(node.send_node,

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -41,10 +41,9 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList, :config do
       RUBY
     end
 
-    it 'flags n.times with argument' do
-      expect_offense(<<-RUBY)
+    it 'ignores n.times with argument' do
+      expect_no_offenses(<<-RUBY)
         3.times { |n| create :user, created_at: n.days.ago }
-        ^^^^^^^ Prefer create_list.
       RUBY
     end
 


### PR DESCRIPTION

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
