### PR TITLE
Runners in language module

### DIFF
--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Don\'t use `be` without an argument.'.freeze
 
         def_node_matcher :be_without_args, <<-PATTERN
-          (send _ {:to :not_to :to_not} $(send nil? :be))
+          (send _ #{Runners::ALL.node_pattern_union} $(send nil? :be))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -33,13 +33,13 @@ module RuboCop
           # Supported matchers: eq(...) / match(/regexp/) / match('regexp')
           def_node_matcher :as_is_matcher, <<-PATTERN
             (send
-              #expectation_set_on_current_path ${:to :not_to :to_not}
+              #expectation_set_on_current_path $#{Runners::ALL.node_pattern_union}
               ${(send nil? :eq ...) (send nil? :match (regexp ...))})
           PATTERN
 
           def_node_matcher :regexp_str_matcher, <<-PATTERN
             (send
-              #expectation_set_on_current_path ${:to :not_to :to_not}
+              #expectation_set_on_current_path $#{Runners::ALL.node_pattern_union}
               $(send nil? :match (str $_)))
           PATTERN
 

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -32,7 +32,7 @@ module RuboCop
         def_node_matcher :implicit_expect, <<-PATTERN
           {
             (send nil? ${:should :should_not} ...)
-            (send (send nil? $:is_expected) {:to :to_not :not_to} ...)
+            (send (send nil? $:is_expected) #{Runners::ALL.node_pattern_union} ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -17,7 +17,7 @@ module RuboCop
         MSG = 'Omit `?` from `%<matcher>s`.'.freeze
 
         def_node_matcher :invalid_predicate_matcher?, <<-PATTERN
-          (send (send nil? :expect ...) {:to :not_to :to_not} $(send nil? #predicate?))
+          (send (send nil? :expect ...) #{Runners::ALL.node_pattern_union} $(send nil? #predicate?))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -37,7 +37,7 @@ module RuboCop
         SUPPORTED_STYLES = %w[have_received receive].freeze
 
         def_node_matcher :message_expectation, %(
-          (send (send nil? :expect $_) {:to :to_not :not_to} ...)
+          (send (send nil? :expect $_) #{Runners::ALL.node_pattern_union} ...)
         )
 
         def_node_search :receive_message, %(

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -3,6 +3,7 @@ module RuboCop
     module RSpec
       # A helper for `inflected` style
       module InflectedHelper
+        include RuboCop::RSpec::Language
         extend NodePattern::Macros
 
         MSG_INFLECTED = 'Prefer using `%<matcher_name>s` matcher over ' \
@@ -25,7 +26,7 @@ module RuboCop
             (send nil? :expect {
               (block $(send !nil? #predicate? ...) ...)
               $(send !nil? #predicate? ...)})
-            ${:to :not_to :to_not}
+            $#{Runners::ALL.node_pattern_union}
             $#boolean_matcher?)
         PATTERN
 
@@ -123,6 +124,7 @@ module RuboCop
       # A helper for `explicit` style
       # rubocop:disable Metrics/ModuleLength
       module ExplicitHelper
+        include RuboCop::RSpec::Language
         extend NodePattern::Macros
 
         MSG_EXPLICIT = 'Prefer using `%<predicate_name>s` over ' \
@@ -160,7 +162,7 @@ module RuboCop
         def_node_matcher :predicate_matcher?, <<-PATTERN
           (send
             (send nil? :expect $!nil?)
-            {:to :not_to :to_not}
+            #{Runners::ALL.node_pattern_union}
             {$(send nil? #predicate_matcher_name? ...)
               (block $(send nil? #predicate_matcher_name? ...) ...)})
         PATTERN
@@ -169,7 +171,7 @@ module RuboCop
           (block
             (send
               (send nil? :expect $!nil?)
-              {:to :not_to :to_not}
+              #{Runners::ALL.node_pattern_union}
               $(send nil? #predicate_matcher_name?))
             ...)
         PATTERN

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -108,6 +108,10 @@ module RuboCop
         ALL = SelectorSet.new(%i[expect is_expected expect_any_instance_of])
       end
 
+      module Runners
+        ALL = SelectorSet.new(%i[to to_not not_to])
+      end
+
       ALL =
         ExampleGroups::ALL +
         SharedGroups::ALL  +
@@ -115,7 +119,8 @@ module RuboCop
         Hooks::ALL         +
         Helpers::ALL       +
         Subject::ALL       +
-        Expectations::ALL
+        Expectations::ALL  +
+        Runners::ALL
     end
   end
 end


### PR DESCRIPTION
Extract a named Language constant from the duplicated `{:to :not_to :to_not}`/`{:to :to_not :not_to}` in our node matchers.

`Language::Runners` is extracted from #726.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
