### PR TITLE
[Fix #719] Allow using arrays, variables and method in receive_message_chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `IgnoreSharedExamples` option for `RSpec/NamedSubject`. ([@RST-J][])
 * Add autocorrect support for `Capybara/CurrentPathExpectation` cop. ([@ypresto][])
 * Add support for built-in `exists` matcher for `RSpec/PredicateMatcher` cop. ([@mkenyon][])
+* `SingleArgumentMessageChain` no longer reports an array as it's only argument as an offense. ([@Darhazer][])
 
 ## 1.30.1 (2018-11-01)
 


### PR DESCRIPTION
Array with multiple elements is a valid way to specify a message chain.
Also, in case a variable (or send node) is used, we cannot know if it doesn't evaluate to an array with multiple elements, so we should not report those.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
