### PR TITLE
Fix doc issue for ContextWording cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -50,7 +50,7 @@ RSpec/BeforeAfterAll:
   StyleGuide: http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 RSpec/ContextWording:
-  Description: "`context` block descriptions should start with 'when', or 'with'."
+  Description: Checks that `context` docstring starts with an allowed prefix.
   Enabled: true
   Prefixes:
   - when

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -3,18 +3,22 @@
 module RuboCop
   module Cop
     module RSpec
-      # `context` block descriptions should start with 'when', or 'with'.
+      # Checks that `context` docstring starts with an allowed prefix.
       #
       # @see https://github.com/reachlocal/rspec-style-guide#context-descriptions
       # @see http://www.betterspecs.org/#contexts
       #
-      # @example `Prefixes` configuration option, defaults: 'when', 'with', and
-      # 'without'
-      #   Prefixes:
-      #     - when
-      #     - with
-      #     - without
-      #     - if
+      # @example `Prefixes` configuration
+      #
+      #   # .rubocop.yml
+      #   # RSpec/ContextWording:
+      #   #   Prefixes:
+      #   #     - when
+      #   #     - with
+      #   #     - without
+      #   #     - if
+      #   #     - unless
+      #   #     - for
       #
       # @example
       #   # bad

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -239,21 +239,22 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-`context` block descriptions should start with 'when', or 'with'.
-
-'without'
-  Prefixes:
-    - when
-    - with
-    - without
-    - if
+Checks that `context` docstring starts with an allowed prefix.
 
 ### Examples
 
-#### `Prefixes` configuration option, defaults: 'when', 'with', and
+#### `Prefixes` configuration
 
 ```ruby
-
+# .rubocop.yml
+# RSpec/ContextWording:
+#   Prefixes:
+#     - when
+#     - with
+#     - without
+#     - if
+#     - unless
+#     - for
 ```
 ```ruby
 # bad


### PR DESCRIPTION
fixes #758


The end of the sentence was cut off:
> Prefixes configuration option, defaults: 'when', 'with', and

Also, the description was not updated when `without` was legalized.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.