### PR TITLE
Remove unnecessary RSpec configuration

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,14 +21,6 @@ RSpec.configure do |config|
 
   config.order = :random
 
-  config.expect_with :rspec do |expectations|
-    expectations.syntax = :expect # Disable `should`
-  end
-
-  config.mock_with :rspec do |mocks|
-    mocks.syntax = :expect # Disable `should_receive` and `stub`
-  end
-
   # Forbid RSpec from monkey patching any of our objects
   config.disable_monkey_patching!
 


### PR DESCRIPTION
According to https://www.rubydoc.info/gems/rspec-core/RSpec/Core/Configuration#disable_monkey_patching!-instance_method these configurations are already set by `config.disable_monkey_patching!`:

```rb

# It disables all monkey patching.
RSpec.configure do |config|
  config.disable_monkey_patching!
end

# Is an equivalent to
RSpec.configure do |config|
  config.expose_dsl_globally = false

  config.mock_with :rspec do |mocks|
    mocks.syntax = :expect
    mocks.patch_marshal_to_support_partial_doubles = false
  end

  config.expect_with :rspec do |expectations|
    expectations.syntax = :expect
  end
end
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
