### PR TITLE
Load only RuboCop-RSpec config when generating cops documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rubocop', '< 0.60.0'
+
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Enforces use of symbolic or numeric value to describe HTTP status.
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -237,7 +237,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def main
     cops   = RuboCop::Cop::Cop.registry
-    config = RuboCop::ConfigLoader.default_configuration
+    config = RuboCop::ConfigLoader.load_file('config/default.yml')
 
     YARD::Registry.load!
     cops.departments.sort!.each do |department|
@@ -260,15 +260,13 @@ task documentation_syntax_check: :yard_for_generate_documentation do
   YARD::Registry.load!
   cops = RuboCop::Cop::Cop.registry
   cops.each do |cop|
-    next unless %i[RSpec Capybara FactoryBot].include?(cop.department)
-
     examples = YARD::Registry.all(:class).find do |code_object|
       next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge
 
       break code_object.tags('example')
     end
 
-    examples.each do |example|
+    examples.to_a.each do |example|
       begin
         buffer = Parser::Source::Buffer.new('<code>', 1)
         buffer.source = example.text


### PR DESCRIPTION
This resolves the case where there is a name conflict, as it doesn't load the rest of RuboCop configuration (which is not needed, we are trying to skip the rest of the cops anyway)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
