### PR TITLE
[Fix #712] check that the method is called on `receive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix `FactoryBot/CreateList` autocorrect crashing when the factory is called with a block=. ([@Darhazer][])
 * Fixed `RSpec/Focus` not flagging some cases of `RSpec.describe` with `focus: true`. ([@Darhazer][])
 * Fixed `RSpec/Pending` not flagging some cases of `RSpec.describe` with `:skip`. ([@Darhazer][])
+* Fix false positive in `RSpec/ReceiveCounts` when method name `exactly`, `at_least` or `at_most` is used along with `times`, without being an RSpec API. ([@Darhazer][])
 
 ## 1.31.0 (2019-01-02)
 

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -30,8 +30,12 @@ module RuboCop
           (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)
         PATTERN
 
+        def_node_search :stub?, '(send nil? :receive ...)'
+
         def on_send(node)
           receive_counts(node) do |offending_node|
+            return unless stub?(offending_node.receiver)
+
             offending_range = range(node, offending_node)
 
             add_offense(
@@ -48,10 +52,9 @@ module RuboCop
               node.method_name,
               node.first_argument.source.to_i
             )
-            corrector.replace(
-              range(node.parent, node),
-              replacement
-            )
+
+            original = range(node.parent, node)
+            corrector.replace(original, replacement)
           end
         end
 

--- a/spec/rubocop/cop/rspec/receive_counts_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_counts_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
     RUBY
   end
 
+  it 'allows exactly(1).times when not called on `receive`' do
+    expect_no_offenses(<<-RUBY)
+      expect(action).to have_published_event.exactly(1).times
+    RUBY
+  end
+
   include_examples 'autocorrect',
                    'expect(foo).to receive(:bar).exactly(1).times { true }',
                    'expect(foo).to receive(:bar).once { true }'
@@ -85,4 +91,9 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
   include_examples 'autocorrect',
                    'expect(foo).to receive(:bar).at_least(2).times { true }',
                    'expect(foo).to receive(:bar).at_least(:twice) { true }'
+
+  # Does not auto-correct if not part of the RSpec API
+  include_examples 'autocorrect',
+                   'expect(foo).to have_published_event(:bar).exactly(2).times',
+                   'expect(foo).to have_published_event(:bar).exactly(2).times'
 end


### PR DESCRIPTION
The cop didn't check that the receiver is actually a stub, leading to false positives if other objects implement similar API

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
