### PR TITLE
Add support for metadata to ContextWording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
+
 ## 1.32.0 (2019-01-27)
 
 * Add `RSpec/Yield` cop, suggesting using the `and_yield` method when stubbing a method, accepting a block. ([@Darhazer][])

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -30,7 +30,7 @@ module RuboCop
         MSG = 'Start context description with %<prefixes>s.'.freeze
 
         def_node_matcher :context_wording, <<-PATTERN
-          (block (send _ { :context :shared_context } $(str #bad_prefix?)) ...)
+          (block (send #{RSPEC} { :context :shared_context } $(str #bad_prefix?) ...) ...)
         PATTERN
 
         def on_block(node)

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -41,6 +41,36 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
     RUBY
   end
 
+  context 'with metadata hash' do
+    it 'finds context without separate `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        context 'whenever you do', legend: true do
+                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+        end
+      RUBY
+    end
+  end
+
+  context 'with symbol metadata' do
+    it 'finds context without separate `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        context 'whenever you do', :legend do
+                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+        end
+      RUBY
+    end
+  end
+
+  context 'with mixed metadata' do
+    it 'finds context without separate `when` at the beginning' do
+      expect_offense(<<-RUBY)
+        context 'whenever you do', :legend, myth: true do
+                ^^^^^^^^^^^^^^^^^ Start context description with 'when', or 'with'.
+        end
+      RUBY
+    end
+  end
+
   context 'when configured' do
     let(:cop_config) { { 'Prefixes' => %w[if] } }
 


### PR DESCRIPTION
RSpec/ContextWording cop previously missed the `context`s with metadata.
This change adds support for metadata detection.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.