### PR TITLE
Implement auto-correct for factory calls with block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/Yield` cop, suggesting using the `and_yield` method when stubbing a method, accepting a block. ([@Darhazer][])
+* Fix `FactoryBot/CreateList` autocorrect crashing when the factory is called with a block=. ([@Darhazer][])
 
 ## 1.31.0 (2019-01-02)
 

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -88,6 +88,36 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList, :config do
     include_examples 'autocorrect',
                      '5.times { FactoryGirl.create :user }',
                      'FactoryGirl.create_list :user, 5'
+
+    bad_code = <<-RUBY
+      3.times do
+        create(:user, :trait) { |user| create :account, user: user }
+      end
+    RUBY
+
+    good_code = <<-RUBY
+      create_list(:user, 3, :trait) { |user| create :account, user: user }
+    RUBY
+
+    include_examples 'autocorrect', bad_code, good_code
+
+    bad_code = <<-RUBY
+      3.times do
+        create(:user, :trait) do |user|
+          create :account, user: user
+          create :profile, user: user
+        end
+      end
+    RUBY
+
+    good_code = <<-RUBY
+      create_list(:user, 3, :trait) do |user|
+          create :account, user: user
+          create :profile, user: user
+      end
+    RUBY
+
+    include_examples 'autocorrect', bad_code, good_code
   end
 
   context 'when EnforcedStyle is :n_times' do


### PR DESCRIPTION
This also fixes the build with rubocop 0.63

On a side note... 120+ lines of code for auto-correction... I nearly regret creating this cop :joy: 

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
