### PR TITLE
Test on CI also with Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ rubocop: &rubocop
 jobs:
   confirm_config_and_documentation:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby
     steps:
       - checkout
       - run: bundle install
@@ -82,7 +82,7 @@ jobs:
 
   code-climate:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby
     steps:
       - checkout
       - run: bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,16 @@ jobs:
       - image: circleci/ruby:2.5
     <<: *rubocop
 
+  # Ruby 2.6
+  ruby-2.6-rspec:
+    docker:
+      - image: circleci/ruby:2.6
+    <<: *rspec
+  ruby-2.6-rubocop:
+    docker:
+      - image: circleci/ruby:2.6
+    <<: *rubocop
+
   # JRuby
   jruby:
     docker:
@@ -120,6 +130,10 @@ workflows:
       - ruby-2.5-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.5-rubocop:
+          requires: [confirm_config_and_documentation]
+      - ruby-2.6-rspec:
+          requires: [confirm_config_and_documentation]
+      - ruby-2.6-rubocop:
           requires: [confirm_config_and_documentation]
       - jruby
       - code-climate


### PR DESCRIPTION
Ruby 2.6.0 is released: https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
