### PR TITLE
[Fix #453] Allow implicit subject in shared examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Master (Unreleased)
 
+* Add `IgnoreSharedExamples` option for `RSpec/NamedSubject`. ([@RST-J][])
+
 ## 1.30.1 (2018-11-01)
 
 * `FactoryBot/CreateList` now ignores `times` blocks with an argument. ([@Darhazer][])
-* Add `AllowInSharedExamples` option for `RSpec/NamedSubject`. ([@RST-J][])
 
 ## 1.30.0 (2018-10-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * `FactoryBot/CreateList` now ignores `times` blocks with an argument. ([@Darhazer][])
+* Add `AllowInSharedExamples` option for `RSpec/NamedSubject`. ([@RST-J][])
 
 ## 1.30.0 (2018-10-08)
 
@@ -387,3 +388,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@vzvu3k6k]: https://github.com/vzvu3k6k
 [@BrentWheeldon]: https://github.com/BrentWheeldon
 [@daveworth]: https://github.com/daveworth
+[@RST-J]: https://github.com/RST-J

--- a/config/default.yml
+++ b/config/default.yml
@@ -303,6 +303,7 @@ RSpec/MultipleSubjects:
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
+  AllowInSharedExamples: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:

--- a/config/default.yml
+++ b/config/default.yml
@@ -303,7 +303,7 @@ RSpec/MultipleSubjects:
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
-  AllowInSharedExamples: true
+  IgnoreSharedExamples: true
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -12,6 +12,10 @@ module RuboCop
       # the most important object in your tests so they deserve a descriptive
       # name.
       #
+      # This cop can be configured in your configuration using the
+      # `AllowInSharedExamples` which will not report offenses for implicit
+      # subjects in shared example groups.
+      #
       # @example
       #   # bad
       #   RSpec.describe User do
@@ -48,14 +52,23 @@ module RuboCop
           }
         PATTERN
 
+        def_node_matcher :shared_example?, <<-PATTERN
+          #{SharedGroups::EXAMPLES.block_pattern}
+        PATTERN
+
         def_node_search :subject_usage, '$(send nil? :subject)'
 
         def on_block(node)
-          return unless rspec_block?(node)
+          return if !rspec_block?(node) || allowed_shared_example?(node)
 
           subject_usage(node) do |subject_node|
             add_offense(subject_node, location: :selector)
           end
+        end
+
+        def allowed_shared_example?(node)
+          cop_config['AllowInSharedExamples'] &&
+            node.each_ancestor(:block).any?(&method(:shared_example?))
         end
       end
     end

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -13,7 +13,7 @@ module RuboCop
       # name.
       #
       # This cop can be configured in your configuration using the
-      # `AllowInSharedExamples` which will not report offenses for implicit
+      # `IgnoreSharedExamples` which will not report offenses for implicit
       # subjects in shared example groups.
       #
       # @example
@@ -59,15 +59,15 @@ module RuboCop
         def_node_search :subject_usage, '$(send nil? :subject)'
 
         def on_block(node)
-          return if !rspec_block?(node) || allowed_shared_example?(node)
+          return if !rspec_block?(node) || ignored_shared_example?(node)
 
           subject_usage(node) do |subject_node|
             add_offense(subject_node, location: :selector)
           end
         end
 
-        def allowed_shared_example?(node)
-          cop_config['AllowInSharedExamples'] &&
+        def ignored_shared_example?(node)
+          cop_config['IgnoreSharedExamples'] &&
             node.each_ancestor(:block).any?(&method(:shared_example?))
         end
       end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1785,7 +1785,7 @@ the most important object in your tests so they deserve a descriptive
 name.
 
 This cop can be configured in your configuration using the
-`AllowInSharedExamples` which will not report offenses for implicit
+`IgnoreSharedExamples` which will not report offenses for implicit
 subjects in shared example groups.
 
 ### Examples
@@ -1821,7 +1821,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-AllowInSharedExamples | `true` | Boolean
+IgnoreSharedExamples | `true` | Boolean
 
 ### References
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1784,6 +1784,10 @@ reference your test subject you should explicitly name it using
 the most important object in your tests so they deserve a descriptive
 name.
 
+This cop can be configured in your configuration using the
+`AllowInSharedExamples` which will not report offenses for implicit
+subjects in shared example groups.
+
 ### Examples
 
 ```ruby
@@ -1812,6 +1816,12 @@ RSpec.describe Foo do
   it { should be_valid }
 end
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+AllowInSharedExamples | `true` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
     end
   end
 
-  context 'when AllowInSharedExamples is false' do
-    let(:cop_config) { { 'AllowInSharedExamples' => false } }
+  context 'when IgnoreSharedExamples is false' do
+    let(:cop_config) { { 'IgnoreSharedExamples' => false } }
 
     it_behaves_like 'checking subject outside of shared examples'
 
@@ -93,8 +93,8 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
     end
   end
 
-  context 'when AllowInSharedExamples is true' do
-    let(:cop_config) { { 'AllowInSharedExamples' => true } }
+  context 'when IgnoreSharedExamples is true' do
+    let(:cop_config) { { 'IgnoreSharedExamples' => true } }
 
     it_behaves_like 'checking subject outside of shared examples'
 

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -1,62 +1,123 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
-  subject(:cop) { described_class.new }
+RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'checks `it` and `specify` for explicit subject usage' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        subject { described_class.new }
+  shared_examples_for 'checking subject outside of shared examples' do
+    it 'checks `it` and `specify` for explicit subject usage' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          subject { described_class.new }
 
-        it "is valid" do
-          expect(subject.valid?).to be(true)
-                 ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          it "is valid" do
+            expect(subject.valid?).to be(true)
+                   ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
+
+          specify do
+            expect(subject.valid?).to be(true)
+                   ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
         end
+      RUBY
+    end
 
-        specify do
-          expect(subject.valid?).to be(true)
-                 ^^^^^^^ Name your test subject if you need to reference it explicitly.
+    it 'checks before and after for explicit subject usage' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          subject { described_class.new }
+
+          before(:each) do
+            do_something_with(subject)
+                              ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
+
+          after do
+            do_something_with(subject)
+                              ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
+
+    it 'checks around(:each) for explicit subject usage' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          subject { described_class.new }
+
+          around(:each) do |test|
+            do_something_with(subject)
+                              ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores subject when not wrapped inside a test' do
+      expect_no_offenses(<<-RUBY)
+        def foo
+          it(subject)
+        end
+      RUBY
+    end
   end
 
-  it 'checks before and after for explicit subject usage' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        subject { described_class.new }
+  context 'when AllowInSharedExamples is false' do
+    let(:cop_config) { { 'AllowInSharedExamples' => false } }
 
-        before(:each) do
-          do_something_with(subject)
-                            ^^^^^^^ Name your test subject if you need to reference it explicitly.
-        end
+    it_behaves_like 'checking subject outside of shared examples'
 
-        after do
-          do_something_with(subject)
-                            ^^^^^^^ Name your test subject if you need to reference it explicitly.
+    it 'checks shared_examples for explicit subject usage' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          subject(:new_user) { described_class.new }
+
+          shared_examples_for 'a valid new user' do
+            it "is a User" do
+              expect(subject).to be_a(User)
+                     ^^^^^^^ Name your test subject if you need to reference it explicitly.
+            end
+
+            it "is valid" do
+              expect(subject.valid?).to be(true)
+                     ^^^^^^^ Name your test subject if you need to reference it explicitly.
+            end
+
+            it "is new" do
+              expect(subject).to be_new_record
+                     ^^^^^^^ Name your test subject if you need to reference it explicitly.
+            end
+          end
         end
-      end
-    RUBY
+      RUBY
+    end
   end
 
-  it 'checks around(:each) for explicit subject usage' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        subject { described_class.new }
+  context 'when AllowInSharedExamples is true' do
+    let(:cop_config) { { 'AllowInSharedExamples' => true } }
 
-        around(:each) do |test|
-          do_something_with(subject)
-                            ^^^^^^^ Name your test subject if you need to reference it explicitly.
+    it_behaves_like 'checking subject outside of shared examples'
+
+    it 'ignores explicit subject in shared_examples' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          subject(:new_user) { described_class.new }
+
+          shared_examples_for 'a valid new user' do
+            it "is a User" do
+              expect(subject).to be_a(User)
+            end
+
+            it "is valid" do
+              expect(subject.valid?).to be(true)
+            end
+
+            it "is new" do
+              expect(subject).to be_new_record
+            end
+          end
         end
-      end
-    RUBY
-  end
-
-  it 'ignores subject when not wrapped inside a test' do
-    expect_no_offenses(<<-RUBY)
-      def foo
-        it(subject)
-      end
-    RUBY
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Having explicit subjects is a good idea, except for shared_examples which are meant to be used in different contexts that likely/possibly have different subjects. This PR introduces the `AllowInSharedExamples` option for `RSpec/NamedSubject` to let users decide whether to allow implicit subjects in shared examples or not.

I set the default for this option to `true` because I think, intuitively it is what one would expect.

Fixes #453 