### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,6 @@ jobs:
       - run: bundle install
       - run: rake confirm_config documentation_syntax_check confirm_documentation
 
-  # Ruby 2.2
-  ruby-2.2-rspec:
-    docker:
-      - image: circleci/ruby:2.2
-    <<: *rspec
-  ruby-2.2-rubocop:
-    docker:
-      - image: circleci/ruby:2.2
-    <<: *rubocop
-
   # Ruby 2.3
   ruby-2.3-rspec:
     docker:
@@ -115,10 +105,6 @@ workflows:
       - confirm_config_and_documentation
 
       # Use `requires: [confirm_config_and_documentation]` to trick Circle CI into starting the slow jruby job early.
-      - ruby-2.2-rspec:
-          requires: [confirm_config_and_documentation]
-      - ruby-2.2-rubocop:
-          requires: [confirm_config_and_documentation]
       - ruby-2.3-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.3-rubocop:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])
 * Add `RSpec/Dialect` enforces custom RSpec dialects. ([@gsamokovarov][])
 * Fix redundant blank lines in `RSpec/MultipleSubjects`'s autocorrect. ([@pirj][])
+* Drop support for ruby `2.2`. ([@bquorning][])
 
 ## 1.32.0 (2019-01-27)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 
 require 'bundler'

--- a/bin/build_config
+++ b/bin/build_config
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'yaml'
 

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -18,7 +18,7 @@ module RuboCop
       #     let(:a)      { b }
       #
       class AlignLeftLetBrace < Cop
-        MSG = 'Align left let brace'.freeze
+        MSG = 'Align left let brace'
 
         def self.autocorrect_incompatible_with
           [Layout::ExtraSpacing]

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -18,7 +18,7 @@ module RuboCop
       #     let(:a)      { b        }
       #
       class AlignRightLetBrace < Cop
-        MSG = 'Align right let brace'.freeze
+        MSG = 'Align right let brace'
 
         def self.autocorrect_incompatible_with
           [Layout::ExtraSpacing]

--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -21,7 +23,7 @@ module RuboCop
       #     end
       #   end
       class AnyInstance < Cop
-        MSG = 'Avoid stubbing using `%<method>s`.'.freeze
+        MSG = 'Avoid stubbing using `%<method>s`.'
 
         def_node_matcher :disallowed_stub, <<-PATTERN
           (send _ ${:any_instance :allow_any_instance_of :expect_any_instance_of} ...)

--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -24,9 +26,9 @@ module RuboCop
       #     test.run
       #   end
       class AroundBlock < Cop
-        MSG_NO_ARG     = 'Test object should be passed to around block.'.freeze
+        MSG_NO_ARG     = 'Test object should be passed to around block.'
         MSG_UNUSED_ARG = 'You should call `%<arg>s.call` '\
-                         'or `%<arg>s.run`.'.freeze
+                         'or `%<arg>s.run`.'
 
         def_node_matcher :hook, <<-PATTERN
           (block {(send nil? :around) (send nil? :around sym)} (args $...) ...)

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -18,7 +20,7 @@ module RuboCop
       #   expect(foo).to be(true)
       #
       class Be < Cop
-        MSG = 'Don\'t use `be` without an argument.'.freeze
+        MSG = 'Don\'t use `be` without an argument.'
 
         def_node_matcher :be_without_args, <<-PATTERN
           (send _ #{Runners::ALL.node_pattern_union} $(send nil? :be))

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -34,7 +36,7 @@ module RuboCop
       # coerce objects for comparison.
       #
       class BeEql < Cop
-        MSG = 'Prefer `be` over `eql`.'.freeze
+        MSG = 'Prefer `be` over `eql`.'
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
           (send _ :to $(send nil? :eql {true false int float sym nil_type?}))

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -27,7 +27,7 @@ module RuboCop
         MSG = 'Beware of using `%<hook>s` as it may cause state to leak '\
               'between tests. If you are using `rspec-rails`, and '\
               '`use_transactional_fixtures` is enabled, then records created '\
-              'in `%<hook>s` are not automatically rolled back.'.freeze
+              'in `%<hook>s` are not automatically rolled back.'
 
         def_node_matcher :before_or_after_all, <<-PATTERN
           $(send _ {:before :after} (sym {:all :context}))

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -24,7 +26,7 @@ module RuboCop
         class CurrentPathExpectation < Cop
           MSG = 'Do not set an RSpec expectation on `current_path` in ' \
                 'Capybara feature specs - instead, use the ' \
-                '`have_current_path` matcher on `page`'.freeze
+                '`have_current_path` matcher on `page`'
 
           def_node_matcher :expectation_set_on_current_path, <<-PATTERN
             (send nil? :expect (send {(send nil? :page) nil?} :current_path))

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -41,7 +41,7 @@ module RuboCop
         #     end
         #   end
         class FeatureMethods < Cop
-          MSG = 'Use `%<replacement>s` instead of `%<method>s`.'.freeze
+          MSG = 'Use `%<replacement>s` instead of `%<method>s`.'
 
           # https://git.io/v7Kwr
           MAP = {

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -27,7 +27,7 @@ module RuboCop
       #     # ...
       #   end
       class ContextWording < Cop
-        MSG = 'Start context description with %<prefixes>s.'.freeze
+        MSG = 'Start context description with %<prefixes>s.'
 
         def_node_matcher :context_wording, <<-PATTERN
           (block (send #{RSPEC} { :context :shared_context } $(str #bad_prefix?) ...) ...)

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -20,7 +20,7 @@ module RuboCop
         include RuboCop::RSpec::TopLevelDescribe
 
         MSG = 'The first argument to describe should be '\
-              'the class or module being tested.'.freeze
+              'the class or module being tested.'
 
         def_node_matcher :valid_describe?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -21,10 +21,10 @@ module RuboCop
         include RuboCop::RSpec::Util
 
         MSG = 'The second argument to describe should be the method '\
-              "being tested. '#instance' or '.class'.".freeze
+              "being tested. '#instance' or '.class'."
 
         def on_top_level_describe(_node, (_, second_arg))
-          return unless second_arg && second_arg.str_type?
+          return unless second_arg&.str_type?
           return if second_arg.str_content.start_with?('#', '.')
 
           add_offense(second_arg, location: :expression)

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       # @see https://github.com/rspec/rspec-core/issues/1610
       class DescribeSymbol < Cop
-        MSG = 'Avoid describing symbols.'.freeze
+        MSG = 'Avoid describing symbols.'
 
         def_node_matcher :describe_symbol?, <<-PATTERN
           (send #{RSPEC} :describe $sym ...)

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -36,8 +36,8 @@ module RuboCop
         include RuboCop::RSpec::TopLevelDescribe
         include ConfigurableEnforcedStyle
 
-        DESCRIBED_CLASS = 'described_class'.freeze
-        MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'.freeze
+        DESCRIBED_CLASS = 'described_class'
+        MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'
 
         def_node_matcher :common_instance_exec_closure?, <<-PATTERN
           (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -44,7 +44,7 @@ module RuboCop
       class Dialect < Cop
         include MethodPreference
 
-        MSG = 'Prefer `%<prefer>s` over `%<current>s`.'.freeze
+        MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 
         def_node_matcher :rspec_method?, ALL.send_pattern
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -58,7 +58,7 @@ module RuboCop
       #   end
       #
       class EmptyExampleGroup < Cop
-        MSG = 'Empty example group detected.'.freeze
+        MSG = 'Empty example group detected.'
 
         def_node_search :contains_example?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -26,7 +26,7 @@ module RuboCop
       class EmptyLineAfterExampleGroup < Cop
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add an empty line after `%<example_group>s`.'.freeze
+        MSG = 'Add an empty line after `%<example_group>s`.'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -19,7 +19,7 @@ module RuboCop
       class EmptyLineAfterFinalLet < Cop
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add an empty line after the last `let` block.'.freeze
+        MSG = 'Add an empty line after the last `let` block.'
 
         def on_block(node)
           return unless example_group_with_body?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -36,7 +36,7 @@ module RuboCop
       class EmptyLineAfterHook < Cop
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add an empty line after `%<hook>s`.'.freeze
+        MSG = 'Add an empty line after `%<hook>s`.'
 
         def on_block(node)
           return unless hook?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -17,7 +17,7 @@ module RuboCop
       class EmptyLineAfterSubject < Cop
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add empty line after `subject`.'.freeze
+        MSG = 'Add empty line after `subject`.'
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -28,7 +28,7 @@ module RuboCop
       class ExampleLength < Cop
         include CodeLength
 
-        MSG = 'Example has too many lines [%<total>d/%<max>d].'.freeze
+        MSG = 'Example has too many lines [%<total>d/%<max>d].'
 
         def on_block(node)
           return unless example?(node)

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -51,8 +51,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG_DEFAULT_ARGUMENT = 'Omit the argument when you want to ' \
-                               'have auto-generated description.'.freeze
-        MSG_ADD_DESCRIPTION  = 'Add a description.'.freeze
+                               'have auto-generated description.'
+        MSG_ADD_DESCRIPTION  = 'Add a description.'
 
         def_node_matcher :example_description, '(send nil? _ $(str $_))'
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -30,8 +30,8 @@ module RuboCop
       #   it 'does things' do
       #   end
       class ExampleWording < Cop
-        MSG_SHOULD = 'Do not use should when describing your tests.'.freeze
-        MSG_IT     = "Do not repeat 'it' when describing your tests.".freeze
+        MSG_SHOULD = 'Do not use should when describing your tests.'
+        MSG_IT     = "Do not repeat 'it' when describing your tests."
 
         SHOULD_PREFIX = /\Ashould(?:n't)?\b/i.freeze
         IT_PREFIX     = /\Ait /i.freeze

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   expect(name).to eq("John")
       #
       class ExpectActual < Cop
-        MSG = 'Provide the actual you are testing to `expect(...)`.'.freeze
+        MSG = 'Provide the actual you are testing to `expect(...)`.'
 
         SIMPLE_LITERALS = %i[
           true

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -32,8 +32,8 @@ module RuboCop
       class ExpectChange < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_BLOCK = 'Prefer `change(%<obj>s, :%<attr>s)`.'.freeze
-        MSG_CALL = 'Prefer `change { %<obj>s.%<attr>s }`.'.freeze
+        MSG_BLOCK = 'Prefer `change(%<obj>s, :%<attr>s)`.'
+        MSG_CALL = 'Prefer `change { %<obj>s.%<attr>s }`.'
 
         def_node_matcher :expect_change_with_arguments, <<-PATTERN
           (send nil? :change ({const send} nil? $_) (sym $_))

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     expect(something).to eq 'foo'
       #   end
       class ExpectInHook < Cop
-        MSG = 'Do not use `%<expect>s` in `%<hook>s` hook'.freeze
+        MSG = 'Do not use `%<expect>s` in `%<hook>s` hook'
 
         def_node_search :expectation, Expectations::ALL.send_pattern
 

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   expect { my_app.print_report }.to output('Hello World').to_stdout
       class ExpectOutput < Cop
         MSG = 'Use `expect { ... }.to output(...).to_%<name>s` '\
-              'instead of mutating $%<name>s.'.freeze
+              'instead of mutating $%<name>s.'
 
         def on_gvasgn(node)
           return unless inside_example_scope?(node)

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -25,7 +25,7 @@ module RuboCop
         #   # good
         #   count { 1 }
         class AttributeDefinedStatically < Cop
-          MSG = 'Use a block to declare attribute values.'.freeze
+          MSG = 'Use a block to declare attribute values.'
 
           def_node_matcher :value_matcher, <<-PATTERN
             (send _ !#reserved_method? $...)

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -27,8 +27,8 @@ module RuboCop
         class CreateList < Cop
           include ConfigurableEnforcedStyle
 
-          MSG_CREATE_LIST = 'Prefer create_list.'.freeze
-          MSG_N_TIMES = 'Prefer %<number>s.times.'.freeze
+          MSG_CREATE_LIST = 'Prefer create_list.'
+          MSG_N_TIMES = 'Prefer %<number>s.times.'
 
           def_node_matcher :n_times_block_without_arg?, <<-PATTERN
             (block

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -44,7 +44,7 @@ module RuboCop
       class FilePath < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Spec path should end with `%<suffix>s`.'.freeze
+        MSG = 'Spec path should end with `%<suffix>s`.'
 
         def_node_search :const_described?,  '(send _ :describe (const ...) ...)'
         def_node_search :routing_metadata?, '(pair (sym :type) (sym :routing))'
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def name_glob(name)
-          return unless name && name.str_type?
+          return unless name&.str_type?
 
           "*#{name.str_content.gsub(/\W/, '')}" unless ignore_methods?
         end

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -20,7 +20,7 @@ module RuboCop
       #   describe MyClass do
       #   end
       class Focus < Cop
-        MSG = 'Focused spec found.'.freeze
+        MSG = 'Focused spec found.'
 
         focusable =
           ExampleGroups::GROUPS  +

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -61,8 +61,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         IMPLICIT_MSG = 'Omit the default `%<scope>p` ' \
-                       'argument for RSpec hooks.'.freeze
-        EXPLICIT_MSG = 'Use `%<scope>p` for RSpec hooks.'.freeze
+                       'argument for RSpec hooks.'
+        EXPLICIT_MSG = 'Use `%<scope>p` for RSpec hooks.'
 
         HOOKS = Hooks::ALL.node_pattern_union.freeze
 

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -27,7 +27,7 @@ module RuboCop
         include RangeHelp
         include RuboCop::RSpec::FinalEndLocation
 
-        MSG = 'Move `%<hook>s` above the examples in the group.'.freeze
+        MSG = 'Move `%<hook>s` above the examples in the group.'
 
         def_node_matcher :example_or_group?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -27,7 +27,7 @@ module RuboCop
       class ImplicitExpect < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%<good>s` over `%<bad>s`.'.freeze
+        MSG = 'Prefer `%<good>s` over `%<bad>s`.'
 
         def_node_matcher :implicit_expect, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -29,7 +29,7 @@ module RuboCop
       class ImplicitSubject < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = "Don't use implicit subject.".freeze
+        MSG = "Don't use implicit subject."
 
         def_node_matcher :implicit_subject?, <<-PATTERN
           (send nil? {:should :should_not :is_expected} ...)

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -20,7 +20,7 @@ module RuboCop
       #
       class InstanceSpy < Cop
         MSG = 'Use `instance_spy` when you check your double '\
-              'with `have_received`.'.freeze
+              'with `have_received`.'
 
         def_node_search :null_double, <<-PATTERN
           (lvasgn $_

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -47,7 +47,7 @@ module RuboCop
       #   end
       #
       class InstanceVariable < Cop
-        MSG = 'Replace instance variable with local variable or `let`.'.freeze
+        MSG = 'Replace instance variable with local variable or `let`.'
 
         EXAMPLE_GROUP_METHODS = ExampleGroups::ALL + SharedGroups::ALL
 

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -14,7 +16,7 @@ module RuboCop
       #   # good
       #   expect(foo).to be_something
       class InvalidPredicateMatcher < Cop
-        MSG = 'Omit `?` from `%<matcher>s`.'.freeze
+        MSG = 'Omit `?` from `%<matcher>s`.'
 
         def_node_matcher :invalid_predicate_matcher?, <<-PATTERN
           (send (send nil? :expect ...) #{Runners::ALL.node_pattern_union} $(send nil? #predicate?))

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -22,7 +22,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<replacement>s` over `%<original>s` when including '\
-              'examples in a nested context.'.freeze
+              'examples in a nested context.'
 
         def_node_matcher :example_inclusion_offense, '(send _ % ...)'
 

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -15,7 +17,7 @@ module RuboCop
       #   end
       class IteratedExpectation < Cop
         MSG = 'Prefer using the `all` matcher instead ' \
-                  'of iterating over an array.'.freeze
+                  'of iterating over an array.'
 
         def_node_matcher :each?, <<-PATTERN
           (block

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -34,8 +34,7 @@ module RuboCop
       class LeadingSubject < Cop
         include RangeHelp
 
-        MSG = 'Declare `subject` above any other `%<offending>s` ' \
-          'declarations.'.freeze
+        MSG = 'Declare `subject` above any other `%<offending>s` declarations.'
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -34,7 +34,7 @@ module RuboCop
         include RangeHelp
         include RuboCop::RSpec::FinalEndLocation
 
-        MSG = 'Move `let` before the examples in the group.'.freeze
+        MSG = 'Move `let` before the examples in the group.'
 
         def_node_matcher :example_or_group?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -28,7 +28,7 @@ module RuboCop
       class LetSetup < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Do not use `let!` for test setup.'.freeze
+        MSG = 'Do not use `let!` for test setup.'
 
         def_node_search :let_bang, <<-PATTERN
           (block $(send nil? :let! (sym $_)) args ...)

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -12,7 +14,7 @@ module RuboCop
       #   allow(foo).to receive(bar: thing)
       #
       class MessageChain < Cop
-        MSG = 'Avoid stubbing using `%<method>s`.'.freeze
+        MSG = 'Avoid stubbing using `%<method>s`.'
 
         def_node_matcher :message_chain, <<-PATTERN
           (send _ {:receive_message_chain :stub_chain} ...)

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -27,7 +27,7 @@ module RuboCop
       class MessageExpectation < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%<style>s` for setting message expectations.'.freeze
+        MSG = 'Prefer `%<style>s` for setting message expectations.'
 
         SUPPORTED_STYLES = %w[allow expect].freeze
 

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -27,12 +27,11 @@ module RuboCop
       class MessageSpies < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_RECEIVE = 'Prefer `receive` for setting message '\
-                      'expectations.'.freeze
+        MSG_RECEIVE = 'Prefer `receive` for setting message expectations.'
 
         MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message '\
                             'expectations. Setup `%<source>s` as a spy using '\
-                            '`allow` or `instance_spy`.'.freeze
+                            '`allow` or `instance_spy`.'
 
         SUPPORTED_STYLES = %w[have_received receive].freeze
 

--- a/lib/rubocop/cop/rspec/missing_example_group_argument.rb
+++ b/lib/rubocop/cop/rspec/missing_example_group_argument.rb
@@ -20,7 +20,7 @@ module RuboCop
       #   describe "A feature example" do
       #   end
       class MissingExampleGroupArgument < Cop
-        MSG = 'The first argument to `%<method>s` should not be empty.'.freeze
+        MSG = 'The first argument to `%<method>s` should not be empty.'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -26,7 +26,7 @@ module RuboCop
         include RuboCop::RSpec::TopLevelDescribe
 
         MSG = 'Do not use multiple top level describes - '\
-              'try to nest them.'.freeze
+              'try to nest them.'
 
         def on_top_level_describe(node, _args)
           return if single_top_level_describe?

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -48,7 +48,7 @@ module RuboCop
       class MultipleExpectations < Cop
         include ConfigurableMax
 
-        MSG = 'Example has too many expectations [%<total>d/%<max>d].'.freeze
+        MSG = 'Example has too many expectations [%<total>d/%<max>d].'
 
         def_node_search :with_aggregated_failures?, '(sym :aggregate_failures)'
         def_node_search :disabled_aggregated_failures?, <<-PATTERN

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -36,7 +36,7 @@ module RuboCop
       class MultipleSubjects < Cop
         include RangeHelp
 
-        MSG = 'Do not set more than one subject per example group'.freeze
+        MSG = 'Do not set more than one subject per example group'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -43,7 +43,7 @@ module RuboCop
       #   end
       class NamedSubject < Cop
         MSG = 'Name your test subject if you need '\
-              'to reference it explicitly.'.freeze
+              'to reference it explicitly.'
 
         def_node_matcher :rspec_block?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -89,14 +89,13 @@ module RuboCop
         include ConfigurableMax
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Maximum example group nesting exceeded ' \
-              '[%<total>d/%<max>d].'.freeze
+        MSG = 'Maximum example group nesting exceeded [%<total>d/%<max>d].'
 
-        DEPRECATED_MAX_KEY = 'MaxNesting'.freeze
+        DEPRECATED_MAX_KEY = 'MaxNesting'
 
         DEPRECATION_WARNING =
           "Configuration key `#{DEPRECATED_MAX_KEY}` for #{cop_name} is " \
-          'deprecated in favor of `Max`. Please use that instead.'.freeze
+          'deprecated in favor of `Max`. Please use that instead.'
 
         def_node_search :find_contexts, ExampleGroups::ALL.block_pattern
 

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -16,7 +18,7 @@ module RuboCop
       class NotToNot < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%<replacement>s` over `%<original>s`.'.freeze
+        MSG = 'Prefer `%<replacement>s` over `%<original>s`.'
 
         def_node_matcher :not_to_not_offense, '(send _ % ...)'
 

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -22,7 +22,7 @@ module RuboCop
       #   let(:baz) { baz }
       #   let!(:other) { other }
       class OverwritingSetup < Cop
-        MSG = '`%<name>s` is already defined.'.freeze
+        MSG = '`%<name>s` is already defined.'
 
         def_node_matcher :setup?, (Helpers::ALL + Subject::ALL).block_pattern
         def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -26,7 +26,7 @@ module RuboCop
       #   describe MyClass do
       #   end
       class Pending < Cop
-        MSG = 'Pending spec found.'.freeze
+        MSG = 'Pending spec found.'
 
         PENDING_EXAMPLES    = Examples::PENDING + Examples::SKIPPED \
                                 + ExampleGroups::SKIPPED

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -7,7 +9,7 @@ module RuboCop
         extend NodePattern::Macros
 
         MSG_INFLECTED = 'Prefer using `%<matcher_name>s` matcher over ' \
-                        '`%<predicate_name>s`.'.freeze
+                        '`%<predicate_name>s`.'
 
         private
 
@@ -128,7 +130,7 @@ module RuboCop
         extend NodePattern::Macros
 
         MSG_EXPLICIT = 'Prefer using `%<predicate_name>s` over ' \
-                       '`%<matcher_name>s` matcher.'.freeze
+                       '`%<matcher_name>s` matcher.'
         BUILT_IN_MATCHERS = %w[
           be_truthy be_falsey be_falsy
           have_attributes have_received

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -67,7 +67,7 @@ module RuboCop
           # :nodoc:
           class SymbolicStyleChecker
             MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
-                  'to describe HTTP status code.'.freeze
+                  'to describe HTTP status code.'
 
             attr_reader :node
             def initialize(node)
@@ -105,7 +105,7 @@ module RuboCop
           # :nodoc:
           class NumericStyleChecker
             MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
-                  'to describe HTTP status code.'.freeze
+                  'to describe HTTP status code.'
 
             WHITELIST_STATUS = %i[error success missing redirect].freeze
 

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -22,7 +24,7 @@ module RuboCop
       #     expect(foo).to receive(:bar).at_most(:twice).times
       #
       class ReceiveCounts < Cop
-        MSG = 'Use `%<alternative>s` instead of `%<original>s`.'.freeze
+        MSG = 'Use `%<alternative>s` instead of `%<original>s`.'
 
         def_node_matcher :receive_counts, <<-PATTERN
           (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -12,7 +14,7 @@ module RuboCop
       #     expect(foo).not_to receive(:bar)
       #
       class ReceiveNever < Cop
-        MSG = 'Use `not_to receive` instead of `never`.'.freeze
+        MSG = 'Use `not_to receive` instead of `never`.'
 
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
 

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -28,7 +30,7 @@ module RuboCop
       #     end
       #
       class RepeatedDescription < Cop
-        MSG = "Don't repeat descriptions within an example group.".freeze
+        MSG = "Don't repeat descriptions within an example group."
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/repeated_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_example.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -14,7 +16,7 @@ module RuboCop
       #    end
       #
       class RepeatedExample < Cop
-        MSG = "Don't repeat examples within an example group.".freeze
+        MSG = "Don't repeat examples within an example group."
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -36,8 +36,8 @@ module RuboCop
       class ReturnFromStub < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_AND_RETURN = 'Use `and_return` for static values.'.freeze
-        MSG_BLOCK = 'Use block for static values.'.freeze
+        MSG_AND_RETURN = 'Use `and_return` for static values.'
+        MSG_BLOCK = 'Use block for static values.'
 
         def_node_search :contains_stub?, '(send nil? :receive (...))'
         def_node_search :and_return_value, <<-PATTERN

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -27,7 +27,7 @@ module RuboCop
       #   end
       #
       class ScatteredLet < Cop
-        MSG = 'Group all let/let! blocks in the example group together.'.freeze
+        MSG = 'Group all let/let! blocks in the example group together.'
 
         def on_block(node)
           return unless example_group_with_body?(node)

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   end
       #
       class ScatteredSetup < Cop
-        MSG = 'Do not define multiple hooks in the same example group.'.freeze
+        MSG = 'Do not define multiple hooks in the same example group.'
 
         def on_block(node)
           return unless example_group?(node)

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -52,10 +52,10 @@ module RuboCop
       #
       class SharedContext < Cop
         MSG_EXAMPLES = "Use `shared_examples` when you don't "\
-                       'define context.'.freeze
+                       'define context.'
 
         MSG_CONTEXT  = "Use `shared_context` when you don't "\
-                       'define examples.'.freeze
+                       'define examples.'
 
         examples = (Examples::ALL + Includes::EXAMPLES)
         def_node_search :examples?, examples.send_pattern

--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -27,7 +27,7 @@ module RuboCop
         def on_send(node)
           shared_examples(node) do
             ast_node = node.first_argument
-            next unless ast_node && ast_node.sym_type?
+            next unless ast_node&.sym_type?
 
             checker = Checker.new(ast_node)
             add_offense(checker.node, message: checker.message)
@@ -44,7 +44,7 @@ module RuboCop
         # :nodoc:
         class Checker
           MSG = 'Prefer %<prefer>s over `%<current>s` ' \
-                'to titleize shared examples.'.freeze
+                'to titleize shared examples.'
 
           attr_reader :node
           def initialize(node)

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -16,7 +18,7 @@ module RuboCop
       #
       class SingleArgumentMessageChain < Cop
         MSG = 'Use `%<recommended>s` instead of calling '\
-              '`%<called>s` with a single argument.'.freeze
+              '`%<called>s` with a single argument.'
 
         def_node_matcher :message_chain, <<-PATTERN
           (send _ {:receive_message_chain :stub_chain} $_)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -20,7 +20,7 @@ module RuboCop
       class SubjectStub < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Do not stub your test subject.'.freeze
+        MSG = 'Do not stub your test subject.'
 
         # @!method subject(node)
         #   Find a named or unnamed subject definition

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     module RSpec
@@ -29,9 +31,9 @@ module RuboCop
       #
       #     expect { do_something }.not_to raise_error
       class UnspecifiedException < Cop
-        MSG = 'Specify the exception being captured'.freeze
+        MSG = 'Specify the exception being captured'
 
-        def_node_matcher :empty_raise_error_or_exception, <<-PATTERN.freeze
+        def_node_matcher :empty_raise_error_or_exception, <<-PATTERN
           (send
             (block
                 (send nil? :expect) ...)
@@ -54,7 +56,7 @@ module RuboCop
         end
 
         def block_with_args?(node)
-          return unless node && node.block_type?
+          return unless node&.block_type?
 
           node.arguments?
         end

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     instance_double("ClassName", method_name: 'returned value')
       #   end
       class VerifiedDoubles < Cop
-        MSG = 'Prefer using verifying doubles over normal doubles.'.freeze
+        MSG = 'Prefer using verifying doubles over normal doubles.'
 
         def_node_matcher :unverified_double, <<-PATTERN
           {(send nil? {:double :spy} $...)}
@@ -41,7 +41,7 @@ module RuboCop
         private
 
         def symbol?(name)
-          name && name.sym_type?
+          name&.sym_type?
         end
       end
     end

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   expect(something).to be(1)
       class VoidExpect < Cop
         MSG = 'Do not use `expect()` without `.to` or `.not_to`. ' \
-              'Chain the methods or remove it.'.freeze
+              'Chain the methods or remove it.'
 
         def_node_matcher :expect?, <<-PATTERN
           (send nil? :expect ...)

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -14,7 +14,7 @@ module RuboCop
       class Yield < Cop
         include RangeHelp
 
-        MSG = 'Use `.and_yield`.'.freeze
+        MSG = 'Use `.and_yield`.'
 
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
 

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'rspec/capybara/current_path_expectation'
 require_relative 'rspec/capybara/feature_methods'
 

--- a/lib/rubocop/rspec.rb
+++ b/lib/rubocop/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   # RuboCop RSpec project namespace
   module RSpec

--- a/lib/rubocop/rspec/blank_line_separation.rb
+++ b/lib/rubocop/rspec/blank_line_separation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # Helps determine the offending location if there is not a blank line
@@ -26,7 +28,7 @@ module RuboCop
       end
 
       def last_child?(node)
-        return true unless node.parent && node.parent.begin_type?
+        return true unless node.parent&.begin_type?
 
         node.equal?(node.parent.children.last)
       end

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module RuboCop
@@ -5,7 +7,7 @@ module RuboCop
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
       NAMESPACES = /^(RSpec|Capybara|FactoryBot|Rails)/.freeze
-      STYLE_GUIDE_BASE_URL = 'http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'.freeze
+      STYLE_GUIDE_BASE_URL = 'http://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
 
       def initialize(config, descriptions)
         @config       = config

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # Extracts cop descriptions from YARD docstrings
@@ -20,7 +22,7 @@ module RuboCop
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
         COP_CLASS_NAMES = %w[RuboCop::Cop RuboCop::Cop::RSpec::Cop].freeze
-        RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'.freeze
+        RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'
 
         def initialize(yardoc)
           @yardoc = yardoc

--- a/lib/rubocop/rspec/factory_bot.rb
+++ b/lib/rubocop/rspec/factory_bot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # RuboCop FactoryBot project namespace

--- a/lib/rubocop/rspec/final_end_location.rb
+++ b/lib/rubocop/rspec/final_end_location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # Helps find the true end location of nodes which might contain heredocs.

--- a/lib/rubocop/rspec/inject.rb
+++ b/lib/rubocop/rspec/inject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # Because RuboCop doesn't yet support plugins, we have to monkey patch in a

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # RSpec public API methods that are commonly used in cops
     module Language
-      RSPEC = '{(const nil? :RSpec) nil?}'.freeze
+      RSPEC = '{(const nil? :RSpec) nil?}'
 
       # Set of method selectors
       class SelectorSet

--- a/lib/rubocop/rspec/top_level_describe.rb
+++ b/lib/rubocop/rspec/top_level_describe.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module RSpec
     # Helper methods for top level describe cops

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.32.0'.freeze
+      STRING = '1.32.0'
     end
   end
 end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path('lib', __dir__)
 require 'rubocop/rspec/version'
 
@@ -19,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.2.0'
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[

--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'CHANGELOG.md' do
   subject(:changelog) { SpecHelper::ROOT.join('CHANGELOG.md').read }
 

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'config/default.yml' do
   subject(:default_config) do
     RuboCop::ConfigLoader.load_file('config/default.yml')

--- a/spec/project/project_requires_spec.rb
+++ b/spec/project/project_requires_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe 'Project requires' do
   it 'alphabetizes cop requires' do
     source   = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'rspec_cops.rb')

--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::BeEql do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/be_spec.rb
+++ b/spec/rubocop/cop/rspec/be_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Be do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/describe_symbol_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_symbol_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/dialect_spec.rb
+++ b/spec/rubocop/cop/rspec/dialect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Dialect, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/example_without_description_spec.rb
+++ b/spec/rubocop/cop/rspec/example_without_description_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Focus do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/invalid_predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/invalid_predicate_matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::InvalidPredicateMatcher do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Pending do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::SharedContext do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
   subject(:cop) { described_class.new(config) }
 

--- a/spec/rubocop/cop/rspec/void_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/void_expect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/yield_spec.rb
+++ b/spec/rubocop/cop/rspec/yield_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::Cop::RSpec::Yield do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop/rspec/config_formatter'
 
 RSpec.describe RuboCop::RSpec::ConfigFormatter do

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yard'
 
 require 'rubocop/rspec/description_extractor'

--- a/spec/rubocop/rspec/language/selector_set_spec.rb
+++ b/spec/rubocop/rspec/language/selector_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::RSpec::Language::SelectorSet do
   subject(:selector_set) { described_class.new(%i[foo bar]) }
 

--- a/spec/rubocop/rspec/util/one_spec.rb
+++ b/spec/rubocop/rspec/util/one_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::RSpec::Util, '.one' do
   let(:first)  { instance_double(Object)                          }
   let(:array)  { instance_double(Array, one?: true, first: first) }

--- a/spec/rubocop/rspec/wording_spec.rb
+++ b/spec/rubocop/rspec/wording_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe RuboCop::RSpec::Wording do
   let(:replacements) { { 'have' => 'has' } }
   let(:ignores)      { %w[only really]     }

--- a/spec/shared/autocorrect_behavior.rb
+++ b/spec/shared/autocorrect_behavior.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'autocorrect' do |original, corrected|
   it "autocorrects `#{original}` to `#{corrected}`" do
     autocorrected = autocorrect_source(original, 'spec/foo_spec.rb')

--- a/spec/shared/detects_style_behavior.rb
+++ b/spec/shared/detects_style_behavior.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'detects style' do |source, style, filename: 'x_spec.rb'|
   it 'generates a todo based on the detected style' do
     inspect_source(source, filename)

--- a/spec/shared/smoke_test_examples.rb
+++ b/spec/shared/smoke_test_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples 'smoke test', type: :cop_spec do
   context 'with default configuration' do
     # This is overridden to avoid a number of specs that define `cop_config`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubocop'
 
 require 'rubocop/rspec/support'

--- a/spec/support/expect_offense.rb
+++ b/spec/support/expect_offense.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop-rspec gem extension of RuboCop's ExpectOffense module.
 #
 # This mixin is the same as rubocop's ExpectOffense except the default
@@ -5,7 +7,7 @@
 module ExpectOffense
   include RuboCop::RSpec::ExpectOffense
 
-  DEFAULT_FILENAME = 'example_spec.rb'.freeze
+  DEFAULT_FILENAME = 'example_spec.rb'
 
   def expect_offense(source, filename = DEFAULT_FILENAME)
     super

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -19,7 +19,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     content = h2(cop.cop_name)
     content << properties(config, cop)
     content << "#{description}\n"
-    content << examples(examples_objects) if examples_objects.count > 0
+    content << examples(examples_objects) if examples_objects.count.positive?
     content << configurations(pars)
     content << references(config, cop)
     content
@@ -43,27 +43,27 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   end
 
   def h2(title)
-    content = "\n".dup
+    content = +"\n"
     content << "## #{title}\n"
     content << "\n"
     content
   end
 
   def h3(title)
-    content = "\n".dup
+    content = +"\n"
     content << "### #{title}\n"
     content << "\n"
     content
   end
 
   def h4(title)
-    content = "#### #{title}\n".dup
+    content = +"#### #{title}\n"
     content << "\n"
     content
   end
 
   def code_example(ruby_code)
-    content = "```ruby\n".dup
+    content = +"```ruby\n"
     content << ruby_code.text
       .gsub('@good', '# good')
       .gsub('@bad', '# bad').strip
@@ -157,7 +157,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
     return if selected_cops.empty?
 
-    content = "# #{department}\n".dup
+    content = +"# #{department}\n"
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
     end
@@ -199,7 +199,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
     type_title = department[0].upcase + department[1..-1]
     filename = "cops_#{department.downcase}.md"
-    content = "#### Department [#{type_title}](#{filename})\n\n".dup
+    content = +"#### Department [#{type_title}](#{filename})\n\n"
     selected_cops.each do |cop|
       anchor = cop.cop_name.sub('/', '').downcase
       content << "* [#{cop.cop_name}](#{filename}##{anchor})\n"
@@ -213,7 +213,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   def print_table_of_contents(cops)
     path = "#{Dir.pwd}/manual/cops.md"
     original = File.read(path)
-    content = "<!-- START_COP_LIST -->\n".dup
+    content = +"<!-- START_COP_LIST -->\n"
 
     content << table_contents(cops)
 


### PR DESCRIPTION
Ruby 2.2 has been EOL’ed for a while, and RuboCop just merged in a PR to drop Ruby 2.2 support. I don’t think it makes sense for RuboCop-RSpec to support Ruby 2.2 now.

The commit changes the Ruby version in gemspec and .rubocop.yml, and fixes the cop offenses that follows.

See https://github.com/rubocop-hq/rubocop/pull/7026 (and https://github.com/rubocop-hq/rubocop-performance/pull/53)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).