### PR TITLE
Fix blank lines produced by MultipleSubjects cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])
 * Add `RSpec/Dialect` enforces custom RSpec dialects. ([@gsamokovarov][])
+* Fix redundant blank lines in `RSpec/MultipleSubjects`'s autocorrect. ([@pirj][])
 
 ## 1.32.0 (2019-01-27)
 

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -34,6 +34,8 @@ module RuboCop
       #     This is enough of an edge case that people can just move this to
       #     a `before` hook on their own
       class MultipleSubjects < Cop
+        include RangeHelp
+
         MSG = 'Do not set more than one subject per example group'.freeze
 
         def on_block(node)
@@ -70,7 +72,9 @@ module RuboCop
 
         def remove_autocorrect(node)
           lambda do |corrector|
-            corrector.remove(node.loc.expression)
+            range = range_by_whole_lines(node.source_range,
+                                         include_final_newline: true)
+            corrector.remove(range)
           end
         end
       end

--- a/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
   let(:cop) { described_class.new }
 
   it 'registers an offense for every overwritten subject' do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY)
       describe 'hello there' do
         subject(:foo) { 1 }
         ^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
@@ -20,30 +20,30 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
       end
     RUBY
 
-    expect_correction [
-      "describe 'hello there' do",
-      '  let(:foo) { 1 }',
-      '  let(:bar) { 2 }',
-      '  ',
-      '  subject(:baz) { 4 }',
-      '',
-      "  describe 'baz' do",
-      '    subject(:norf) { 1 }',
-      '  end',
-      'end',
-      ''
-    ].join("\n")
+    expect_correction(<<-RUBY)
+      describe 'hello there' do
+        let(:foo) { 1 }
+        let(:bar) { 2 }
+        subject(:baz) { 4 }
+
+        describe 'baz' do
+          subject(:norf) { 1 }
+        end
+      end
+    RUBY
   end
 
   it 'does not try to autocorrect subject!' do
     source = <<-RUBY
       describe Foo do
         subject! { a }
+        ^^^^^^^^^^^^^^ Do not set more than one subject per example group
         subject! { b }
       end
     RUBY
 
-    expect(autocorrect_source(source, 'example_spec.rb')).to eql(source)
+    expect_offense(source)
+    expect_no_corrections
   end
 
   it 'does not flag shared example groups' do
@@ -64,21 +64,20 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
     RUBY
   end
 
-  include_examples(
-    'autocorrect',
-    <<-RUBY.strip_indent.chomp,
+  it 'autocorrects' do
+    expect_offense(<<-RUBY)
       describe 'hello there' do
         subject { 1 }
+        ^^^^^^^^^^^^^ Do not set more than one subject per example group
         subject { 2 }
+        ^^^^^^^^^^^^^ Do not set more than one subject per example group
         subject { 3 }
       end
     RUBY
-    [
-      "describe 'hello there' do",
-      '  ',
-      '  ',
-      '  subject { 3 }',
-      'end'
-    ].join("\n")
-  )
+    expect_correction(<<-RUBY)
+      describe 'hello there' do
+        subject { 3 }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Previously, an example group like:

    describe 'hello there' do
      subject { 1 }
      subject { 2 }
      subject { 3 }
    end

was autocorrected to:

    describe 'hello there' do
      ¶
      ¶
      subject { 3 }
    end

(notice whitespace and redundant newlines) resulting in unnecessary blank lines.

Example group under microscope:
![image](https://user-images.githubusercontent.com/6916/57481404-b51b9000-72aa-11e9-87c3-dde077efd636.png)
Autocorrection before the fix:
![image](https://user-images.githubusercontent.com/6916/57481425-c4024280-72aa-11e9-9104-80d860a0851b.png)
Autocorrection after the fix:
![image](https://user-images.githubusercontent.com/6916/57481441-cebcd780-72aa-11e9-87dd-215d68382251.png)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).