### PR TITLE
Changed message of RSpec/LetSetup cop to be more descriptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RSpec/LeakyConstantDeclaration` cop. ([@jonatas][], [@pirj][])
 * Improve `aggregate_failures` metadata detection of `RSpec/MultipleExpectations`. ([@pirj][])
 * Improve `RSpec/SubjectStub` detection and message. ([@pirj][])
+* Change message of `RSpec/LetSetup` cop to be more descriptive. ([@foton][])
 
 ## 1.33.0 (2019-05-13)
 
@@ -423,3 +424,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mkenyon]: https://github.com/mkenyon
 [@gsamokovarov]: https://github.com/gsamokovarov
 [@schmijos]: https://github.com/schmijos
+[@foton]: https://github.com/foton

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -28,7 +28,7 @@ module RuboCop
       class LetSetup < Cop
         include RuboCop::RSpec::TopLevelDescribe
 
-        MSG = 'Do not use `let!` for test setup.'
+        MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
         def_node_search :let_bang, <<-PATTERN
           (block $(send nil? :let! (sym $_)) args ...)

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
     expect_offense(<<-RUBY)
       describe Foo do
         let!(:foo) { bar }
-        ^^^^^^^^^^ Do not use `let!` for test setup.
+        ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
 
         it 'does not use foo' do
           expect(baz).to eq(qux)
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
       describe Foo do
         context 'when something special happens' do
           let!(:foo) { bar }
-          ^^^^^^^^^^ Do not use `let!` for test setup.
+          ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
 
           it 'does not use foo' do
             expect(baz).to eq(qux)


### PR DESCRIPTION
I get this `rubocop` offence: 
```
spec/features/catalog/creating_product_spec.rb:11:3: C: RSpec/LetSetup: Do not use let! for test setup.
  let!(:options) { FactoryBot.create_list(:option_with_items, 2, item_count: 3) }
  ^^^^^^^^^^^^^
```
That `let!` was new one between other `let!`s. But I get error for just this one.
The  "enlightening" came, when I read documentation of `RSpec/LetSetup` cop: 
> Checks unreferenced `let!` calls being used for test setup.

So I think, that better message for this cop is `"Do not use `let!` for setup of objects which are not referenced in tests."`


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
