### PR TITLE
Compatibility with RuboCop v0.60.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'tmp/**/*'
     - 'spec/smoke_tests/**/*.rb'
 
+# See https://github.com/rubocop-hq/rubocop/issues/6410
+Layout/AlignHash:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - rubocop-rspec.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rubocop', '< 0.60.0'
-
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -33,8 +33,8 @@ module RuboCop
         MSG_SHOULD = 'Do not use should when describing your tests.'.freeze
         MSG_IT     = "Do not repeat 'it' when describing your tests.".freeze
 
-        SHOULD_PREFIX = /\Ashould(?:n't)?\b/i
-        IT_PREFIX     = /\Ait /i
+        SHOULD_PREFIX = /\Ashould(?:n't)?\b/i.freeze
+        IT_PREFIX     = /\Ait /i.freeze
 
         def_node_matcher(
           :it_description,

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      NAMESPACES = /^(RSpec|Capybara|FactoryBot|Rails)/
+      NAMESPACES = /^(RSpec|Capybara|FactoryBot|Rails)/.freeze
       STYLE_GUIDE_BASE_URL = 'http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'.freeze
 
       def initialize(config, descriptions)

--- a/lib/rubocop/rspec/wording.rb
+++ b/lib/rubocop/rspec/wording.rb
@@ -4,10 +4,10 @@ module RuboCop
   module RSpec
     # RSpec example wording rewriter
     class Wording
-      SHOULDNT_PREFIX    = /\Ashould(?:n't| not)\b/i
-      SHOULDNT_BE_PREFIX = /#{SHOULDNT_PREFIX} be\b/i
-      ES_SUFFIX_PATTERN  = /(?:o|s|x|ch|sh|z)\z/i
-      IES_SUFFIX_PATTERN = /[^aeou]y\z/i
+      SHOULDNT_PREFIX    = /\Ashould(?:n't| not)\b/i.freeze
+      SHOULDNT_BE_PREFIX = /#{SHOULDNT_PREFIX} be\b/i.freeze
+      ES_SUFFIX_PATTERN  = /(?:o|s|x|ch|sh|z)\z/i.freeze
+      IES_SUFFIX_PATTERN = /[^aeou]y\z/i.freeze
 
       def initialize(text, ignore:, replace:)
         @text         = text

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.58.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.60.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -229,6 +229,6 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
       end
     RUBY
 
-    expect(cop.config_to_allow_offenses).to eq('Max' => 3)
+    expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 3)
   end
 end

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
       end
     RUBY
 
-    expect(cop.config_to_allow_offenses).to eq('Max' => 4)
+    expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 4)
   end
 
   it 'ignores non-spec context methods' do


### PR DESCRIPTION
There are a few interesting changes between RuboCop v0.59.2 and v0.60.0:

1. We need to add `[:exclude_limit]` when checking `cop.config_to_allow_offenses`.
2. Style/MutableConstant reported a few new issues.
3. Layout/AlignHash has been changed so a combination of `key` and `table` styles is no longer allowed. I disagree with this decision, and have voiced my opinion on the issue rubocop-hq/rubocop#6410
4. There seems to be some namespace collision between the cops `Rails/HttpStatus` and `RSpec/Rails/HttpStatus` … again. @Darhazer would you take a look at my last commit “tmp”?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
