### PR TITLE
Improve MultipleExpectations metadata detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove `AggregateFailuresByDefault` config option of `RSpec/MultipleExpectations`. ([@pirj][])
 * Add `RSpec/LeakyConstantDeclaration` cop. ([@jonatas][], [@pirj][])
+* Improve `aggregate_failures` metadata detection of `RSpec/MultipleExpectations`. ([@pirj][])
 
 ## 1.33.0 (2019-05-13)
 


### PR DESCRIPTION
Previously, `aggregate_failures` were only detected on the example itself, even though this metadata can be set on any of ancestor example groups.
E.g.:

    it '...', :aggregate_failures do
      expect(foo).to eq(bar)
      expect(baz).to eq(bar)
    end

was ignored, but:

    describe '...', :aggregate_failures do
      it '...' do
        expect(foo).to eq(bar)
        expect(baz).to eq(bar)
      end
    end

was not.

Fixes #761 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).