### PR TITLE
Improve RSpec/SubjectStub cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove `AggregateFailuresByDefault` config option of `RSpec/MultipleExpectations`. ([@pirj][])
 * Add `RSpec/LeakyConstantDeclaration` cop. ([@jonatas][], [@pirj][])
 * Improve `aggregate_failures` metadata detection of `RSpec/MultipleExpectations`. ([@pirj][])
+* Improve `RSpec/SubjectStub` detection and message. ([@pirj][])
 
 ## 1.33.0 (2019-05-13)
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -60,10 +60,14 @@ module RuboCop
         #     expect(foo).to all(receive(:bar))
         #
         def_node_matcher :message_expectation?, <<-PATTERN
-          {
-            (send nil? :allow (send nil? %))
-            (send (send nil? :expect (send nil? %)) :to #expectation?)
-          }
+          (send
+            {
+              (send nil? { :expect :allow } (send nil? %))
+              (send nil? :is_expected)
+            }
+            :to
+            #expectation?
+          )
         PATTERN
 
         def_node_matcher :all_matcher?, '(send nil? :all ...)'

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -6,6 +6,8 @@ module RuboCop
       # Checks for stubbed test subjects.
       #
       # @see https://robots.thoughtbot.com/don-t-stub-the-system-under-test
+      # @see https://samphippen.com/introducing-rspec-smells-and-where-to-find-them#smell-1-stubject
+      # @see https://github.com/rubocop-hq/rspec-style-guide#dont-stub-subject
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -70,7 +70,9 @@ module RuboCop
         PATTERN
 
         def_node_search :message_expectation_matcher?, <<-PATTERN
-          (send nil? { :receive :receive_messages :receive_message_chain } ...)
+          (send nil? {
+            :receive :receive_messages :receive_message_chain :have_received
+            } ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -61,7 +61,7 @@ module RuboCop
         def_node_matcher :message_expectation?, <<-PATTERN
           (send
             {
-              (send nil? { :expect :allow } (send nil? %))
+              (send nil? { :expect :allow } (send nil? {% :subject}))
               (send nil? :is_expected)
             }
             #{Runners::ALL.node_pattern_union}

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -65,7 +65,7 @@ module RuboCop
               (send nil? { :expect :allow } (send nil? %))
               (send nil? :is_expected)
             }
-            :to
+            #{Runners::ALL.node_pattern_union}
             #expectation?
           )
         PATTERN

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -72,7 +72,9 @@ module RuboCop
 
         def_node_matcher :all_matcher?, '(send nil? :all ...)'
 
-        def_node_search :receive_message?, '(send nil? :receive ...)'
+        def_node_search :receive_message?, <<-PATTERN
+          (send nil? { :receive :receive_messages :receive_message_chain } ...)
+        PATTERN
 
         def expectation?(node)
           return if all_matcher?(node)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -20,7 +20,7 @@ module RuboCop
       class SubjectStub < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Do not stub your test subject.'
+        MSG = 'Do not stub methods of the object under test.'
 
         # @!method subject(node)
         #   Find a named or unnamed subject definition

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -58,9 +58,6 @@ module RuboCop
         #     expect(foo).to receive(:bar).with(1)
         #     expect(foo).to receive(:bar).with(1).and_return(2)
         #
-        #   @example source that not matches
-        #     expect(foo).to all(receive(:bar))
-        #
         def_node_matcher :message_expectation?, <<-PATTERN
           (send
             {
@@ -68,21 +65,13 @@ module RuboCop
               (send nil? :is_expected)
             }
             #{Runners::ALL.node_pattern_union}
-            #expectation?
+            #message_expectation_matcher?
           )
         PATTERN
 
-        def_node_matcher :all_matcher?, '(send nil? :all ...)'
-
-        def_node_search :receive_message?, <<-PATTERN
+        def_node_search :message_expectation_matcher?, <<-PATTERN
           (send nil? { :receive :receive_messages :receive_message_chain } ...)
         PATTERN
-
-        def expectation?(node)
-          return if all_matcher?(node)
-
-          receive_message?(node)
-        end
 
         def on_block(node)
           return unless example_group?(node)

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -204,4 +204,20 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       end
     RUBY
   end
+
+  it 'flags negated runners' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        specify do
+          expect(foo).not_to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          expect(foo).to_not receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          expect(foo.bar).to eq(baz)
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         before do
           allow(foo).to receive(:bar).and_return(baz)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
 
         it 'uses expect twice' do
@@ -27,13 +27,13 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         before do
           expect(foo).to receive(:bar).and_return(baz)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo).to receive(:bar)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo).to receive(:bar).with(1)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo).to receive(:bar).with(1).and_return(2)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
 
         it 'uses expect twice' do
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         it 'uses one-line expectation syntax' do
           is_expected.to receive(:bar)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
       end
     RUBY
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
           before do
             allow(foo).to receive(:wow)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
         context 'when I shake things up' do
           before do
             allow(foo).to receive(:wow)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
           before do
             allow(foo).to receive(:wow)
             allow(bar).to receive(:wow)
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         it 'still flags this test' do
           allow(foo).to receive(:blah)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
       end
     RUBY
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
               allow(foo).to receive(:wow)
               allow(bar).to receive(:wow)
               allow(baz).to receive(:wow)
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
             end
           end
         end
@@ -212,9 +212,9 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         specify do
           expect(foo).not_to receive(:bar)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo).to_not receive(:bar)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo.bar).to eq(baz)
         end
       end
@@ -228,7 +228,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         specify do
           expect(foo).to receive_messages(bar: :baz, baz: :baz)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo.bar).to eq(baz)
         end
       end
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         specify do
           expect(foo).to receive_message_chain(:bar, baz: :baz)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
           expect(foo.bar.baz).to eq(baz)
         end
       end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'flags when an unnamed subject is mocked' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject { described_class.new }
+
+        it 'uses unnamed subject' do
+          expect(subject).to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an expectation made on an unnamed subject' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        it 'uses unnamed subject' do
+          expect(subject).to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
   it 'flags one-line expectcation syntax' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -249,4 +249,19 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       end
     RUBY
   end
+
+  it 'flags spy subject stubs' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        specify do
+          allow(foo).to some_matcher_that_allows_a_bar_message
+          expect(foo.bar).to eq(baz)
+          expect(foo).to have_received(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -220,4 +220,32 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       end
     RUBY
   end
+
+  it 'flags multiple-method stubs' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        specify do
+          expect(foo).to receive_messages(bar: :baz, baz: :baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          expect(foo.bar).to eq(baz)
+        end
+      end
+    RUBY
+  end
+
+  it 'flags chain stubs' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        specify do
+          expect(foo).to receive_message_chain(:bar, baz: :baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
+          expect(foo.bar.baz).to eq(baz)
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   subject(:cop) { described_class.new }
 
-  it 'complains when subject is stubbed' do
+  it 'flags when subject is stubbed' do
     expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
-  it 'complains when subject is mocked' do
+  it 'flags when subject is mocked' do
     expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
-  it 'ignores stub when inside all matcher' do
-    expect_no_offenses(<<-RUBY)
+  it 'flags stub inside all matcher' do
+    expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { [Object.new] }
         it 'tries to trick rubocop-rspec' do
           expect(foo).to all(receive(:baz))
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
       end
     RUBY

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         before do
           allow(foo).to receive(:bar).and_return(baz)
-          ^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
         end
 
         it 'uses expect twice' do
@@ -38,6 +38,19 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         it 'uses expect twice' do
           expect(foo.bar).to eq(baz)
+        end
+      end
+    RUBY
+  end
+
+  it 'flags one-line expectcation syntax' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+
+        it 'uses one-line expectation syntax' do
+          is_expected.to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
         end
       end
     RUBY
@@ -80,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
           before do
             allow(foo).to receive(:wow)
-            ^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -119,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
         context 'when I shake things up' do
           before do
             allow(foo).to receive(:wow)
-            ^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -141,7 +154,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
           before do
             allow(foo).to receive(:wow)
             allow(bar).to receive(:wow)
-            ^^^^^^^^^^ Do not stub your test subject.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
           end
 
           it 'tries to trick rubocop-rspec' do
@@ -163,7 +176,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
         it 'still flags this test' do
           allow(foo).to receive(:blah)
-          ^^^^^^^^^^ Do not stub your test subject.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
         end
       end
     RUBY
@@ -184,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
               allow(foo).to receive(:wow)
               allow(bar).to receive(:wow)
               allow(baz).to receive(:wow)
-              ^^^^^^^^^^ Do not stub your test subject.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub your test subject.
             end
           end
         end


### PR DESCRIPTION
**1.** Use consistent wording in docstrings

**2.** Improve stub detection

Previously, the following code would still be detected as an offence:

    allow(subject)

even though there are no message expectations.

**3.** Add detection of negated runners (`not_to`, `to_not`) - fixes #705

**4.** Add support for chain and multiple stub detection (`receive_messages`, `receive_message_chain`)

**5.** Add more reasoning references

**6.** Improve offence message

**7.** Remove special case `all` matcher (see #488)

This special case treatment was added to address one use case, of an object that acts as a container for and a delegator of method calls to containing items by inheriting from an `Array`.

The original code that suffered from a false detection was:

    expect(formatter_set).to all(receive(:started).with(files))
    formatter_set.started(files)

However, it has been [reworked to](https://github.com/rubocop-hq/rubocop/blob/70ae6ca7978770ea699a2809f57ca2a6bdeec6be/spec/rubocop/formatter/formatter_set_spec.rb#L17):

      formatter_set.each do |formatter|
        allow(formatter).to receive(:started)
      end
      formatter_set.started(files)
      expect(formatter_set).to all(have_received(:started).with(files))

and can be further simplified to:

    formatter_set.each do |formatter|
      expect(formatter).to receive(:started).with(files)
    end
    formatter_set.started(files)

which in case of this specific object design is more indicative of what happens.

**8.** Added support for `have_received` detection, to detect the bad code above.

**9.** Fixed detection of the unnamed subject stubbing when the subject is named.

Fixes #705

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).