### PR TITLE
Use RuboCop internal affairs department

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require: 
+ - rubocop-rspec
+ - rubocop/cop/internal_affairs 
 
 AllCops:
   DisplayCopNames: true

--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -33,7 +33,6 @@ module RuboCop
           disallowed_stub(node) do |method|
             add_offense(
               node,
-              location: :expression,
               message: format(MSG, method: method)
             )
           end

--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -51,7 +51,7 @@ module RuboCop
         private
 
         def add_no_arg_offense(node)
-          add_offense(node, location: :expression, message: MSG_NO_ARG)
+          add_offense(node, message: MSG_NO_ARG)
         end
 
         def check_for_unused_proxy(block, proxy)
@@ -63,7 +63,6 @@ module RuboCop
 
           add_offense(
             proxy,
-            location: :expression,
             message: format(MSG_UNUSED_ARG, arg: name)
           )
         end

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -37,7 +37,6 @@ module RuboCop
           before_or_after_all(node) do |hook|
             add_offense(
               node,
-              location: :expression,
               message: format(MSG, hook: hook.source)
             )
           end

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -39,7 +39,8 @@ module RuboCop
 
         def on_block(node)
           context_wording(node) do |context|
-            add_offense(context, message: message)
+            add_offense(context,
+                        message: format(MSG, prefixes: joined_prefixes))
           end
         end
 
@@ -49,20 +50,16 @@ module RuboCop
           !prefixes.include?(description.split.first)
         end
 
-        def prefixes
-          cop_config['Prefixes'] || []
-        end
-
-        def message
-          format(MSG, prefixes: joined_prefixes)
-        end
-
         def joined_prefixes
           quoted = prefixes.map { |prefix| "'#{prefix}'" }
           return quoted.first if quoted.size == 1
 
           quoted << "or #{quoted.pop}"
           quoted.join(', ')
+        end
+
+        def prefixes
+          cop_config['Prefixes'] || []
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -52,7 +52,7 @@ module RuboCop
             return if pairs.any?(&method(:rails_metadata?))
           end
 
-          add_offense(args.first, location: :expression)
+          add_offense(args.first)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -27,7 +27,7 @@ module RuboCop
           return unless second_arg&.str_type?
           return if second_arg.str_content.start_with?('#', '.')
 
-          add_offense(second_arg, location: :expression)
+          add_offense(second_arg)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def on_send(node)
           describe_symbol?(node) do |match|
-            add_offense(match, location: :expression)
+            add_offense(match)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -59,7 +59,6 @@ module RuboCop
           find_usage(body) do |match|
             add_offense(
               match,
-              location: :expression,
               message: message(match.const_name)
             )
           end

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -70,7 +70,7 @@ module RuboCop
         def on_block(node)
           return unless example_group?(node) && !contains_example?(node)
 
-          add_offense(node.send_node, location: :expression)
+          add_offense(node.send_node)
         end
 
         private

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -24,7 +24,7 @@ module RuboCop
           return if last_child?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(node, location: location, message: MSG)
+            add_offense(node, location: location)
           end
         end
 

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -37,7 +37,7 @@ module RuboCop
 
           return unless length > max_length
 
-          add_offense(node, location: :expression, message: message(length))
+          add_offense(node, message: message(length))
         end
 
         private

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         def on_send(node)
           expect_literal(node) do |argument|
-            add_offense(argument, location: :expression)
+            add_offense(argument)
           end
         end
 

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -21,7 +21,9 @@ module RuboCop
         def on_gvasgn(node)
           return unless inside_example_scope?(node)
 
+          # rubocop:disable InternalAffairs/NodeDestructuring
           variable_name, _rhs = *node
+          # rubocop:enable InternalAffairs/NodeDestructuring
           name = variable_name[1..-1]
           return unless name.eql?('stdout') || name.eql?('stderr')
 

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -40,7 +40,7 @@ module RuboCop
               next unless offensive_receiver?(attribute.receiver, node)
               next if proc?(attribute) || association?(attribute)
 
-              add_offense(attribute, location: :expression)
+              add_offense(attribute)
             end
           end
 

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -51,8 +51,7 @@ module RuboCop
             return unless n_times_block_without_arg?(node)
             return unless contains_only_factory?(node.body)
 
-            add_offense(node.send_node,
-                        location: :expression, message: MSG_CREATE_LIST)
+            add_offense(node.send_node, message: MSG_CREATE_LIST)
           end
 
           def on_send(node)

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -59,7 +59,6 @@ module RuboCop
 
           add_offense(
             node,
-            location: :expression,
             message: format(MSG, suffix: glob)
           )
         end

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def on_send(node)
           focus_metadata(node) do |focus|
-            add_offense(focus, location: :expression)
+            add_offense(focus)
           end
         end
 

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -80,7 +80,6 @@ module RuboCop
             style_detected(scope_name)
             add_offense(
               method_send,
-              location: :expression,
               message: explicit_message(scope_name)
             )
           end

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -43,7 +43,7 @@ module RuboCop
 
           null_double(node) do |var, receiver|
             have_received_usage(node) do |expected|
-              add_offense(receiver, location: :expression) if expected == var
+              add_offense(receiver) if expected == var
             end
           end
         end

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -68,7 +68,7 @@ module RuboCop
             return if inside_dynamic_class?(ivar)
             return if assignment_only? && !ivar_assigned?(node, name)
 
-            add_offense(ivar, location: :expression)
+            add_offense(ivar)
           end
         end
 

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -24,7 +24,7 @@ module RuboCop
 
         def on_send(node)
           invalid_predicate_matcher?(node) do |predicate|
-            add_offense(predicate, location: :expression)
+            add_offense(predicate)
           end
         end
 

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def on_send(node)
           example_inclusion_offense(node, alternative_style) do
-            add_offense(node, location: :expression)
+            add_offense(node)
           end
         end
 

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -34,7 +34,7 @@ module RuboCop
         def on_block(node)
           each?(node) do |arg, body|
             if single_expectation?(body, arg) || only_expectations?(body, arg)
-              add_offense(node.send_node, location: :expression)
+              add_offense(node.send_node)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -47,7 +47,6 @@ module RuboCop
             if offending?(sibling)
               add_offense(
                 node,
-                location: :expression,
                 message: format(MSG, offending: sibling.method_name)
               )
             end

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -73,7 +73,7 @@ module RuboCop
           node.each_child_node do |child|
             next if child.sibling_index < first_example.sibling_index
 
-            add_offense(child, location: :expression) if let?(child)
+            add_offense(child) if let?(child)
           end
         end
 

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -40,7 +40,7 @@ module RuboCop
           return unless example_group?(node)
 
           unused_let_bang(node) do |let|
-            add_offense(let, location: :expression)
+            add_offense(let)
           end
         end
 

--- a/lib/rubocop/cop/rspec/missing_example_group_argument.rb
+++ b/lib/rubocop/cop/rspec/missing_example_group_argument.rb
@@ -26,8 +26,7 @@ module RuboCop
           return unless example_group?(node)
           return if node.send_node.arguments?
 
-          add_offense(node, location: :expression,
-                            message: format(MSG, method: node.method_name))
+          add_offense(node, message: format(MSG, method: node.method_name))
         end
       end
     end

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -32,7 +32,7 @@ module RuboCop
           return if single_top_level_describe?
           return unless top_level_nodes.first.equal?(node)
 
-          add_offense(node, location: :expression)
+          add_offense(node)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -97,7 +97,6 @@ module RuboCop
         def flag_example(node, expectation_count:)
           add_offense(
             node.send_node,
-            location: :expression,
             message: format(
               MSG,
               total: expectation_count,

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -44,7 +44,7 @@ module RuboCop
           subjects = RuboCop::RSpec::ExampleGroup.new(node).subjects
 
           subjects[0...-1].each do |subject|
-            add_offense(subject, location: :expression)
+            add_offense(subject)
           end
         end
 

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -104,7 +104,6 @@ module RuboCop
             self.max = nesting
             add_offense(
               context.send_node,
-              location: :expression,
               message: message(nesting)
             )
           end

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -33,7 +33,6 @@ module RuboCop
           find_duplicates(node.body) do |duplicate, name|
             add_offense(
               duplicate,
-              location: :expression,
               message: format(MSG, name: name)
             )
           end

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -46,7 +46,7 @@ module RuboCop
         def on_send(node)
           return unless pending_block?(node) || skipped_from_metadata?(node)
 
-          add_offense(node, location: :expression)
+          add_offense(node)
         end
 
         private

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -17,7 +17,6 @@ module RuboCop
           predicate_in_actual?(node) do |predicate|
             add_offense(
               node,
-              location: :expression,
               message: message_inflected(predicate)
             )
           end
@@ -143,7 +142,6 @@ module RuboCop
           predicate_matcher_block?(node) do |_actual, matcher|
             add_offense(
               node,
-              location: :expression,
               message: message_explicit(matcher)
             )
             ignore_node(node.children.first)
@@ -155,7 +153,6 @@ module RuboCop
           predicate_matcher?(node) do |_actual, matcher|
             add_offense(
               node,
-              location: :expression,
               message: message_explicit(matcher)
             )
           end

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -36,7 +36,7 @@ module RuboCop
           return unless example_group?(node)
 
           repeated_descriptions(node).each do |repeated_description|
-            add_offense(repeated_description, location: :expression)
+            add_offense(repeated_description)
           end
         end
 

--- a/lib/rubocop/cop/rspec/repeated_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_example.rb
@@ -22,7 +22,7 @@ module RuboCop
           return unless example_group?(node)
 
           repeated_examples(node).each do |repeated_example|
-            add_offense(repeated_example, location: :expression)
+            add_offense(repeated_example)
           end
         end
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -44,7 +44,7 @@ module RuboCop
           lets.each_with_index do |node, idx|
             next if node.sibling_index == first_let.sibling_index + idx
 
-            add_offense(node, location: :expression)
+            add_offense(node)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -29,7 +29,7 @@ module RuboCop
           return unless example_group?(node)
 
           analyzable_hooks(node).each do |repeated_hook|
-            add_offense(repeated_hook, location: :expression)
+            add_offense(repeated_hook)
           end
         end
 

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -101,7 +101,6 @@ module RuboCop
         def add_shared_item_offense(node, message)
           add_offense(
             node,
-            location: :expression,
             message: message
           )
         end

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def key_to_arg(node)
-          key, = *node
+          key, = *node # rubocop:disable InternalAffairs/NodeDestructuring
           node.sym_type? ? ":#{key}" : node.source
         end
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -80,7 +80,7 @@ module RuboCop
           return unless example_group?(node)
 
           find_subject_stub(node) do |stub|
-            add_offense(stub, location: :expression)
+            add_offense(stub)
           end
         end
 

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -45,10 +45,7 @@ module RuboCop
         def on_send(node)
           return unless empty_exception_matcher?(node)
 
-          add_offense(
-            node.children.last,
-            location: :expression
-          )
+          add_offense(node.children.last)
         end
 
         def empty_exception_matcher?(node)

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -34,7 +34,7 @@ module RuboCop
             return if name.nil? && cop_config['IgnoreNameless']
             return if symbol?(name) && cop_config['IgnoreSymbolicNames']
 
-            add_offense(node, location: :expression)
+            add_offense(node)
           end
         end
 

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -40,7 +40,7 @@ module RuboCop
         def check_expect(node)
           return unless void?(node)
 
-          add_offense(node, location: :expression)
+          add_offense(node)
         end
 
         def void?(expect)

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
     # rubocop:disable ClassAndModuleChildren, RSpec/LeakyConstantDeclaration
     class RuboCop::RSpec::FakeCop < described_class
       def on_send(node)
-        add_offense(node, location: :expression, message: 'I flag everything')
+        add_offense(node, message: 'I flag everything')
       end
     end
     # rubocop:enable ClassAndModuleChildren, RSpec/LeakyConstantDeclaration


### PR DESCRIPTION
This InternalAffairs/NodeDestructuring cop is [globally disabled in RuboCop itself](https://github.com/rubocop-hq/rubocop/blob/e002ac2/.rubocop_todo.yml#L11), because there's no direct replacement for node deconstruction's var extraction, only `asgn_rhs`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).