### PR TITLE
[Fix #728] Fix false negatives in Focus cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `RSpec/Yield` cop, suggesting using the `and_yield` method when stubbing a method, accepting a block. ([@Darhazer][])
 * Fix `FactoryBot/CreateList` autocorrect crashing when the factory is called with a block=. ([@Darhazer][])
+* Fixed `RSpec/Focus` not flagging some cases of `RSpec.describe` with `focus: true`. ([@Darhazer][])
 
 ## 1.31.0 (2019-01-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `RSpec/Yield` cop, suggesting using the `and_yield` method when stubbing a method, accepting a block. ([@Darhazer][])
 * Fix `FactoryBot/CreateList` autocorrect crashing when the factory is called with a block=. ([@Darhazer][])
 * Fixed `RSpec/Focus` not flagging some cases of `RSpec.describe` with `focus: true`. ([@Darhazer][])
+* Fixed `RSpec/Pending` not flagging some cases of `RSpec.describe` with `:skip`. ([@Darhazer][])
 
 ## 1.31.0 (2019-01-02)
 

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -36,8 +36,8 @@ module RuboCop
         FOCUS_TRUE   = s(:pair, FOCUS_SYMBOL, s(:true))
 
         def_node_matcher :metadata, <<-PATTERN
-          {(send nil? #{FOCUSABLE_SELECTORS} ... (hash $...))
-           (send nil? #{FOCUSABLE_SELECTORS} $...)}
+          {(send {(const nil? :RSpec) nil?} #{FOCUSABLE_SELECTORS} ... (hash $...))
+           (send {(const nil? :RSpec) nil?} #{FOCUSABLE_SELECTORS} $...)}
         PATTERN
 
         def_node_matcher :focused_block?, focused.send_pattern

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -37,8 +37,8 @@ module RuboCop
         PENDING_SYMBOL = s(:sym, :pending)
 
         def_node_matcher :metadata, <<-PATTERN
-          {(send nil? #{SKIPPABLE_SELECTORS} ... (hash $...))
-           (send nil? #{SKIPPABLE_SELECTORS} $...)}
+          {(send {(const nil? :RSpec) nil?} #{SKIPPABLE_SELECTORS} ... (hash $...))
+           (send {(const nil? :RSpec) nil?} #{SKIPPABLE_SELECTORS} $...)}
         PATTERN
 
         def_node_matcher :pending_block?, PENDING_EXAMPLES.send_pattern

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                               ^^^^^^^^^^^ Focused spec found.
       describe 'test', meta: true, focus: true do; end
                                    ^^^^^^^^^^^ Focused spec found.
+      RSpec.describe 'test', meta: true, focus: true do; end
+                                         ^^^^^^^^^^^ Focused spec found.
       it 'test', meta: true, focus: true do; end
                              ^^^^^^^^^^^ Focused spec found.
       xspecify 'test', meta: true, focus: true do; end
@@ -61,6 +63,8 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                        ^^^^^^ Focused spec found.
       describe 'test', :focus do; end
                        ^^^^^^ Focused spec found.
+      RSpec.describe 'test', :focus do; end
+                             ^^^^^^ Focused spec found.
       xit 'test', :focus do; end
                   ^^^^^^ Focused spec found.
       context 'test', :focus do; end
@@ -108,10 +112,13 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
+  # rubocop:disable RSpec/ExampleLength
   it 'flags focused block types' do
     expect_offense(<<-RUBY)
       fdescribe 'test' do; end
       ^^^^^^^^^^^^^^^^ Focused spec found.
+      RSpec.fdescribe 'test' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^ Focused spec found.
       ffeature 'test' do; end
       ^^^^^^^^^^^^^^^ Focused spec found.
       fcontext 'test' do; end
@@ -128,4 +135,5 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       ^^^^^^^^^^^^ Focused spec found.
     RUBY
   end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     RUBY
   end
 
+  it 'flags describe with skip symbol metadata' do
+    expect_offense(<<-RUBY)
+      RSpec.describe 'test', :skip do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
+      end
+    RUBY
+  end
+
   it 'flags blocks with pending symbol metadata' do
     expect_offense(<<-RUBY)
       it 'test', :pending do


### PR DESCRIPTION
A while ago we made sure that our matchers include both explicit `RSpec` receiver and implicit (`nil?`) one. There were a couple of cops however that use just `node_pattern_union`, skipping the language module, and using only implicit receiver.

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
