### PR TITLE
Use the new expect_correction spec helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,7 +40,7 @@ Lint/InterpolationCheck:
     - spec/**/*.rb
 
 RSpec/ExampleLength:
-  Max: 19
+  Max: 30
 
 RSpec/DescribeClass:
   Exclude:

--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
   subject(:cop) { described_class.new }
 
+  # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<-RUBY)
       let(:foo) { bar }
@@ -15,52 +16,34 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
       }
 
       describe 'blah' do
-        let(:blahblah) { baz }
+        let(:long_name) { thing }
         let(:blah) { thing }
                    ^ Align left let brace
         let(:a) { thing }
                 ^ Align left let brace
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      let(:foo)      { bar }
+      let(:hi)       { baz }
+      let(:blahblah) { baz }
+
+      let(:thing) { ignore_this }
+      let(:other) {
+        ignore_this_too
+      }
+
+      describe 'blah' do
+        let(:long_name) { thing }
+        let(:blah)      { thing }
+        let(:a)         { thing }
+      end
+    RUBY
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'works with empty file' do
     expect_no_offenses('')
   end
-
-  offensive_source = <<-RUBY
-    let(:foo) { bar }
-    let(:hi) { baz }
-    let(:blahblah) { baz }
-
-    let(:thing) { ignore_this }
-    let(:other) {
-      ignore_this_too
-    }
-
-    describe 'blah' do
-      let(:long_name) { thing }
-      let(:blah) { thing }
-      let(:a) { thing }
-    end
-  RUBY
-
-  corrected_source = <<-RUBY
-    let(:foo)      { bar }
-    let(:hi)       { baz }
-    let(:blahblah) { baz }
-
-    let(:thing) { ignore_this }
-    let(:other) {
-      ignore_this_too
-    }
-
-    describe 'blah' do
-      let(:long_name) { thing }
-      let(:blah)      { thing }
-      let(:a)         { thing }
-    end
-  RUBY
-
-  include_examples 'autocorrect', offensive_source, corrected_source
 end

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
   subject(:cop) { described_class.new }
 
+  # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<-RUBY)
       let(:foo)      { a }
@@ -22,45 +23,27 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
         let(:a)        { abc }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      let(:foo)      { a    }
+      let(:hi)       { ab   }
+      let(:blahblah) { abcd }
+
+      let(:thing) { ignore_this }
+      let(:other) {
+        ignore_this_too
+      }
+
+      describe 'blah' do
+        let(:blahblah) { a   }
+        let(:blah)     { bc  }
+        let(:a)        { abc }
+      end
+    RUBY
   end
+  # rubocop:enable RSpec/ExampleLength
 
   it 'works with empty file' do
     expect_no_offenses('')
   end
-
-  offensive_source = <<-RUBY
-    let(:foo)      { a }
-    let(:hi)       { ab }
-    let(:blahblah) { abcd }
-
-    let(:thing) { ignore_this }
-    let(:other) {
-      ignore_this_too
-    }
-
-    describe 'blah' do
-      let(:blahblah) { a }
-      let(:blah)     { bc }
-      let(:a)        { abc }
-    end
-  RUBY
-
-  corrected_source = <<-RUBY
-    let(:foo)      { a    }
-    let(:hi)       { ab   }
-    let(:blahblah) { abcd }
-
-    let(:thing) { ignore_this }
-    let(:other) {
-      ignore_this_too
-    }
-
-    describe 'blah' do
-      let(:blahblah) { a   }
-      let(:blah)     { bc  }
-      let(:a)        { abc }
-    end
-  RUBY
-
-  include_examples 'autocorrect', offensive_source, corrected_source
 end

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
       it { expect(foo).to eql(false) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      it { expect(foo).to be(true) }
+      it { expect(foo).to be(false) }
+    RUBY
   end
 
   it 'registers an offense for `eql` when argument is an integer' do
@@ -16,6 +21,11 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(123) }
                           ^^^ Prefer `be` over `eql`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it { expect(foo).to be(0) }
+      it { expect(foo).to be(123) }
     RUBY
   end
 
@@ -26,6 +36,11 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
       it { expect(foo).to eql(1.23) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      it { expect(foo).to be(1.0) }
+      it { expect(foo).to be(1.23) }
+    RUBY
   end
 
   it 'registers an offense for `eql` when argument is a symbol' do
@@ -33,12 +48,20 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
       it { expect(foo).to eql(:foo) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      it { expect(foo).to be(:foo) }
+    RUBY
   end
 
   it 'registers an offense for `eql` when argument is nil' do
     expect_offense(<<-RUBY)
       it { expect(foo).to eql(nil) }
                           ^^^ Prefer `be` over `eql`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it { expect(foo).to be(nil) }
     RUBY
   end
 
@@ -53,8 +76,4 @@ RSpec.describe RuboCop::Cop::RSpec::BeEql do
       it { expect(foo).to_not eql(1) }
     RUBY
   end
-
-  include_examples 'autocorrect',
-                   'it { expect(foo).to eql(1) }',
-                   'it { expect(foo).to be(1) }'
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        describe '#bar' do
+        end
+
+        describe '#baz' do
+        end
+      end
+    RUBY
   end
 
   it 'highlights single line formulations correctly' do
@@ -20,6 +30,15 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       RSpec.describe Foo do
         describe('#bar') { }
         ^^^^^^^^^^^^^^^^^^^^ Add an empty line after `describe`.
+        describe '#baz' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        describe('#bar') { }
+
         describe '#baz' do
         end
       end
@@ -32,6 +51,16 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
         context 'bar' do
         end
         ^^^ Add an empty line after `context`.
+        context 'baz' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.context 'foo' do
+        context 'bar' do
+        end
+
         context 'baz' do
         end
       end
@@ -75,28 +104,18 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      if RUBY_VERSION < 2.3
+        describe 'skips checks under old ruby' do
+        end
+      else
+        describe 'first check' do
+        end
+
+        describe 'second check' do
+        end
+      end
+    RUBY
   end
-
-  bad_example = <<-RUBY
-    RSpec.describe Foo do
-      describe '#bar' do
-      end
-      describe '#baz' do
-      end
-    end
-  RUBY
-
-  good_example = <<-RUBY
-    RSpec.describe Foo do
-      describe '#bar' do
-      end
-
-      describe '#baz' do
-      end
-    end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -12,6 +12,15 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         it { expect(a).to eq(b) }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+
+        it { expect(a).to eq(b) }
+      end
+    RUBY
   end
 
   it 'check for empty line after the last `let!`' do
@@ -22,6 +31,17 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
           b
         end
         ^^^ Add an empty line after the last `let` block.
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let!(:b) do
+          b
+        end
+
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -60,6 +80,40 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         it { expect(a).to eq(b) }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        # end of setup
+
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+  end
+
+  it 'flags missing empty line after a multiline comment after last let' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        # a multiline comment marking
+        # the end of setup
+        ^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        # a multiline comment marking
+        # the end of setup
+
+        it { expect(a).to eq(b) }
+      end
+    RUBY
   end
 
   it 'ignores empty lines between the lets' do
@@ -71,6 +125,18 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
 
         let!(:b) { b }
         ^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+
+        subject { described_class }
+
+        let!(:b) { b }
+
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -156,76 +222,18 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe 'silly heredoc syntax' do
+        let(:foo) { <<-BAR }
+        hello
+        world
+        BAR
+
+        it 'has tricky syntax' do
+          expect(foo).to eql("  hello\n  world\n")
+        end
+      end
+    RUBY
   end
-
-  bad_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { foo }
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  good_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { foo }
-
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
-
-  bad_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { foo }
-    # a multiline comment marking
-    # the end of setup
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  good_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { foo }
-    # a multiline comment marking
-    # the end of setup
-
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
-
-  bad_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { <<-DOC }
-     I'm super annoying!
-    DOC
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  good_example = <<-RUBY
-  RSpec.describe User do
-    let(:params) { <<-DOC }
-     I'm super annoying!
-    DOC
-
-    it 'has a new line' do
-    end
-  end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         it { does_something }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+
+        it { does_something }
+      end
+    RUBY
   end
 
   it 'checks for empty line after `after` hook' do
@@ -21,6 +29,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         it { does_something }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        after { do_something }
+
+        it { does_something }
+      end
+    RUBY
   end
 
   it 'checks for empty line after `around` hook' do
@@ -28,6 +44,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
       RSpec.describe User do
         around { |test| test.run }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
+        it { does_something }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        around { |test| test.run }
+
         it { does_something }
       end
     RUBY
@@ -106,23 +130,4 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
       end
     RUBY
   end
-
-  bad_example = <<-RUBY
-    RSpec.describe User do
-      before { do_something }
-      it { does_something }
-    end
-  RUBY
-
-  good_example = <<-RUBY
-    RSpec.describe User do
-      before { do_something }
-
-      it { does_something }
-    end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
         let(:params) { foo }
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        subject { described_class.new }
+
+        let(:params) { foo }
+      end
+    RUBY
   end
 
   it 'checks for empty line after subject!' do
@@ -18,6 +26,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       RSpec.describe User do
         subject! { described_class.new }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after `subject`.
+        let(:params) { foo }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        subject! { described_class.new }
+
         let(:params) { foo }
       end
     RUBY
@@ -75,23 +91,4 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
   end
-
-  bad_example = <<-RUBY
-  RSpec.describe User do
-    subject { described_class.new }
-    let(:params) { foo }
-  end
-  RUBY
-
-  good_example = <<-RUBY
-  RSpec.describe User do
-    subject { described_class.new }
-
-    let(:params) { foo }
-  end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_example,
-                   good_example
 end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -19,12 +19,22 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
             ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something' do
+        end
+      RUBY
     end
 
     it 'finds description with `Should` at the beginning' do
       expect_offense(<<-RUBY)
         it 'Should do something' do
             ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something' do
         end
       RUBY
     end
@@ -35,12 +45,35 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
             ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it "does not do something" do
+        end
+      RUBY
+    end
+
+    it 'finds description with `SHOULDN\'T` at the beginning' do
+      expect_offense(<<-RUBY)
+        it "SHOULDN'T do something" do
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it "DOES NOT do something" do
+        end
+      RUBY
     end
 
     it 'flags a lone should' do
       expect_offense(<<-RUBY)
         it 'should' do
             ^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it '' do
         end
       RUBY
     end
@@ -51,12 +84,22 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
             ^^^^^^^^^^ Do not use should when describing your tests.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does not' do
+        end
+      RUBY
     end
 
     it 'finds leading its' do
       expect_offense(<<-RUBY)
         it "it does something" do
             ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it "does something" do
         end
       RUBY
     end
@@ -81,30 +124,6 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
         end
       RUBY
     end
-
-    include_examples 'autocorrect',
-                     'it "should only have trait" do end',
-                     'it "only has trait" do end'
-
-    include_examples 'autocorrect',
-                     'it "SHOULDN\'T only have trait" do end',
-                     'it "DOES NOT only have trait" do end'
-
-    include_examples 'autocorrect',
-                     'it "it does something" do end',
-                     'it "does something" do end'
-
-    include_examples 'autocorrect',
-                     'it "It does something" do end',
-                     'it "does something" do end'
-
-    include_examples 'autocorrect',
-                     'it "should" do end',
-                     'it "" do end'
-
-    include_examples 'autocorrect',
-                     'it "should not" do end',
-                     'it "does not" do end'
   end
 
   context 'when configuration is empty' do

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
     it 'finds blocks that contain simple message sending' do
       expect_offense(<<-RUBY)
         it do
-          expect(run).to change { User.count }
+          expect(run).to change { User.count }.by(1)
                          ^^^^^^^^^^^^^^^^^^^^^ Prefer `change(User, :count)`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect(run).to change(User, :count).by(1)
         end
       RUBY
     end
@@ -32,12 +38,6 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
         end
       RUBY
     end
-
-    include_examples(
-      'autocorrect',
-      'expect(run).to change { User.count }.by(1)',
-      'expect(run).to change(User, :count).by(1)'
-    )
   end
 
   context 'with EnforcedStyle `block`' do
@@ -46,8 +46,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
     it 'finds change matcher without block' do
       expect_offense(<<-RUBY)
         it do
-          expect(run).to change(User, :count)
+          expect(run).to change(User, :count).by(1)
                          ^^^^^^^^^^^^^^^^^^^^ Prefer `change { User.count }`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect(run).to change { User.count }.by(1)
         end
       RUBY
     end
@@ -59,6 +65,12 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
                          ^^^^^^^^^^^^^^^^^^^^ Prefer `change { user.count }`.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect(run).to change { user.count }
+        end
+      RUBY
     end
 
     it 'ignores methods called change' do
@@ -68,11 +80,5 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
         end
       RUBY
     end
-
-    include_examples(
-      'autocorrect',
-      'expect(run).to change(User, :count).by(1)',
-      'expect(run).to change { User.count }.by(1)'
-    )
   end
 end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it 'flags focused block types' do
     expect_offense(<<-RUBY)
       fdescribe 'test' do; end
@@ -135,5 +134,4 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       ^^^^^^^^^^^^ Focused spec found.
     RUBY
   end
-  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -13,12 +13,20 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
         it { should be_truthy }
              ^^^^^^ Prefer `is_expected.to` over `should`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to be_truthy }
+      RUBY
     end
 
     it 'flags it { should_not }' do
       expect_offense(<<-RUBY)
         it { should_not be_truthy }
              ^^^^^^^^^^ Prefer `is_expected.to_not` over `should_not`.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to_not be_truthy }
       RUBY
     end
 
@@ -35,13 +43,6 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
     end
 
     include_examples 'detects style', 'it { should be_truthy }', 'should'
-    include_examples 'autocorrect',
-                     'it { should be_truthy }',
-                     'it { is_expected.to be_truthy }'
-
-    include_examples 'autocorrect',
-                     'it { should_not be_truthy }',
-                     'it { is_expected.to_not be_truthy }'
   end
 
   context 'when EnforcedStyle is should' do
@@ -54,6 +55,10 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
         it { is_expected.to be_truthy }
              ^^^^^^^^^^^^^^ Prefer `should` over `is_expected.to`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { should be_truthy }
+      RUBY
     end
 
     it 'flags it { is_expected.to_not }' do
@@ -61,12 +66,20 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
         it { is_expected.to_not be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.to_not`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { should_not be_truthy }
+      RUBY
     end
 
     it 'flags it { is_expected.not_to }' do
       expect_offense(<<-RUBY)
         it { is_expected.not_to be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.not_to`.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { should_not be_truthy }
       RUBY
     end
 
@@ -85,17 +98,5 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
     include_examples 'detects style',
                      'it { should be_truthy }',
                      'should'
-
-    include_examples 'autocorrect',
-                     'it { is_expected.to be_truthy }',
-                     'it { should be_truthy }'
-
-    include_examples 'autocorrect',
-                     'it { is_expected.to_not be_truthy }',
-                     'it { should_not be_truthy }'
-
-    include_examples 'autocorrect',
-                     'it { is_expected.not_to be_truthy }',
-                     'it { should_not be_truthy }'
   end
 end

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
           ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it 'expect subject to be used' do
+          expect(subject).to be_good
+        end
+      RUBY
     end
 
     it 'allows `is_expected` inside `its` block, in multi-line examples' do
@@ -30,6 +36,15 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
         it 'expect subject to be used' do
           should be_good
           ^^^^^^^^^^^^^^ Don't use implicit subject.
+          should_not be_bad
+          ^^^^^^^^^^^^^^^^^ Don't use implicit subject.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'expect subject to be used' do
+          expect(subject).to be_good
+          expect(subject).not_to be_bad
         end
       RUBY
     end
@@ -63,41 +78,13 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
                                   ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        def permits(actions)
+          actions.each { |action| expect(subject).to permit_action(action) }
+        end
+      RUBY
     end
-
-    bad_code = <<-RUBY
-      it 'works' do
-        is_expected.to be_truthy
-      end
-    RUBY
-
-    good_code = <<-RUBY
-      it 'works' do
-        expect(subject).to be_truthy
-      end
-    RUBY
-
-    include_examples 'autocorrect',
-                     bad_code,
-                     good_code
-
-    bad_code = <<-RUBY
-      it 'works' do
-        should be_truthy
-        should_not be_falsy
-      end
-    RUBY
-
-    good_code = <<-RUBY
-      it 'works' do
-        expect(subject).to be_truthy
-        expect(subject).not_to be_falsy
-      end
-    RUBY
-
-    include_examples 'autocorrect',
-                     bad_code,
-                     good_code
   end
 
   context 'with EnforcedStyle `single_statement_only`' do
@@ -119,29 +106,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
           ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it 'expect subject to be used' do
+          subject.age = 18
+          expect(subject).to be_valid
+        end
+      RUBY
     end
-
-    bad_code = <<-RUBY
-      it 'is valid' do
-        subject.age = 18
-        is_expected.to be_valid
-      end
-    RUBY
-
-    good_code = <<-RUBY
-      it 'is valid' do
-        subject.age = 18
-        expect(subject).to be_valid
-      end
-    RUBY
-
-    include_examples 'autocorrect',
-                     bad_code,
-                     good_code
-
-    include_examples 'autocorrect',
-                     bad_code,
-                     good_code
   end
 
   context 'with EnforcedStyle `disallow`' do
@@ -154,12 +126,22 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
           ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it 'expect subject to be used' do
+          expect(subject).to be_good
+        end
+      RUBY
     end
 
     it 'flags `is_expected` in single-line examples' do
       expect_offense(<<-RUBY)
         it { is_expected.to be_good }
              ^^^^^^^^^^^ Don't use implicit subject.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { expect(subject).to be_good }
       RUBY
     end
 
@@ -168,6 +150,15 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
         it 'expect subject to be used' do
           should be_good
           ^^^^^^^^^^^^^^ Don't use implicit subject.
+          should_not be_bad
+          ^^^^^^^^^^^^^^^^^ Don't use implicit subject.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'expect subject to be used' do
+          expect(subject).to be_good
+          expect(subject).not_to be_bad
         end
       RUBY
     end
@@ -176,6 +167,13 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
       expect_offense(<<-RUBY)
         it { should be_good }
              ^^^^^^^^^^^^^^ Don't use implicit subject.
+        it { should_not be_bad }
+             ^^^^^^^^^^^^^^^^^ Don't use implicit subject.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { expect(subject).to be_good }
+        it { expect(subject).not_to be_bad }
       RUBY
     end
 
@@ -184,17 +182,5 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
         its(:quality) { is_expected.to be :high }
       RUBY
     end
-
-    include_examples 'autocorrect',
-                     'it { is_expected.to be_truthy }',
-                     'it { expect(subject).to be_truthy }'
-
-    include_examples 'autocorrect',
-                     'it { should be_truthy }',
-                     'it { expect(subject).to be_truthy }'
-
-    include_examples 'autocorrect',
-                     'it { should_not be_truthy }',
-                     'it { expect(subject).not_to be_truthy }'
   end
 end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
           expect(foo).to have_received(:bar)
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          foo = instance_spy(Foo)
+          expect(foo).to have_received(:bar)
+        end
+      RUBY
     end
 
     it 'adds an offense for an instance_double with multiple arguments' do
@@ -17,6 +24,13 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
         it do
           foo = instance_double(Foo, :name).as_null_object
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
+          expect(foo).to have_received(:bar)
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          foo = instance_spy(Foo, :name)
           expect(foo).to have_received(:bar)
         end
       RUBY
@@ -42,19 +56,4 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
       RUBY
     end
   end
-
-  original = <<-RUBY
-    it do
-      foo = instance_double(Foo, :name).as_null_object
-      expect(foo).to have_received(:bar)
-    end
-  RUBY
-  corrected = <<-RUBY
-    it do
-      foo = instance_spy(Foo, :name)
-      expect(foo).to have_received(:bar)
-    end
-  RUBY
-
-  include_examples 'autocorrect', original, corrected
 end

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -13,17 +13,15 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
         it_should_behave_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_behaves_like` over `it_should_behave_like` when including examples in a nested context.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it_behaves_like 'a foo'
+      RUBY
     end
 
     it 'does not flag a violation for it_behaves_like' do
       expect_no_offenses("it_behaves_like 'a foo'")
     end
-
-    include_examples(
-      'autocorrect',
-      "foo(); it_should_behave_like 'a foo'",
-      "foo(); it_behaves_like 'a foo'"
-    )
   end
 
   context 'when the enforced style is `it_should_behave_like`' do
@@ -34,16 +32,14 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
         it_behaves_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_should_behave_like` over `it_behaves_like` when including examples in a nested context.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it_should_behave_like 'a foo'
+      RUBY
     end
 
     it 'does not flag a violation for it_behaves_like' do
       expect_no_offenses("it_should_behave_like 'a foo'")
     end
-
-    include_examples(
-      'autocorrect',
-      "foo(); it_behaves_like 'a foo'",
-      "foo(); it_should_behave_like 'a foo'"
-    )
   end
 end

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         it { expect(false).to_not be_true }
                            ^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { expect(false).not_to be_true }
+      RUBY
     end
 
     it 'detects the `to_not` offense on an expect block' do
@@ -18,6 +22,12 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         }.to_not raise_error
           ^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        expect {
+          2 + 2
+        }.not_to raise_error
+      RUBY
     end
 
     it 'detects no offense when using `not_to`' do
@@ -25,22 +35,6 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         it { expect(false).not_to be_true }
       RUBY
     end
-
-    include_examples 'autocorrect',
-                     'it { expect(0).to_not equal 1 }',
-                     'it { expect(0).not_to equal 1 }'
-
-    original = <<-RUBY
-      expect {
-        2 + 2
-      }.to_not raise_error
-    RUBY
-    corrected = <<-RUBY
-      expect {
-        2 + 2
-      }.not_to raise_error
-    RUBY
-    include_examples 'autocorrect', original, corrected
   end
 
   context 'when AcceptedMethod is `to_not`' do
@@ -51,6 +45,10 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         it { expect(false).not_to be_true }
                            ^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { expect(false).to_not be_true }
+      RUBY
     end
 
     it 'detects the `not_to` offense on an expect block' do
@@ -60,6 +58,12 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         }.not_to raise_error
           ^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
+
+      expect_correction(<<-RUBY)
+        expect {
+          2 + 2
+        }.to_not raise_error
+      RUBY
     end
 
     it 'detects no offense when using `to_not`' do
@@ -67,21 +71,5 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
         it { expect(false).to_not be_true }
       RUBY
     end
-
-    include_examples 'autocorrect',
-                     'it { expect(0).not_to equal 1 }',
-                     'it { expect(0).to_not equal 1 }'
-
-    original = <<-RUBY
-      expect {
-        2 + 2
-      }.not_to raise_error
-    RUBY
-    corrected = <<-RUBY
-      expect {
-        2 + 2
-      }.to_not raise_error
-    RUBY
-    include_examples 'autocorrect', original, corrected
   end
 end

--- a/spec/rubocop/cop/rspec/receive_counts_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_counts_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(foo).to receive(:bar).exactly(1).times
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).once
+    RUBY
   end
 
   it 'flags usage of `exactly(2).times`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).exactly(2).times
                                   ^^^^^^^^^^^^^^^^^ Use `.twice` instead of `.exactly(2).times`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).twice
     RUBY
   end
 
@@ -34,12 +42,20 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(foo).to receive(:bar).with(baz).exactly(1).times
                                             ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).with(baz).once
+    RUBY
   end
 
   it 'flags usage of `exactly(1).times` with return value' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).exactly(1).times.and_return(true)
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).once.and_return(true)
     RUBY
   end
 
@@ -48,12 +64,20 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(foo).to receive(:bar).exactly(1).times { true }
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).once { true }
+    RUBY
   end
 
   it 'flags usage of `at_least(1).times`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).at_least(1).times
                                   ^^^^^^^^^^^^^^^^^^ Use `.at_least(:once)` instead of `.at_least(1).times`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).at_least(:once)
     RUBY
   end
 
@@ -62,12 +86,31 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(foo).to receive(:bar).at_least(2).times
                                   ^^^^^^^^^^^^^^^^^^ Use `.at_least(:twice)` instead of `.at_least(2).times`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).at_least(:twice)
+    RUBY
+  end
+
+  it 'flags usage of `at_least(2).times` with a block' do
+    expect_offense(<<-RUBY)
+      expect(foo).to receive(:bar).at_least(2).times { true }
+                                  ^^^^^^^^^^^^^^^^^^ Use `.at_least(:twice)` instead of `.at_least(2).times`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).at_least(:twice) { true }
+    RUBY
   end
 
   it 'flags usage of `at_most(1).times`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).at_most(1).times
                                   ^^^^^^^^^^^^^^^^^ Use `.at_most(:once)` instead of `.at_most(1).times`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).at_most(:once)
     RUBY
   end
 
@@ -76,6 +119,10 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(foo).to receive(:bar).at_most(2).times
                                   ^^^^^^^^^^^^^^^^^ Use `.at_most(:twice)` instead of `.at_most(2).times`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).to receive(:bar).at_most(:twice)
+    RUBY
   end
 
   it 'allows exactly(1).times when not called on `receive`' do
@@ -83,14 +130,6 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(action).to have_published_event.exactly(1).times
     RUBY
   end
-
-  include_examples 'autocorrect',
-                   'expect(foo).to receive(:bar).exactly(1).times { true }',
-                   'expect(foo).to receive(:bar).once { true }'
-
-  include_examples 'autocorrect',
-                   'expect(foo).to receive(:bar).at_least(2).times { true }',
-                   'expect(foo).to receive(:bar).at_least(:twice) { true }'
 
   # Does not auto-correct if not part of the RSpec API
   include_examples 'autocorrect',

--- a/spec/rubocop/cop/rspec/receive_never_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_never_spec.rb
@@ -8,12 +8,20 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
       expect(foo).to receive(:bar).never
                                    ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).not_to receive(:bar)
+    RUBY
   end
 
   it 'flags usage of `never` after `with`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).with(baz).never
                                              ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect(foo).not_to receive(:bar).with(baz)
     RUBY
   end
 
@@ -22,12 +30,20 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
       is_expected.to receive(:bar).with(baz).never
                                              ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      is_expected.not_to receive(:bar).with(baz)
+    RUBY
   end
 
   it 'flags usage of `never` with `expect_any_instance_of`' do
     expect_offense(<<-RUBY)
       expect_any_instance_of(Foo).to receive(:bar).with(baz).never
                                                              ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      expect_any_instance_of(Foo).not_to receive(:bar).with(baz)
     RUBY
   end
 
@@ -38,8 +54,4 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
       is_expected.to be never
     RUBY
   end
-
-  include_examples 'autocorrect',
-                   'expect(foo).to receive(:bar).with(0).never',
-                   'expect(foo).not_to receive(:bar).with(0)'
 end

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
           end
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        shared_examples 'foo' do
+          it 'performs actions' do
+          end
+        end
+      RUBY
     end
 
     it 'does not register an offense for `shared_context` with let' do
@@ -70,6 +77,12 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
           let(:foo) { :bar }
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        shared_context 'foo' do
+          let(:foo) { :bar }
+        end
+      RUBY
     end
 
     it 'registers an offense for shared_examples with only subject' do
@@ -79,12 +92,26 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
           subject(:foo) { :bar }
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        shared_context 'foo' do
+          subject(:foo) { :bar }
+        end
+      RUBY
     end
 
     it 'registers an offense for shared_examples with only hooks' do
       expect_offense(<<-RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
+          before do
+            foo
+          end
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        shared_context 'foo' do
           before do
             foo
           end
@@ -105,38 +132,4 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
       RUBY
     end
   end
-
-  bad_shared_context = <<-RUBY
-    shared_context 'foo' do
-      it 'performs actions' do
-      end
-    end
-  RUBY
-
-  good_shared_context = <<-RUBY
-    shared_examples 'foo' do
-      it 'performs actions' do
-      end
-    end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_shared_context,
-                   good_shared_context
-
-  bad_shared_examples = <<-RUBY
-    shared_examples 'foo' do
-      let(:foo) { :bar }
-    end
-  RUBY
-
-  good_shared_examples = <<-RUBY
-    shared_context 'foo' do
-      let(:foo) { :bar }
-    end
-  RUBY
-
-  include_examples 'autocorrect',
-                   bad_shared_examples,
-                   good_shared_examples
 end

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -18,13 +18,28 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
       include_examples :foo_bar_baz, 'foo', 'bar'
                        ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
 
-      shared_examples :foo_bar_baz do |param|
+      shared_examples :foo_bar_baz, 'foo', 'bar' do |param|
                       ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
         # ...
       end
 
       RSpec.shared_examples :foo_bar_baz
                             ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it_behaves_like 'foo bar baz'
+      it_should_behave_like 'foo bar baz'
+      shared_examples 'foo bar baz'
+      shared_examples_for 'foo bar baz'
+      include_examples 'foo bar baz'
+      include_examples 'foo bar baz', 'foo', 'bar'
+
+      shared_examples 'foo bar baz', 'foo', 'bar' do |param|
+        # ...
+      end
+
+      RSpec.shared_examples 'foo bar baz'
     RUBY
   end
 
@@ -57,37 +72,4 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
       end
     RUBY
   end
-
-  include_examples 'autocorrect',
-                   'it_behaves_like :foo_bar_baz',
-                   "it_behaves_like 'foo bar baz'"
-  include_examples 'autocorrect',
-                   'it_should_behave_like :foo_bar_baz',
-                   "it_should_behave_like 'foo bar baz'"
-  include_examples 'autocorrect',
-                   'shared_examples :foo_bar_baz',
-                   "shared_examples 'foo bar baz'"
-  include_examples 'autocorrect',
-                   'shared_examples_for :foo_bar_baz',
-                   "shared_examples_for 'foo bar baz'"
-  include_examples 'autocorrect',
-                   'include_examples :foo_bar_baz',
-                   "include_examples 'foo bar baz'"
-  include_examples 'autocorrect',
-                   "include_examples :foo_bar_baz, 'foo', 'bar'",
-                   "include_examples 'foo bar baz', 'foo', 'bar'"
-
-  bad_code_with_block = <<-RUBY
-    shared_examples :foo_bar_baz, 'foo', 'bar' do |param|
-      # ...
-    end
-  RUBY
-
-  good_code_with_block = <<-RUBY
-    shared_examples 'foo bar baz', 'foo', 'bar' do |param|
-      # ...
-    end
-  RUBY
-
-  include_examples 'autocorrect', bad_code_with_block, good_code_with_block
 end

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
-    end
 
-    include_examples(
-      'autocorrect',
-      'before { allow(foo).to receive_message_chain(:one) { :two } }',
-      'before { allow(foo).to receive(:one) { :two } }'
-    )
+      expect_correction(<<-RUBY)
+        before do
+          allow(foo).to receive(:one) { :two }
+        end
+      RUBY
+    end
 
     it 'accepts multi-argument calls' do
       expect_no_offenses(<<-RUBY)
@@ -32,13 +32,13 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
-    end
 
-    include_examples(
-      'autocorrect',
-      'before { allow(foo).to receive_message_chain("one") { :two } }',
-      'before { allow(foo).to receive("one") { :two } }'
-    )
+      expect_correction(<<-RUBY)
+        before do
+          allow(foo).to receive("one") { :two }
+        end
+      RUBY
+    end
 
     it 'accepts multi-argument string calls' do
       expect_no_offenses(<<-RUBY)
@@ -73,13 +73,13 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
                           ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
           end
         RUBY
-      end
 
-      include_examples(
-        'autocorrect',
-        'before { allow(foo).to receive_message_chain([:one]) { :two } }',
-        'before { allow(foo).to receive(:one) { :two } }'
-      )
+        expect_correction(<<-RUBY)
+          before do
+            allow(foo).to receive(:one) { :two }
+          end
+        RUBY
+      end
     end
 
     context 'with multiple-element array argument' do
@@ -98,27 +98,21 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
           before do
             allow(foo).to receive_message_chain(bar: 42)
                           ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
+            allow(foo).to receive_message_chain("bar" => 42)
+                          ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
+            allow(foo).to receive_message_chain(:"\#{foo}" => 42)
+                          ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
+          end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          before do
+            allow(foo).to receive(:bar).and_return(42)
+            allow(foo).to receive("bar").and_return(42)
+            allow(foo).to receive(:"\#{foo}").and_return(42)
           end
         RUBY
       end
-
-      include_examples(
-        'autocorrect',
-        'before { allow(foo).to receive_message_chain(bar: 42) }',
-        'before { allow(foo).to receive(:bar).and_return(42) }'
-      )
-
-      include_examples(
-        'autocorrect',
-        'before { allow(foo).to receive_message_chain("bar" => 42) }',
-        'before { allow(foo).to receive("bar").and_return(42) }'
-      )
-
-      include_examples(
-        'autocorrect',
-        'before { allow(foo).to receive_message_chain(:"#{foo}" => 42) }',
-        'before { allow(foo).to receive(:"#{foo}").and_return(42) }'
-      )
     end
 
     context 'with multiple keys hash argument' do
@@ -140,13 +134,13 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
-    end
 
-    include_examples(
-      'autocorrect',
-      'before { foo.stub_chain(:one) { :two } }',
-      'before { foo.stub(:one) { :two } }'
-    )
+      expect_correction(<<-RUBY)
+        before do
+          foo.stub(:one) { :two }
+        end
+      RUBY
+    end
 
     it 'accepts multi-argument calls' do
       expect_no_offenses(<<-RUBY)
@@ -163,13 +157,13 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
-    end
 
-    include_examples(
-      'autocorrect',
-      'before { foo.stub_chain("one") { :two } }',
-      'before { foo.stub("one") { :two } }'
-    )
+      expect_correction(<<-RUBY)
+        before do
+          foo.stub("one") { :two }
+        end
+      RUBY
+    end
 
     it 'accepts multi-argument string calls' do
       expect_no_offenses(<<-RUBY)

--- a/spec/rubocop/cop/rspec/yield_spec.rb
+++ b/spec/rubocop/cop/rspec/yield_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
       allow(foo).to receive(:bar) { |&block| block.call }
                                   ^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
     RUBY
+
+    expect_correction(<<-RUBY)
+      allow(foo).to receive(:bar).and_yield
+    RUBY
   end
 
   it 'flags multiple `block.call`' do
@@ -16,12 +20,20 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
         block.call
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      allow(foo).to receive(:bar).and_yield.and_yield
+    RUBY
   end
 
   it 'flags `block.call` with arguments' do
     expect_offense(<<-RUBY)
       allow(foo).to receive(:bar) { |&block| block.call(1, 2) }
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      allow(foo).to receive(:bar).and_yield(1, 2)
     RUBY
   end
 
@@ -33,12 +45,20 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
          block.call(2)
        end
     RUBY
+
+    expect_correction(<<-RUBY)
+      allow(foo).to receive(:bar).and_yield(1).and_yield(2)
+    RUBY
   end
 
   it 'flags `block.call` when `receive` is chained' do
     expect_offense(<<-RUBY)
       allow(foo).to receive(:bar).with(anything) { |&block| block.call }
                                                  ^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      allow(foo).to receive(:bar).with(anything).and_yield
     RUBY
   end
 
@@ -56,25 +76,4 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
       end
     RUBY
   end
-
-  include_examples 'autocorrect',
-                   'allow(foo).to receive(:bar) { |&block| block.call }',
-                   'allow(foo).to receive(:bar).and_yield'
-
-  include_examples 'autocorrect',
-                   'allow(foo).to receive(:bar) { |&block| block.call(1, 2) }',
-                   'allow(foo).to receive(:bar).and_yield(1, 2)'
-
-  bad_code = <<-RUBY
-    allow(foo).to receive(:bar) do |&block|
-      block.call(1)
-      block.call(2)
-    end
-  RUBY
-
-  good_code = <<-RUBY
-    allow(foo).to receive(:bar).and_yield(1).and_yield(2)
-  RUBY
-
-  include_examples 'autocorrect', bad_code, good_code
 end


### PR DESCRIPTION
A new `expect_correction` spec helper was added to Rubocop recently. It makes it possible to clean up our specs a whole lot.

I haven’t gone through *all* our spec files, but maybe half.

Note that this causes some examples to be twice as long as before, and I have increased `RSpec/ExampleLength[Max]` accordingly.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
