### PR TITLE
Add 'for' and 'if' default prefixes for ContextWording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])
 * Add `RSpec/Dialect` enforces custom RSpec dialects. ([@gsamokovarov][])
+* Add 'for' and 'if' default prefixes for `ContextWording`. ([@josephan][])
 
 ## 1.32.0 (2019-01-27)
 
@@ -414,3 +415,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mkenyon]: https://github.com/mkenyon
 [@gsamokovarov]: https://github.com/gsamokovarov
 [@schmijos]: https://github.com/schmijos
+[@josephan]: https://github.com/josephan

--- a/config/default.yml
+++ b/config/default.yml
@@ -53,6 +53,8 @@ RSpec/ContextWording:
   Description: "`context` block descriptions should start with 'when', or 'with'."
   Enabled: true
   Prefixes:
+  - for
+  - if
   - when
   - with
   - without

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -8,9 +8,10 @@ module RuboCop
       # @see https://github.com/reachlocal/rspec-style-guide#context-descriptions
       # @see http://www.betterspecs.org/#contexts
       #
-      # @example `Prefixes` configuration option, defaults: 'when', 'with', and
-      # 'without'
+      # @example `Prefixes` configuration option, defaults: 'for', 'when',
+      # 'with', 'without', and 'if'
       #   Prefixes:
+      #     - for
       #     - when
       #     - with
       #     - without

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -241,8 +241,9 @@ Enabled | No
 
 `context` block descriptions should start with 'when', or 'with'.
 
-'without'
+'with', 'without', and 'if'
   Prefixes:
+    - for
     - when
     - with
     - without
@@ -250,7 +251,7 @@ Enabled | No
 
 ### Examples
 
-#### `Prefixes` configuration option, defaults: 'when', 'with', and
+#### `Prefixes` configuration option, defaults: 'for', 'when',
 
 ```ruby
 
@@ -271,7 +272,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
-Prefixes | `when`, `with`, `without` | Array
+Prefixes | `for`, `if`, `when`, `with`, `without` | Array
 
 ### References
 


### PR DESCRIPTION
Add `for` as a default prefix in `ContextWording` check.

An example:

```ruby
context "when a team has the display_name, 'TGIF'" do
  # ...
end

# or...

context "for a team with display_name, 'TGIF'" do
  # ...
end

```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
