### PR TITLE
Remove AggregateFailuresByDefault config option for MultipleExpectations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add `RSpec/Dialect` enforces custom RSpec dialects. ([@gsamokovarov][])
 * Fix redundant blank lines in `RSpec/MultipleSubjects`'s autocorrect. ([@pirj][])
 * Drop support for ruby `2.2`. ([@bquorning][])
+* Remove `AggregateFailuresByDefault` config option of `RSpec/MultipleExpectations`. ([@pirj][])
 
 ## 1.32.0 (2019-01-27)
 

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -79,8 +79,7 @@ module RuboCop
         def example_with_aggregated_failures?(node)
           example = node.send_node
 
-          (aggregated_failures_by_default? ||
-            with_aggregated_failures?(example)) &&
+          with_aggregated_failures?(example) &&
             !disabled_aggregated_failures?(example)
         end
 
@@ -109,10 +108,6 @@ module RuboCop
 
         def max_expectations
           Integer(cop_config.fetch('Max', 1))
-        end
-
-        def aggregated_failures_by_default?
-          cop_config.fetch('AggregateFailuresByDefault', false)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -162,57 +162,6 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
     end
   end
 
-  context 'with AggregateFailuresByDefault configuration' do
-    let(:cop_config) do
-      { 'AggregateFailuresByDefault' => true }
-    end
-
-    it 'ignores examples without metadata' do
-      expect_no_offenses(<<-RUBY)
-        describe Foo do
-          it 'uses expect twice' do
-            expect(foo).to eq(bar)
-            expect(baz).to eq(bar)
-          end
-        end
-      RUBY
-    end
-
-    it 'ignores examples with `:aggregate_failures`' do
-      expect_no_offenses(<<-RUBY)
-        describe Foo do
-          it 'uses expect twice', :aggregate_failures do
-            expect(foo).to eq(bar)
-            expect(baz).to eq(bar)
-          end
-        end
-      RUBY
-    end
-
-    it 'ignores examples with `aggregate_failures: true`' do
-      expect_no_offenses(<<-RUBY)
-        describe Foo do
-          it 'uses expect twice', aggregate_failures: true do
-            expect(foo).to eq(bar)
-            expect(baz).to eq(bar)
-          end
-        end
-      RUBY
-    end
-
-    it 'checks examples with `aggregate_failures: false`' do
-      expect_offense(<<-RUBY)
-        describe Foo do
-          it 'uses expect twice', aggregate_failures: false do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
-            expect(foo).to eq(bar)
-            expect(baz).to eq(bar)
-          end
-        end
-      RUBY
-    end
-  end
-
   it 'generates a todo based on the worst violation' do
     inspect_source(<<-RUBY, 'spec/foo_spec.rb')
       describe Foo do


### PR DESCRIPTION
Remove AggregateFailuresByDefault config option for MultipleExpectations.

Fixes #697

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] *Removed* tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.