### PR TITLE
Remove `range_between` usage in favor of `with(end_pos: ...)`

### DIFF
--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -59,7 +59,6 @@ module RuboCop
       #   end
       class HookArgument < Cop
         include ConfigurableEnforcedStyle
-        include RangeHelp
 
         IMPLICIT_MSG = 'Omit the default `%<scope>p` ' \
                        'argument for RSpec hooks.'.freeze
@@ -125,9 +124,8 @@ module RuboCop
         end
 
         def argument_range(send_node)
-          range_between(
-            send_node.loc.selector.end_pos,
-            send_node.loc.expression.end_pos
+          send_node.loc.selector.end.with(
+            end_pos: send_node.loc.expression.end_pos
           )
         end
       end

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -88,10 +88,7 @@ module RuboCop
         end
 
         def node_range(node)
-          range_between(
-            node.loc.expression.begin_pos,
-            final_end_location(node).end_pos
-          )
+          node.loc.expression.with(end_pos: final_end_location(node).end_pos)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -91,10 +91,7 @@ module RuboCop
         end
 
         def node_range(node)
-          range_between(
-            node.loc.expression.begin_pos,
-            final_end_location(node).end_pos
-          )
+          node.loc.expression.with(end_pos: final_end_location(node).end_pos)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -86,10 +86,10 @@ module RuboCop
         end
 
         def remove_predicate(corrector, predicate)
-          range = range_between(
-            predicate.loc.dot.begin_pos,
-            predicate.loc.expression.end_pos
+          range = predicate.loc.dot.with(
+            end_pos: predicate.loc.expression.end_pos
           )
+
           corrector.remove(range)
 
           block_range = block_loc(predicate)
@@ -299,7 +299,6 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include InflectedHelper
         include ExplicitHelper
-        include RangeHelp
 
         def on_send(node)
           case style
@@ -330,8 +329,9 @@ module RuboCop
         #   foo 1, 2
         #      ^^^^^
         def args_loc(send_node)
-          range_between(send_node.loc.selector.end_pos,
-                        send_node.loc.expression.end_pos)
+          send_node.loc.selector.end.with(
+            end_pos: send_node.loc.expression.end_pos
+          )
         end
 
         # returns block location with whitespace
@@ -342,9 +342,8 @@ module RuboCop
           parent = send_node.parent
           return unless parent.block_type?
 
-          range_between(
-            send_node.loc.expression.end_pos,
-            parent.loc.expression.end_pos
+          send_node.loc.expression.end.with(
+            end_pos: parent.loc.expression.end_pos
           )
         end
       end

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -22,8 +22,6 @@ module RuboCop
       #     expect(foo).to receive(:bar).at_most(:twice).times
       #
       class ReceiveCounts < Cop
-        include RangeHelp
-
         MSG = 'Use `%<alternative>s` instead of `%<original>s`.'.freeze
 
         def_node_matcher :receive_counts, <<-PATTERN
@@ -78,9 +76,8 @@ module RuboCop
         end
 
         def range(node, offending_node)
-          range_between(
-            offending_node.loc.dot.begin_pos,
-            node.loc.expression.end_pos
+          offending_node.loc.dot.with(
+            end_pos: node.loc.expression.end_pos
           )
         end
       end

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -12,8 +12,6 @@ module RuboCop
       #     expect(foo).not_to receive(:bar)
       #
       class ReceiveNever < Cop
-        include RangeHelp
-
         MSG = 'Use `not_to receive` instead of `never`.'.freeze
 
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
@@ -30,10 +28,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(node.parent.loc.selector, 'not_to')
-            range = range_between(
-              node.loc.dot.begin_pos,
-              node.loc.selector.end_pos
-            )
+            range = node.loc.dot.with(end_pos: node.loc.selector.end_pos)
             corrector.remove(range)
           end
         end

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -52,9 +52,7 @@ module RuboCop
         end
 
         def block_range(node)
-          block_start = node.loc.begin.begin_pos
-          block_end = node.loc.end.end_pos
-          range_between(block_start, block_end)
+          node.loc.begin.with(end_pos: node.loc.end.end_pos)
         end
 
         def generate_replacement(node)


### PR DESCRIPTION
Just learned about this API, looks better to me (and allows removing the RangeHelp from cops that use only range_between) 

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
