### PR TITLE
Update RuboCop version to 0.70.0+

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.60.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.70.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Since only a minimal version to use is defined, update that version to the latest available at the moment.

This allows for use of [children matching](https://github.com/rubocop-hq/rubocop/pull/6965), that was introduced in 0.68.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).