### PR TITLE
Add cop metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Before submitting the PR make sure the following are checked:
 * [ ] Squashed related commits together.
 * [ ] Added tests.
 * [ ] Updated documentation.
-* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
+* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
 * [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
 
 If you have created a new cop:
@@ -16,3 +16,8 @@ If you have created a new cop:
 * [ ] Added the new cop to `config/default.yml`.
 * [ ] The cop documents examples of good and bad code.
 * [ ] The tests assert both that bad code is reported and that good code is not reported.
+* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.
+
+If you have modified an existing cop's configuration options:
+
+* [ ] Set `VersionChanged` in `default/config.yml` to the next major version.

--- a/config/default.yml
+++ b/config/default.yml
@@ -13,36 +13,43 @@ AllCops:
 RSpec/AlignLeftLetBrace:
   Description: Checks that left braces for adjacent single line lets are aligned.
   Enabled: false
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignLeftLetBrace
 
 RSpec/AlignRightLetBrace:
   Description: Checks that right braces for adjacent single line lets are aligned.
   Enabled: false
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignRightLetBrace
 
 RSpec/AnyInstance:
   Description: Check that instances are not being stubbed globally.
   Enabled: true
+  VersionAdded: '1.4'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
 
 RSpec/AroundBlock:
   Description: Checks that around blocks actually run the test.
   Enabled: true
+  VersionAdded: '1.11'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AroundBlock
 
 RSpec/Be:
   Description: Check for expectations where `be` is used without argument.
   Enabled: true
+  VersionAdded: '1.25'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
 
 RSpec/BeEql:
   Description: Check for expectations where `be(...)` can replace `eql(...)`.
   Enabled: true
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeforeAfterAll:
   Description: Check that before/after(:all) isn't being used.
   Enabled: true
+  VersionAdded: '1.12'
   Exclude:
   - spec/spec_helper.rb
   - spec/rails_helper.rb
@@ -57,6 +64,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Description: Checks that `context` docstring starts with an allowed prefix.
   Enabled: true
+  VersionAdded: '1.20'
+  VersionChanged: 1.20.1
   Prefixes:
   - when
   - with
@@ -66,22 +75,27 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Description: Check that the first argument to the top level describe is a constant.
   Enabled: true
+  VersionAdded: '1.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:
   Description: Checks that the second argument to `describe` specifies a method.
   Enabled: true
+  VersionAdded: '1.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeMethod
 
 RSpec/DescribeSymbol:
   Description: Avoid describing symbols.
   Enabled: true
+  VersionAdded: '1.15'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
 
 RSpec/DescribedClass:
   Description: Checks that tests use `described_class`.
-  SkipBlocks: false
   Enabled: true
+  VersionAdded: '1.0'
+  VersionChanged: '1.11'
+  SkipBlocks: false
   EnforcedStyle: described_class
   SupportedStyles:
   - described_class
@@ -102,6 +116,7 @@ RSpec/Dialect:
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
+  VersionAdded: '1.7'
   CustomIncludeMethods: []
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
@@ -120,32 +135,38 @@ RSpec/EmptyLineAfterExample:
 RSpec/EmptyLineAfterExampleGroup:
   Description: Checks if there is an empty line after example group blocks.
   Enabled: true
+  VersionAdded: '1.27'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
 
 RSpec/EmptyLineAfterFinalLet:
   Description: Checks if there is an empty line after the last let block.
   Enabled: true
+  VersionAdded: '1.14'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
 
 RSpec/EmptyLineAfterHook:
   Description: Checks if there is an empty line after hook blocks.
   Enabled: true
+  VersionAdded: '1.27'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
 
 RSpec/EmptyLineAfterSubject:
   Description: Checks if there is an empty line after subject block.
   Enabled: true
+  VersionAdded: '1.14'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
 
 RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true
+  VersionAdded: '1.5'
   Max: 5
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 RSpec/ExampleWithoutDescription:
   Description: Checks for examples without a description.
   Enabled: true
+  VersionAdded: '1.22'
   EnforcedStyle: always_allow
   SupportedStyles:
   - always_allow
@@ -156,6 +177,8 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExampleWording:
   Description: Checks for common mistakes in example descriptions.
   Enabled: true
+  VersionAdded: '1.0'
+  VersionChanged: '1.2'
   CustomTransform:
     be: is
     BE: IS
@@ -167,6 +190,7 @@ RSpec/ExampleWording:
 RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
   Enabled: true
+  VersionAdded: '1.7'
   Exclude:
   - spec/routing/**/*
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
@@ -174,6 +198,7 @@ RSpec/ExpectActual:
 RSpec/ExpectChange:
   Description: Checks for consistent style of change matcher.
   Enabled: true
+  VersionAdded: '1.22'
   EnforcedStyle: method_call
   SupportedStyles:
   - method_call
@@ -182,17 +207,20 @@ RSpec/ExpectChange:
 
 RSpec/ExpectInHook:
   Enabled: true
+  VersionAdded: '1.16'
   Description: Do not use `expect` in hooks such as `before`.
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
 
 RSpec/ExpectOutput:
   Description: Checks for opportunities to use `expect { ... }.to output`.
   Enabled: true
+  VersionAdded: '1.10'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
 
 RSpec/FilePath:
   Description: Checks that spec file paths are consistent and well-formed.
   Enabled: true
+  VersionAdded: '1.2'
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
@@ -203,11 +231,13 @@ RSpec/FilePath:
 RSpec/Focus:
   Description: Checks if examples are focused.
   Enabled: true
+  VersionAdded: '1.5'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 RSpec/HookArgument:
   Description: Checks the arguments passed to `before`, `around`, and `after`.
   Enabled: true
+  VersionAdded: '1.7'
   EnforcedStyle: implicit
   SupportedStyles:
   - implicit
@@ -216,8 +246,9 @@ RSpec/HookArgument:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 RSpec/HooksBeforeExamples:
-  Enabled: true
   Description: Checks for before/around/after hooks that come after an example.
+  Enabled: true
+  VersionAdded: '1.29'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples
 
 RSpec/ImplicitBlockExpectation:
@@ -228,6 +259,7 @@ RSpec/ImplicitBlockExpectation:
 RSpec/ImplicitExpect:
   Description: Check that a consistent implicit expectation style is used.
   Enabled: true
+  VersionAdded: '1.8'
   EnforcedStyle: is_expected
   SupportedStyles:
   - is_expected
@@ -235,8 +267,10 @@ RSpec/ImplicitExpect:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 RSpec/ImplicitSubject:
-  Enabled: true
   Description: Checks for usage of implicit subject (`is_expected` / `should`).
+  Enabled: true
+  VersionAdded: '1.29'
+  VersionChanged: '1.30'
   EnforcedStyle: single_line_only
   SupportedStyles:
   - single_line_only
@@ -247,22 +281,27 @@ RSpec/ImplicitSubject:
 RSpec/InstanceSpy:
   Description: Checks for `instance_double` used with `have_received`.
   Enabled: true
+  VersionAdded: '1.12'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceSpy
 
 RSpec/InstanceVariable:
   Description: Checks for instance variable usage in specs.
-  AssignmentOnly: false
   Enabled: true
+  VersionAdded: '1.0'
+  VersionChanged: '1.7'
+  AssignmentOnly: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 RSpec/InvalidPredicateMatcher:
   Description: Checks invalid usage for predicate matcher.
   Enabled: true
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InvalidPredicateMatcher
 
 RSpec/ItBehavesLike:
   Description: Checks that only one `it_behaves_like` style is used.
   Enabled: true
+  VersionAdded: '1.13'
   EnforcedStyle: it_behaves_like
   SupportedStyles:
   - it_behaves_like
@@ -272,11 +311,14 @@ RSpec/ItBehavesLike:
 RSpec/IteratedExpectation:
   Description: Check that `all` matcher is used instead of iterating over an array.
   Enabled: true
+  VersionAdded: '1.14'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IteratedExpectation
 
 RSpec/LeadingSubject:
   Description: Enforce that subject is the first definition in the test.
   Enabled: true
+  VersionAdded: '1.7'
+  VersionChanged: '1.14'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 
 RSpec/LeakyConstantDeclaration:
@@ -287,21 +329,27 @@ RSpec/LeakyConstantDeclaration:
 RSpec/LetBeforeExamples:
   Description: Checks for `let` definitions that come after an example.
   Enabled: true
+  VersionAdded: '1.16'
+  VersionChanged: '1.22'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetBeforeExamples
 
 RSpec/LetSetup:
   Description: Checks unreferenced `let!` calls being used for test setup.
   Enabled: true
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
 
 RSpec/MessageChain:
   Description: Check that chains of messages are not being stubbed.
   Enabled: true
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageChain
 
 RSpec/MessageExpectation:
   Description: Checks for consistent message expectation style.
   Enabled: false
+  VersionAdded: '1.7'
+  VersionChanged: '1.8'
   EnforcedStyle: allow
   SupportedStyles:
   - allow
@@ -311,6 +359,7 @@ RSpec/MessageExpectation:
 RSpec/MessageSpies:
   Description: Checks that message expectations are set using spies.
   Enabled: true
+  VersionAdded: '1.9'
   EnforcedStyle: have_received
   SupportedStyles:
   - have_received
@@ -320,58 +369,70 @@ RSpec/MessageSpies:
 RSpec/MissingExampleGroupArgument:
   Description: Checks that the first argument to an example group is not empty.
   Enabled: true
+  VersionAdded: '1.28'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
 
 RSpec/MultipleDescribes:
   Description: Checks for multiple top level describes.
   Enabled: true
+  VersionAdded: '1.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
 
 RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
+  VersionAdded: '1.7'
+  VersionChanged: '1.21'
   Max: 1
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleSubjects:
   Description: Checks if an example group defines `subject` multiple times.
   Enabled: true
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleSubjects
 
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
+  VersionAdded: 1.5.3
   IgnoreSharedExamples: true
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:
   Description: Checks for nested example groups.
   Enabled: true
+  VersionAdded: '1.7'
+  VersionChanged: '1.10'
   Max: 3
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
 
 RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.
+  Enabled: true
+  VersionAdded: '1.4'
   EnforcedStyle: not_to
   SupportedStyles:
   - not_to
   - to_not
-  Enabled: true
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
 
 RSpec/OverwritingSetup:
-  Enabled: true
   Description: Checks if there is a let/subject that overwrites an existing one.
+  Enabled: true
+  VersionAdded: '1.14'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/OverwritingSetup
 
 RSpec/Pending:
-  Enabled: false
   Description: Checks for any pending or skipped examples.
+  Enabled: false
+  VersionAdded: '1.25'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
 
 RSpec/PredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
   Enabled: true
+  VersionAdded: '1.16'
   Strict: true
   EnforcedStyle: inflected
   AllowedExplicitMatchers: []
@@ -381,23 +442,27 @@ RSpec/PredicateMatcher:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 RSpec/ReceiveCounts:
-  Enabled: true
   Description: Check for `once` and `twice` receive counts matchers usage.
+  Enabled: true
+  VersionAdded: '1.26'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
 
 RSpec/ReceiveNever:
-  Enabled: true
   Description: Prefer `not_to receive(...)` over `receive(...).never`.
+  Enabled: true
+  VersionAdded: '1.28'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveNever
 
 RSpec/RepeatedDescription:
-  Enabled: true
   Description: Check for repeated description strings in example groups.
+  Enabled: true
+  VersionAdded: '1.9'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedDescription
 
 RSpec/RepeatedExample:
-  Enabled: true
   Description: Check for repeated examples within example groups.
+  Enabled: true
+  VersionAdded: '1.10'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
 
 RSpec/RepeatedExampleGroupBody:
@@ -411,8 +476,10 @@ RSpec/RepeatedExampleGroupDescription:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
 
 RSpec/ReturnFromStub:
-  Enabled: true
   Description: Checks for consistent style of stub's return setting.
+  Enabled: true
+  VersionAdded: '1.16'
+  VersionChanged: '1.22'
   EnforcedStyle: and_return
   SupportedStyles:
   - and_return
@@ -422,37 +489,45 @@ RSpec/ReturnFromStub:
 RSpec/ScatteredLet:
   Description: Checks for let scattered across the example group.
   Enabled: true
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
+  VersionAdded: '1.14'
   VersionChanged: '1.39'
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
 
 RSpec/ScatteredSetup:
   Description: Checks for setup scattered across multiple hooks in an example group.
   Enabled: true
+  VersionAdded: '1.10'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
 
 RSpec/SharedContext:
   Description: Checks for proper shared_context and shared_examples usage.
   Enabled: true
+  VersionAdded: '1.13'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:
   Description: Enforces use of string to titleize shared examples.
   Enabled: true
+  VersionAdded: '1.25'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:
   Description: Checks that chains of messages contain more than one element.
   Enabled: true
+  VersionAdded: '1.9'
+  VersionChanged: '1.10'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SingleArgumentMessageChain
 
 RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
   Enabled: true
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 
 RSpec/UnspecifiedException:
   Description: Checks for a specified error in checking raised errors.
   Enabled: true
+  VersionAdded: '1.30'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UnspecifiedException
 
 RSpec/VariableDefinition:
@@ -478,6 +553,8 @@ RSpec/VariableName:
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
   Enabled: true
+  VersionAdded: 1.2.1
+  VersionChanged: '1.5'
   IgnoreNameless: true
   IgnoreSymbolicNames: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
@@ -485,6 +562,7 @@ RSpec/VerifiedDoubles:
 RSpec/VoidExpect:
   Description: This cop checks void `expect()`.
   Enabled: true
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
 
 RSpec/Yield:
@@ -495,11 +573,14 @@ RSpec/Yield:
 Capybara/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.
   Enabled: true
+  VersionAdded: '1.18'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/CurrentPathExpectation
 
 Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
   Enabled: true
+  VersionAdded: '1.17'
+  VersionChanged: '1.25'
   EnabledMethods: []
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
@@ -512,11 +593,13 @@ Capybara/VisibilityMatcher:
 FactoryBot/AttributeDefinedStatically:
   Description: Always declare attribute values as blocks.
   Enabled: true
+  VersionAdded: '1.28'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
 
 FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true
+  VersionAdded: '1.25'
   EnforcedStyle: create_list
   SupportedStyles:
   - create_list
@@ -531,6 +614,7 @@ FactoryBot/FactoryClassName:
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true
+  VersionAdded: '1.23'
   EnforcedStyle: symbolic
   SupportedStyles:
   - numeric

--- a/config/default.yml
+++ b/config/default.yml
@@ -59,13 +59,14 @@ RSpec/BeforeAfterAll:
 RSpec/ContextMethod:
   Description: "`context` should not be used for specifying methods."
   Enabled: true
+  VersionAdded: '1.36'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 RSpec/ContextWording:
   Description: Checks that `context` docstring starts with an allowed prefix.
   Enabled: true
   VersionAdded: '1.20'
-  VersionChanged: 1.20.1
+  VersionChanged: '1.20.1'
   Prefixes:
   - when
   - with
@@ -105,11 +106,13 @@ RSpec/DescribedClass:
 RSpec/DescribedClassModuleWrapping:
   Description: Avoid opening modules and defining specs within them.
   Enabled: false
+  VersionAdded: '1.37'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
 
 RSpec/Dialect:
   Description: This cop enforces custom RSpec dialects.
   Enabled: false
+  VersionAdded: '1.33'
   PreferredMethods: {}
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
 
@@ -123,12 +126,13 @@ RSpec/EmptyExampleGroup:
 RSpec/EmptyHook:
   Description: Checks for empty before and after hooks.
   Enabled: true
-  VersionAdded: 1.39.0
+  VersionAdded: '1.39'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook
 
 RSpec/EmptyLineAfterExample:
   Description: Checks if there is an empty line after example blocks.
   Enabled: true
+  VersionAdded: '1.36'
   AllowConsecutiveOneLiners: true
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
@@ -254,6 +258,7 @@ RSpec/HooksBeforeExamples:
 RSpec/ImplicitBlockExpectation:
   Description: Check that implicit block expectation syntax is not used.
   Enabled: true
+  VersionAdded: '1.35'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
 
 RSpec/ImplicitExpect:
@@ -324,6 +329,7 @@ RSpec/LeadingSubject:
 RSpec/LeakyConstantDeclaration:
   Description: Checks that no class, module, or constant is declared.
   Enabled: true
+  VersionAdded: '1.35'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
 
 RSpec/LetBeforeExamples:
@@ -395,7 +401,7 @@ RSpec/MultipleSubjects:
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
-  VersionAdded: 1.5.3
+  VersionAdded: '1.5.3'
   IgnoreSharedExamples: true
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
@@ -466,13 +472,15 @@ RSpec/RepeatedExample:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
 
 RSpec/RepeatedExampleGroupBody:
-  Enabled: true
   Description: Check for repeated describe and context block body.
+  Enabled: true
+  VersionAdded: '1.38'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupBody
 
 RSpec/RepeatedExampleGroupDescription:
-  Enabled: true
   Description: Check for repeated example group descriptions.
+  Enabled: true
+  VersionAdded: '1.38'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
 
 RSpec/ReturnFromStub:
@@ -553,7 +561,7 @@ RSpec/VariableName:
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
   Enabled: true
-  VersionAdded: 1.2.1
+  VersionAdded: '1.2.1'
   VersionChanged: '1.5'
   IgnoreNameless: true
   IgnoreSymbolicNames: false
@@ -568,6 +576,7 @@ RSpec/VoidExpect:
 RSpec/Yield:
   Description: This cop checks for calling a block within a stub.
   Enabled: true
+  VersionAdded: '1.32'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield
 
 Capybara/CurrentPathExpectation:
@@ -609,6 +618,7 @@ FactoryBot/CreateList:
 FactoryBot/FactoryClassName:
   Description: Use string value when setting the class attribute explicitly.
   Enabled: true
+  VersionAdded: '1.37'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
 
 Rails/HttpStatus:

--- a/config/default.yml
+++ b/config/default.yml
@@ -49,11 +49,11 @@ RSpec/BeEql:
 RSpec/BeforeAfterAll:
   Description: Check that before/after(:all) isn't being used.
   Enabled: true
-  VersionAdded: '1.12'
   Exclude:
   - spec/spec_helper.rb
   - spec/rails_helper.rb
   - spec/support/**/*.rb
+  VersionAdded: '1.12'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 RSpec/ContextMethod:
@@ -65,12 +65,12 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Description: Checks that `context` docstring starts with an allowed prefix.
   Enabled: true
-  VersionAdded: '1.20'
-  VersionChanged: '1.20.1'
   Prefixes:
   - when
   - with
   - without
+  VersionAdded: '1.20'
+  VersionChanged: 1.20.1
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:
@@ -94,13 +94,13 @@ RSpec/DescribeSymbol:
 RSpec/DescribedClass:
   Description: Checks that tests use `described_class`.
   Enabled: true
-  VersionAdded: '1.0'
-  VersionChanged: '1.11'
   SkipBlocks: false
   EnforcedStyle: described_class
   SupportedStyles:
   - described_class
   - explicit
+  VersionAdded: '1.0'
+  VersionChanged: '1.11'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
 
 RSpec/DescribedClassModuleWrapping:
@@ -112,15 +112,15 @@ RSpec/DescribedClassModuleWrapping:
 RSpec/Dialect:
   Description: This cop enforces custom RSpec dialects.
   Enabled: false
-  VersionAdded: '1.33'
   PreferredMethods: {}
+  VersionAdded: '1.33'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
 
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
-  VersionAdded: '1.7'
   CustomIncludeMethods: []
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
 RSpec/EmptyHook:
@@ -132,8 +132,8 @@ RSpec/EmptyHook:
 RSpec/EmptyLineAfterExample:
   Description: Checks if there is an empty line after example blocks.
   Enabled: true
-  VersionAdded: '1.36'
   AllowConsecutiveOneLiners: true
+  VersionAdded: '1.36'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
 RSpec/EmptyLineAfterExampleGroup:
@@ -163,56 +163,56 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true
-  VersionAdded: '1.5'
   Max: 5
+  VersionAdded: '1.5'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 RSpec/ExampleWithoutDescription:
   Description: Checks for examples without a description.
   Enabled: true
-  VersionAdded: '1.22'
   EnforcedStyle: always_allow
   SupportedStyles:
   - always_allow
   - single_line_only
   - disallow
+  VersionAdded: '1.22'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
 
 RSpec/ExampleWording:
   Description: Checks for common mistakes in example descriptions.
   Enabled: true
-  VersionAdded: '1.0'
-  VersionChanged: '1.2'
   CustomTransform:
     be: is
     BE: IS
     have: has
     HAVE: HAS
   IgnoredWords: []
+  VersionAdded: '1.0'
+  VersionChanged: '1.2'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 
 RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
   Enabled: true
-  VersionAdded: '1.7'
   Exclude:
   - spec/routing/**/*
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
 
 RSpec/ExpectChange:
   Description: Checks for consistent style of change matcher.
   Enabled: true
-  VersionAdded: '1.22'
   EnforcedStyle: method_call
   SupportedStyles:
   - method_call
   - block
+  VersionAdded: '1.22'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:
+  Description: Do not use `expect` in hooks such as `before`.
   Enabled: true
   VersionAdded: '1.16'
-  Description: Do not use `expect` in hooks such as `before`.
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
 
 RSpec/ExpectOutput:
@@ -224,12 +224,12 @@ RSpec/ExpectOutput:
 RSpec/FilePath:
   Description: Checks that spec file paths are consistent and well-formed.
   Enabled: true
-  VersionAdded: '1.2'
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
   IgnoreMethods: false
   SpecSuffixOnly: false
+  VersionAdded: '1.2'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 
 RSpec/Focus:
@@ -241,12 +241,12 @@ RSpec/Focus:
 RSpec/HookArgument:
   Description: Checks the arguments passed to `before`, `around`, and `after`.
   Enabled: true
-  VersionAdded: '1.7'
   EnforcedStyle: implicit
   SupportedStyles:
   - implicit
   - each
   - example
+  VersionAdded: '1.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 RSpec/HooksBeforeExamples:
@@ -264,23 +264,23 @@ RSpec/ImplicitBlockExpectation:
 RSpec/ImplicitExpect:
   Description: Check that a consistent implicit expectation style is used.
   Enabled: true
-  VersionAdded: '1.8'
   EnforcedStyle: is_expected
   SupportedStyles:
   - is_expected
   - should
+  VersionAdded: '1.8'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 RSpec/ImplicitSubject:
   Description: Checks for usage of implicit subject (`is_expected` / `should`).
   Enabled: true
-  VersionAdded: '1.29'
-  VersionChanged: '1.30'
   EnforcedStyle: single_line_only
   SupportedStyles:
   - single_line_only
   - single_statement_only
   - disallow
+  VersionAdded: '1.29'
+  VersionChanged: '1.30'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
 
 RSpec/InstanceSpy:
@@ -292,9 +292,9 @@ RSpec/InstanceSpy:
 RSpec/InstanceVariable:
   Description: Checks for instance variable usage in specs.
   Enabled: true
+  AssignmentOnly: false
   VersionAdded: '1.0'
   VersionChanged: '1.7'
-  AssignmentOnly: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 RSpec/InvalidPredicateMatcher:
@@ -306,11 +306,11 @@ RSpec/InvalidPredicateMatcher:
 RSpec/ItBehavesLike:
   Description: Checks that only one `it_behaves_like` style is used.
   Enabled: true
-  VersionAdded: '1.13'
   EnforcedStyle: it_behaves_like
   SupportedStyles:
   - it_behaves_like
   - it_should_behave_like
+  VersionAdded: '1.13'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
 
 RSpec/IteratedExpectation:
@@ -354,22 +354,22 @@ RSpec/MessageChain:
 RSpec/MessageExpectation:
   Description: Checks for consistent message expectation style.
   Enabled: false
-  VersionAdded: '1.7'
-  VersionChanged: '1.8'
   EnforcedStyle: allow
   SupportedStyles:
   - allow
   - expect
+  VersionAdded: '1.7'
+  VersionChanged: '1.8'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageExpectation
 
 RSpec/MessageSpies:
   Description: Checks that message expectations are set using spies.
   Enabled: true
-  VersionAdded: '1.9'
   EnforcedStyle: have_received
   SupportedStyles:
   - have_received
   - receive
+  VersionAdded: '1.9'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageSpies
 
 RSpec/MissingExampleGroupArgument:
@@ -387,9 +387,9 @@ RSpec/MultipleDescribes:
 RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
+  Max: 1
   VersionAdded: '1.7'
   VersionChanged: '1.21'
-  Max: 1
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleSubjects:
@@ -401,26 +401,26 @@ RSpec/MultipleSubjects:
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
-  VersionAdded: '1.5.3'
   IgnoreSharedExamples: true
+  VersionAdded: 1.5.3
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:
   Description: Checks for nested example groups.
   Enabled: true
+  Max: 3
   VersionAdded: '1.7'
   VersionChanged: '1.10'
-  Max: 3
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
 
 RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.
   Enabled: true
-  VersionAdded: '1.4'
   EnforcedStyle: not_to
   SupportedStyles:
   - not_to
   - to_not
+  VersionAdded: '1.4'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
 
 RSpec/OverwritingSetup:
@@ -438,13 +438,13 @@ RSpec/Pending:
 RSpec/PredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
   Enabled: true
-  VersionAdded: '1.16'
   Strict: true
   EnforcedStyle: inflected
   AllowedExplicitMatchers: []
   SupportedStyles:
   - inflected
   - explicit
+  VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 RSpec/ReceiveCounts:
@@ -486,12 +486,12 @@ RSpec/RepeatedExampleGroupDescription:
 RSpec/ReturnFromStub:
   Description: Checks for consistent style of stub's return setting.
   Enabled: true
-  VersionAdded: '1.16'
-  VersionChanged: '1.22'
   EnforcedStyle: and_return
   SupportedStyles:
   - and_return
   - block
+  VersionAdded: '1.16'
+  VersionChanged: '1.22'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
 
 RSpec/ScatteredLet:
@@ -561,10 +561,10 @@ RSpec/VariableName:
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
   Enabled: true
-  VersionAdded: '1.2.1'
-  VersionChanged: '1.5'
   IgnoreNameless: true
   IgnoreSymbolicNames: false
+  VersionAdded: 1.2.1
+  VersionChanged: '1.5'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
 RSpec/VoidExpect:
@@ -588,9 +588,9 @@ Capybara/CurrentPathExpectation:
 Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
   Enabled: true
+  EnabledMethods: []
   VersionAdded: '1.17'
   VersionChanged: '1.25'
-  EnabledMethods: []
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
 Capybara/VisibilityMatcher:
@@ -608,11 +608,11 @@ FactoryBot/AttributeDefinedStatically:
 FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true
-  VersionAdded: '1.25'
   EnforcedStyle: create_list
   SupportedStyles:
   - create_list
   - n_times
+  VersionAdded: '1.25'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
 FactoryBot/FactoryClassName:
@@ -624,9 +624,9 @@ FactoryBot/FactoryClassName:
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true
-  VersionAdded: '1.23'
   EnforcedStyle: symbolic
   SupportedStyles:
   - numeric
   - symbolic
+  VersionAdded: '1.23'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/config/default.yml
+++ b/config/default.yml
@@ -99,6 +99,7 @@ RSpec/DescribedClass:
   SupportedStyles:
   - described_class
   - explicit
+  SafeAutoCorrect: false
   VersionAdded: '1.0'
   VersionChanged: '1.11'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
@@ -444,6 +445,7 @@ RSpec/PredicateMatcher:
   SupportedStyles:
   - inflected
   - explicit
+  SafeAutoCorrect: false
   VersionAdded: '1.16'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 

--- a/manual/cops_capybara.md
+++ b/manual/cops_capybara.md
@@ -2,9 +2,9 @@
 
 ## Capybara/CurrentPathExpectation
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.18 | -
 
 Checks that no expectations are set on Capybara's `current_path`.
 
@@ -34,9 +34,9 @@ expect(page).to have_current_path(/widgets/)
 
 ## Capybara/FeatureMethods
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.17 | 1.25
 
 Checks for consistent method usage in feature specs.
 
@@ -90,9 +90,9 @@ EnabledMethods | `[]` | Array
 
 ## Capybara/VisibilityMatcher
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.39 | -
 
 Checks for boolean visibility in capybara finders.
 
@@ -117,12 +117,6 @@ expect(page).to have_selector('.foo', visible: :visible)
 expect(page).to have_css('.foo', visible: :all)
 expect(page).to have_link('my link', visible: :hidden)
 ```
-
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-VersionAdded | `1.39` | String
 
 ### References
 

--- a/manual/cops_factorybot.md
+++ b/manual/cops_factorybot.md
@@ -82,7 +82,7 @@ EnforcedStyle | `create_list` | `create_list`, `n_times`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 1.37 | -
 
 Use string value when setting the class attribute explicitly.
 

--- a/manual/cops_factorybot.md
+++ b/manual/cops_factorybot.md
@@ -2,9 +2,9 @@
 
 ## FactoryBot/AttributeDefinedStatically
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.28 | -
 
 Always declare attribute values as blocks.
 
@@ -36,9 +36,9 @@ count { 1 }
 
 ## FactoryBot/CreateList
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.25 | -
 
 Checks for create_list usage.
 
@@ -80,9 +80,9 @@ EnforcedStyle | `create_list` | `create_list`, `n_times`
 
 ## FactoryBot/FactoryClassName
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | - | -
 
 Use string value when setting the class attribute explicitly.
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -2,9 +2,9 @@
 
 ## Rails/HttpStatus
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.23 | -
 
 Enforces use of symbolic or numeric value to describe HTTP status.
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -237,7 +237,7 @@ Exclude | `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb` 
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 1.36 | -
 
 `context` should not be used for specifying methods.
 
@@ -482,7 +482,7 @@ EnforcedStyle | `described_class` | `described_class`, `explicit`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | No | - | -
+Disabled | Yes | No | 1.37 | -
 
 Avoid opening modules and defining specs within them.
 
@@ -510,7 +510,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Disabled | Yes | Yes  | - | -
+Disabled | Yes | Yes  | 1.33 | -
 
 This cop enforces custom RSpec dialects.
 
@@ -643,7 +643,7 @@ CustomIncludeMethods | `[]` | Array
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 1.39.0 | -
+Enabled | Yes | Yes  | 1.39 | -
 
 Checks for empty before and after hooks.
 
@@ -676,7 +676,7 @@ after(:all) { cleanup_feed }
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 1.36 | -
 
 Checks if there is an empty line after example blocks.
 
@@ -1377,7 +1377,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 1.35 | -
 
 Check that implicit block expectation syntax is not used.
 
@@ -1713,7 +1713,7 @@ Enforce that subject is the first definition in the test.
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 1.35 | -
 
 Checks that no class, module, or constant is declared.
 
@@ -2626,7 +2626,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 1.38 | -
 
 Check for repeated describe and context block body.
 
@@ -2678,7 +2678,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 1.38 | -
 
 Check for repeated example group descriptions.
 
@@ -3178,7 +3178,7 @@ expect(something).to be(1)
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Enabled | Yes | Yes  | 1.32 | -
 
 This cop checks for calling a block within a stub.
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2,9 +2,9 @@
 
 ## RSpec/AlignLeftLetBrace
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | Yes  | 1.16 | -
 
 Checks that left braces for adjacent single line lets are aligned.
 
@@ -28,9 +28,9 @@ let(:a)      { b }
 
 ## RSpec/AlignRightLetBrace
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | Yes  | 1.16 | -
 
 Checks that right braces for adjacent single line lets are aligned.
 
@@ -54,9 +54,9 @@ let(:a)      { b        }
 
 ## RSpec/AnyInstance
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.4 | -
 
 Check that instances are not being stubbed globally.
 
@@ -87,9 +87,9 @@ end
 
 ## RSpec/AroundBlock
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.11 | -
 
 Checks that around blocks actually run the test.
 
@@ -123,9 +123,9 @@ end
 
 ## RSpec/Be
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.25 | -
 
 Check for expectations where `be` is used without argument.
 
@@ -151,9 +151,9 @@ expect(foo).to be(true)
 
 ## RSpec/BeEql
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.7 | -
 
 Check for expectations where `be(...)` can replace `eql(...)`.
 
@@ -195,9 +195,9 @@ expect(foo).to be(nil)
 
 ## RSpec/BeforeAfterAll
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.12 | -
 
 Check that before/after(:all) isn't being used.
 
@@ -235,9 +235,9 @@ Exclude | `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb` 
 
 ## RSpec/ContextMethod
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | - | -
 
 `context` should not be used for specifying methods.
 
@@ -269,9 +269,9 @@ end
 
 ## RSpec/ContextWording
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.20 | 1.20.1
 
 Checks that `context` docstring starts with an allowed prefix.
 
@@ -318,9 +318,9 @@ Prefixes | `when`, `with`, `without` | Array
 
 ## RSpec/DescribeClass
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.0 | -
 
 Check that the first argument to the top level describe is a constant.
 
@@ -350,9 +350,9 @@ end
 
 ## RSpec/DescribeMethod
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.0 | -
 
 Checks that the second argument to `describe` specifies a method.
 
@@ -377,9 +377,9 @@ end
 
 ## RSpec/DescribeSymbol
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.15 | -
 
 Avoid describing symbols.
 
@@ -403,9 +403,9 @@ end
 
 ## RSpec/DescribedClass
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.0 | 1.11
 
 Checks that tests use `described_class`.
 
@@ -480,9 +480,9 @@ EnforcedStyle | `described_class` | `described_class`, `explicit`
 
 ## RSpec/DescribedClassModuleWrapping
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | No | - | -
 
 Avoid opening modules and defining specs within them.
 
@@ -508,9 +508,9 @@ end
 
 ## RSpec/Dialect
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | Yes  | - | -
 
 This cop enforces custom RSpec dialects.
 
@@ -566,9 +566,9 @@ PreferredMethods | `{}` |
 
 ## RSpec/EmptyExampleGroup
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | -
 
 Checks if an example group does not include any tests.
 
@@ -641,9 +641,9 @@ CustomIncludeMethods | `[]` | Array
 
 ## RSpec/EmptyHook
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.39.0 | -
 
 Checks for empty before and after hooks.
 
@@ -668,21 +668,15 @@ end
 after(:all) { cleanup_feed }
 ```
 
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-VersionAdded | `1.39.0` | String
-
 ### References
 
 * [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook)
 
 ## RSpec/EmptyLineAfterExample
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | - | -
 
 Checks if there is an empty line after example blocks.
 
@@ -738,9 +732,9 @@ AllowConsecutiveOneLiners | `true` | Boolean
 
 ## RSpec/EmptyLineAfterExampleGroup
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.27 | -
 
 Checks if there is an empty line after example group blocks.
 
@@ -771,9 +765,9 @@ end
 
 ## RSpec/EmptyLineAfterFinalLet
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.14 | -
 
 Checks if there is an empty line after the last let block.
 
@@ -798,9 +792,9 @@ it { does_something }
 
 ## RSpec/EmptyLineAfterHook
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.27 | -
 
 Checks if there is an empty line after hook blocks.
 
@@ -841,9 +835,9 @@ it { does_something }
 
 ## RSpec/EmptyLineAfterSubject
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.14 | -
 
 Checks if there is an empty line after subject block.
 
@@ -866,9 +860,9 @@ let(:foo) { bar }
 
 ## RSpec/ExampleLength
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.5 | -
 
 Checks for long examples.
 
@@ -908,9 +902,9 @@ Max | `5` | Integer
 
 ## RSpec/ExampleWithoutDescription
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.22 | -
 
 Checks for examples without a description.
 
@@ -978,9 +972,9 @@ EnforcedStyle | `always_allow` | `always_allow`, `single_line_only`, `disallow`
 
 ## RSpec/ExampleWording
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.0 | 1.2
 
 Checks for common mistakes in example descriptions.
 
@@ -1023,9 +1017,9 @@ IgnoredWords | `[]` | Array
 
 ## RSpec/ExpectActual
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.7 | -
 
 Checks for `expect(...)` calls containing literal values.
 
@@ -1055,9 +1049,9 @@ Exclude | `spec/routing/**/*` | Array
 
 ## RSpec/ExpectChange
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.22 | -
 
 Checks for consistent style of change matcher.
 
@@ -1104,9 +1098,9 @@ EnforcedStyle | `method_call` | `method_call`, `block`
 
 ## RSpec/ExpectInHook
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.16 | -
 
 Do not use `expect` in hooks such as `before`.
 
@@ -1135,9 +1129,9 @@ end
 
 ## RSpec/ExpectOutput
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.10 | -
 
 Checks for opportunities to use `expect { ... }.to output`.
 
@@ -1160,9 +1154,9 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 
 ## RSpec/FilePath
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.2 | -
 
 Checks that spec file paths are consistent and well-formed.
 
@@ -1238,9 +1232,9 @@ SpecSuffixOnly | `false` | Boolean
 
 ## RSpec/Focus
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.5 | -
 
 Checks if examples are focused.
 
@@ -1268,9 +1262,9 @@ end
 
 ## RSpec/HookArgument
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.7 | -
 
 Checks the arguments passed to `before`, `around`, and `after`.
 
@@ -1348,9 +1342,9 @@ EnforcedStyle | `implicit` | `implicit`, `each`, `example`
 
 ## RSpec/HooksBeforeExamples
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.29 | -
 
 Checks for before/around/after hooks that come after an example.
 
@@ -1381,9 +1375,9 @@ end
 
 ## RSpec/ImplicitBlockExpectation
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
 
 Check that implicit block expectation syntax is not used.
 
@@ -1408,9 +1402,9 @@ end
 
 ## RSpec/ImplicitExpect
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.8 | -
 
 Check that a consistent implicit expectation style is used.
 
@@ -1450,9 +1444,9 @@ EnforcedStyle | `is_expected` | `is_expected`, `should`
 
 ## RSpec/ImplicitSubject
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.29 | 1.30
 
 Checks for usage of implicit subject (`is_expected` / `should`).
 
@@ -1496,9 +1490,9 @@ EnforcedStyle | `single_line_only` | `single_line_only`, `single_statement_only`
 
 ## RSpec/InstanceSpy
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.12 | -
 
 Checks for `instance_double` used with `have_received`.
 
@@ -1524,9 +1518,9 @@ end
 
 ## RSpec/InstanceVariable
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.0 | 1.7
 
 Checks for instance variable usage in specs.
 
@@ -1587,9 +1581,9 @@ AssignmentOnly | `false` | Boolean
 
 ## RSpec/InvalidPredicateMatcher
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.16 | -
 
 Checks invalid usage for predicate matcher.
 
@@ -1612,9 +1606,9 @@ expect(foo).to be_something
 
 ## RSpec/ItBehavesLike
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.13 | -
 
 Checks that only one `it_behaves_like` style is used.
 
@@ -1651,9 +1645,9 @@ EnforcedStyle | `it_behaves_like` | `it_behaves_like`, `it_should_behave_like`
 
 ## RSpec/IteratedExpectation
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.14 | -
 
 Check that `all` matcher is used instead of iterating over an array.
 
@@ -1677,9 +1671,9 @@ end
 
 ## RSpec/LeadingSubject
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.7 | 1.14
 
 Enforce that subject is the first definition in the test.
 
@@ -1717,9 +1711,9 @@ Enforce that subject is the first definition in the test.
 
 ## RSpec/LeakyConstantDeclaration
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
 
 Checks that no class, module, or constant is declared.
 
@@ -1821,9 +1815,9 @@ end
 
 ## RSpec/LetBeforeExamples
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.16 | 1.22
 
 Checks for `let` definitions that come after an example.
 
@@ -1862,9 +1856,9 @@ end
 
 ## RSpec/LetSetup
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | -
 
 Checks unreferenced `let!` calls being used for test setup.
 
@@ -1898,9 +1892,9 @@ end
 
 ## RSpec/MessageChain
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | -
 
 Check that chains of messages are not being stubbed.
 
@@ -1921,9 +1915,9 @@ allow(foo).to receive(:bar).and_return(thing)
 
 ## RSpec/MessageExpectation
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | No | 1.7 | 1.8
 
 Checks for consistent message expectation style.
 
@@ -1963,9 +1957,9 @@ EnforcedStyle | `allow` | `allow`, `expect`
 
 ## RSpec/MessageSpies
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.9 | -
 
 Checks that message expectations are set using spies.
 
@@ -2005,9 +1999,9 @@ EnforcedStyle | `have_received` | `have_received`, `receive`
 
 ## RSpec/MissingExampleGroupArgument
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.28 | -
 
 Checks that the first argument to an example group is not empty.
 
@@ -2035,9 +2029,9 @@ end
 
 ## RSpec/MultipleDescribes
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.0 | -
 
 Checks for multiple top level describes.
 
@@ -2068,9 +2062,9 @@ end
 
 ## RSpec/MultipleExpectations
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | 1.21
 
 Checks if examples contain too many `expect` calls.
 
@@ -2127,9 +2121,9 @@ Max | `1` | Integer
 
 ## RSpec/MultipleSubjects
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.16 | -
 
 Checks if an example group defines `subject` multiple times.
 
@@ -2170,9 +2164,9 @@ end
 
 ## RSpec/NamedSubject
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.5.3 | -
 
 Checks for explicitly referenced test subjects.
 
@@ -2228,9 +2222,9 @@ IgnoreSharedExamples | `true` | Boolean
 
 ## RSpec/NestedGroups
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | 1.10
 
 Checks for nested example groups.
 
@@ -2330,9 +2324,9 @@ Max | `3` | Integer
 
 ## RSpec/NotToNot
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.4 | -
 
 Checks for consistent method usage for negating expectations.
 
@@ -2362,9 +2356,9 @@ EnforcedStyle | `not_to` | `not_to`, `to_not`
 
 ## RSpec/OverwritingSetup
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.14 | -
 
 Checks if there is a let/subject that overwrites an existing one.
 
@@ -2394,9 +2388,9 @@ let!(:other) { other }
 
 ## RSpec/Pending
 
-Enabled by default | Supports autocorrection
---- | ---
-Disabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Disabled | Yes | No | 1.25 | -
 
 Checks for any pending or skipped examples.
 
@@ -2436,9 +2430,9 @@ end
 
 ## RSpec/PredicateMatcher
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.16 | -
 
 Prefer using predicate matcher over using predicate method directly.
 
@@ -2503,9 +2497,9 @@ AllowedExplicitMatchers | `[]` | Array
 
 ## RSpec/ReceiveCounts
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.26 | -
 
 Check for `once` and `twice` receive counts matchers usage.
 
@@ -2535,9 +2529,9 @@ expect(foo).to receive(:bar).at_most(:twice).times
 
 ## RSpec/ReceiveNever
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.28 | -
 
 Prefer `not_to receive(...)` over `receive(...).never`.
 
@@ -2557,9 +2551,9 @@ expect(foo).not_to receive(:bar)
 
 ## RSpec/RepeatedDescription
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.9 | -
 
 Check for repeated description strings in example groups.
 
@@ -2606,9 +2600,9 @@ end
 
 ## RSpec/RepeatedExample
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.10 | -
 
 Check for repeated examples within example groups.
 
@@ -2630,9 +2624,9 @@ end
 
 ## RSpec/RepeatedExampleGroupBody
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
 
 Check for repeated describe and context block body.
 
@@ -2682,9 +2676,9 @@ end
 
 ## RSpec/RepeatedExampleGroupDescription
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
 
 Check for repeated example group descriptions.
 
@@ -2734,9 +2728,9 @@ end
 
 ## RSpec/ReturnFromStub
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.16 | 1.22
 
 Checks for consistent style of stub's return setting.
 
@@ -2787,9 +2781,9 @@ EnforcedStyle | `and_return` | `and_return`, `block`
 
 ## RSpec/ScatteredLet
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.14 | 1.39
 
 Checks for let scattered across the example group.
 
@@ -2817,21 +2811,15 @@ describe Foo do
 end
 ```
 
-### Configurable attributes
-
-Name | Default value | Configurable values
---- | --- | ---
-VersionChanged | `1.39` | String
-
 ### References
 
 * [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet)
 
 ## RSpec/ScatteredSetup
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.10 | -
 
 Checks for setup scattered across multiple hooks in an example group.
 
@@ -2861,9 +2849,9 @@ end
 
 ## RSpec/SharedContext
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.13 | -
 
 Checks for proper shared_context and shared_examples usage.
 
@@ -2921,9 +2909,9 @@ end
 
 ## RSpec/SharedExamples
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.25 | -
 
 Enforces use of string to titleize shared examples.
 
@@ -2951,9 +2939,9 @@ include_examples 'foo bar baz'
 
 ## RSpec/SingleArgumentMessageChain
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | 1.9 | 1.10
 
 Checks that chains of messages contain more than one element.
 
@@ -2977,9 +2965,9 @@ allow(foo).to receive("bar.baz")
 
 ## RSpec/SubjectStub
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.7 | -
 
 Checks for stubbed test subjects.
 
@@ -3002,9 +2990,9 @@ end
 
 ## RSpec/UnspecifiedException
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.30 | -
 
 Checks for a specified error in checking raised errors.
 
@@ -3042,9 +3030,9 @@ expect { do_something }.not_to raise_error
 
 ## RSpec/VariableDefinition
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.40 | -
 
 Checks that memoized helpers names are symbols or strings.
 
@@ -3078,7 +3066,6 @@ subject('user') { create_user }
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `symbols` | `symbols`, `strings`
-VersionAdded | `1.40` | String
 
 ### References
 
@@ -3086,9 +3073,9 @@ VersionAdded | `1.40` | String
 
 ## RSpec/VariableName
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.40 | -
 
 Checks that memoized helper names use the configured style.
 
@@ -3122,7 +3109,6 @@ subject(:userName) { 'Adam' }
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `snake_case` | `snake_case`, `camelCase`
-VersionAdded | `1.40` | String
 
 ### References
 
@@ -3130,9 +3116,9 @@ VersionAdded | `1.40` | String
 
 ## RSpec/VerifiedDoubles
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.2.1 | 1.5
 
 Prefer using verifying doubles over normal doubles.
 
@@ -3168,9 +3154,9 @@ IgnoreSymbolicNames | `false` | Boolean
 
 ## RSpec/VoidExpect
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | No
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | 1.16 | -
 
 This cop checks void `expect()`.
 
@@ -3190,9 +3176,9 @@ expect(something).to be(1)
 
 ## RSpec/Yield
 
-Enabled by default | Supports autocorrection
---- | ---
-Enabled | Yes
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | Yes  | - | -
 
 This cop checks for calling a block within a stub.
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -405,7 +405,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 1.0 | 1.11
+Enabled | Yes | Yes (Unsafe) | 1.0 | 1.11
 
 Checks that tests use `described_class`.
 
@@ -2432,7 +2432,7 @@ end
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | 1.16 | -
+Enabled | Yes | Yes (Unsafe) | 1.16 | -
 
 Prefer using predicate matcher over using predicate method directly.
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -32,15 +32,29 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def properties(config, cop)
-    header = ['Enabled by default', 'Supports autocorrection']
-    enabled_by_default = config.for_cop(cop).fetch('Enabled')
+    header = [
+      'Enabled by default', 'Safe', 'Supports autocorrection', 'VersionAdded',
+      'VersionChanged'
+    ]
+    config = config.for_cop(cop)
+    safe_auto_correct = config.fetch('SafeAutoCorrect', true)
+    autocorrect = if cop.new.support_autocorrect?
+                    "Yes #{'(Unsafe)' unless safe_auto_correct}"
+                  else
+                    'No'
+                  end
     content = [[
-      enabled_by_default ? 'Enabled' : 'Disabled',
-      cop.new.support_autocorrect? ? 'Yes' : 'No'
+      config.fetch('Enabled') ? 'Enabled' : 'Disabled',
+      config.fetch('Safe', true) ? 'Yes' : 'No',
+      autocorrect,
+      config.fetch('VersionAdded', '-'),
+      config.fetch('VersionChanged', '-')
     ]]
     to_table(header, content) + "\n"
   end
+  # rubocop:enable Metrics/MethodLength
 
   def h2(title)
     content = +"\n"
@@ -192,7 +206,10 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def print_cop_with_doc(cop, config) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     t = config.for_cop(cop)
-    non_display_keys = %w[Description Enabled StyleGuide Reference]
+    non_display_keys = %w[
+      Description Enabled StyleGuide Reference Safe SafeAutoCorrect VersionAdded
+      VersionChanged
+    ]
     pars = t.reject { |k| non_display_keys.include? k }
     description = 'No documentation'
     examples_object = []


### PR DESCRIPTION
This is the foundation to support the planned RuboCop behaviors (currently only Safe and SafeAutocorrect affect the actual behavior).

As far as I know we don't have any cops that are unsafe by design, so I've just added the versions. Now we can start also mark cops as Safe: false or SafeAutocorrect: false

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
