### PR TITLE
Fix Naming/RescuedExceptionsVariableName offense

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -273,9 +273,9 @@ task documentation_syntax_check: :yard_for_generate_documentation do
         parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
         parser.diagnostics.all_errors_are_fatal = true
         parser.parse(buffer)
-      rescue Parser::SyntaxError => ex
+      rescue Parser::SyntaxError => e
         path = example.object.file
-        puts "#{path}: Syntax Error in an example. #{ex}"
+        puts "#{path}: Syntax Error in an example. #{e}"
         ok = false
       end
     end


### PR DESCRIPTION
[Latest master build](https://circleci.com/workflow-run/c32ab1e1-fba6-4359-be88-29eaf5677538) is red, caused by the latest release of RuboCop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
