### PR TITLE
Improve Focus cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Update RuboCop dependency to 0.68.1 with support for children matching node pattern syntax. ([@pirj][])
 * Add `RSpec/EmptyLineAfterExample` cop to check that there is an empty line after example blocks. ([@pirj][])
 * Fix `Capybara/CurrentPathExpectation` auto-corrector, to include option `ignore_query: true`. ([@onumis][])
+* Fix `RSpec/Focus` detecting mixed array/hash metadata. ([@dgollahon][])
+* Fix `RSpec/Focus` to also detect `pending` examples. ([@dgollahon][])
 
 ## 1.35.0 (2019-08-02)
 

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -32,12 +32,9 @@ module RuboCop
 
         FOCUSABLE_SELECTORS = focusable.node_pattern_union
 
-        FOCUS_SYMBOL = s(:sym, :focus)
-        FOCUS_TRUE   = s(:pair, FOCUS_SYMBOL, s(:true))
-
         def_node_matcher :metadata, <<-PATTERN
-          {(send #{RSPEC} #{FOCUSABLE_SELECTORS} ... (hash $...))
-           (send #{RSPEC} #{FOCUSABLE_SELECTORS} $...)}
+          {(send #{RSPEC} #{FOCUSABLE_SELECTORS} <$(sym :focus) ...>)
+           (send #{RSPEC} #{FOCUSABLE_SELECTORS} ... (hash <$(pair (sym :focus) true) ...>))}
         PATTERN
 
         def_node_matcher :focused_block?, focused.send_pattern
@@ -53,10 +50,7 @@ module RuboCop
         def focus_metadata(node, &block)
           yield(node) if focused_block?(node)
 
-          metadata(node) do |matches|
-            matches.grep(FOCUS_SYMBOL, &block)
-            matches.grep(FOCUS_TRUE, &block)
-          end
+          metadata(node, &block)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -26,7 +26,8 @@ module RuboCop
           ExampleGroups::GROUPS  +
           ExampleGroups::SKIPPED +
           Examples::EXAMPLES     +
-          Examples::SKIPPED
+          Examples::SKIPPED      +
+          Examples::PENDING
 
         focused = ExampleGroups::FOCUSED + Examples::FOCUSED
 

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -136,4 +136,11 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       ^^^^^^^^^^^^ Focused spec found.
     RUBY
   end
+
+  it 'flags rspec example blocks that include `:focus` preceding a hash' do
+    expect_offense(<<-RUBY)
+      describe 'test', :focus, js: true do; end
+                       ^^^^^^ Focused spec found.
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                                    ^^^^^^^^^^^ Focused spec found.
       xscenario 'test', meta: true, focus: true do; end
                                     ^^^^^^^^^^^ Focused spec found.
+      pending 'test', meta: true, focus: true do; end
+                                  ^^^^^^^^^^^ Focused spec found.
     RUBY
   end
 
@@ -75,6 +77,8 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                        ^^^^^^ Focused spec found.
       it 'test', :focus do; end
                  ^^^^^^ Focused spec found.
+      pending 'test', :focus do; end
+                      ^^^^^^ Focused spec found.
     RUBY
   end
   # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
Improves the Focus cop in a couple of ways.

- Fixes the incorrect metadata detection from #775
- Adds `pending` to the examples that it can detect (since these can be focused).
- WIP/TODO: Trying to address #398 as well but it's actually much trickier than it might first appear.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
