### PR TITLE
WIP: Speed up the jruby job on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,8 @@ jobs:
   jruby:
     docker:
       - image: circleci/jruby:9
+    environment:
+      JRUBY_OPTS: "--dev"
     steps:
       - checkout
       - run: sudo apt-get install -y make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ rspec: &rspec
   steps:
     - checkout
     - run: bundle install
-    - run: rake spec
+    - run: bundle exec rspec
 
 rubocop: &rubocop
   steps:
     - checkout
     - run: bundle install
-    - run: rake internal_investigation
+    - run: bundle exec rubocop
 
 jobs:
   confirm_config_and_documentation:
@@ -90,7 +90,8 @@ jobs:
           key: bundle-v2-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: rake internal_investigation spec
+      - run: bundle exec rubocop
+      - run: bundle exec rspec
 
   code-climate:
     docker:
@@ -107,7 +108,7 @@ jobs:
           name: Run specs
           command: |
             ./cc-test-reporter before-build
-            rake coverage
+            COVERAGE=true bundle exec rspec
             ./cc-test-reporter after-build --exit-code $?
 
 workflows:


### PR DESCRIPTION
As documented on https://github.com/jruby/jruby/wiki/Improving-startup-time,

    you can pass the `--dev` option to JRuby to choose the fastest-starting
    JVM and JRuby flags (at the expense of long-running code speed).

I ran the relevant Ruby commands in a fresh Docker container, and it seems like
they all benefit from the `--dev` option. Here are my benchmarks:

    » docker run -v "$(pwd)":/home/circleci/project -u root -i -t circleci/jruby:9.2 /bin/bash

    # time bundle lock
    real  0m33.060s

    # rm -rf vendor/bundle ; time bundle install --path vendor/bundle
    real  1m6.897s

    # time rake internal_investigation spec
    real  3m31.495s

And starting another container:

    » docker run -v "$(pwd)":/home/circleci/project -u root -i -t circleci/jruby:9.2 /bin/bash

    # time JRUBY_OPTS="--dev" bundle lock
    real  0m23.177s

    # rm -rf vendor/bundle ; time JRUBY_OPTS="--dev" bundle install --path vendor/bundle
    real  0m55.389s

    # time JRUBY_OPTS="--dev" rake internal_investigation spec
    real  2m42.100s

**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
