### PR TITLE
Let `RSpec/DescribedClass` pass `Struct` instantiation closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Let `RSpec/DescribedClass` pass `Struct` instantiation closures. ([@schmijos][])
 * Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])
 * Add `RSpec/Dialect` enforces custom RSpec dialects. ([@gsamokovarov][])
@@ -412,3 +413,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@ypresto]: https://github.com/ypresto
 [@mkenyon]: https://github.com/mkenyon
 [@gsamokovarov]: https://github.com/gsamokovarov
+[@schmijos]: https://github.com/schmijos

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -40,7 +40,7 @@ module RuboCop
         MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'.freeze
 
         def_node_matcher :common_instance_exec_closure?, <<-PATTERN
-          (block (send (const nil? {:Class :Module}) :new ...) ...)
+          (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
         def_node_matcher :rspec_block?,

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
         describe MyClass do
           Class.new  { foo = MyClass }
           Module.new { bar = MyClass }
+          Struct.new { lol = MyClass }
 
           def method
             include MyClass
@@ -121,7 +122,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
             include MyClass
           end
 
-          module MyModle
+          module MyModule
             include MyClass
           end
         end


### PR DESCRIPTION
The `RSpec/DescribedClass` cop complained about the following commonly used pattern in RSpec tests for concerns:

```ruby
RSpec.describe Uploadable do
  …
  let(:uploadable) do
    Struct
      .new(:mounted_as, :model) { include Uploadable }
      .new(mounted_as, model)
  end
  …
end
```

This PR adds `Struct` to the whitelist of blocks where `described_class` isn't mandatory