### PR TITLE
Bump version to v1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.33.0 (2019-05-13)
+
 * Let `RSpec/DescribedClass` pass `Struct` instantiation closures. ([@schmijos][])
 * Fixed `RSpec/ContextWording` missing `context`s with metadata. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver. ([@composerinteralia][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.32.0'
+      STRING = '1.33.0'
     end
   end
 end


### PR DESCRIPTION
Let’s release the Ruby 2.2 incompatibility change today, like rubocop and rubocop-performance just did.

Changes in this release:

* Let `RSpec/DescribedClass` pass `Struct` instantiation closures.
* Fixed `RSpec/ContextWording` missing `context`s with metadata.
* Fix `FactoryBot/AttributeDefinedStatically` not working with an explicit receiver.
* Add `RSpec/Dialect` enforces custom RSpec dialects.
* Fix redundant blank lines in `RSpec/MultipleSubjects`'s autocorrect.
* Drop support for ruby `2.2`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
