### PR TITLE
Improve examples for LeakyConstantDeclaration cop

### DIFF
--- a/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
+++ b/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
@@ -23,35 +23,51 @@ module RuboCop
       #   # bad
       #   describe SomeClass do
       #     OtherClass = Struct.new
-      #     CONSTANT_HERE = 'is also denied'
+      #     CONSTANT_HERE = 'I leak into global namespace'
       #   end
       #
       #   # good
       #   describe SomeClass do
       #     before do
       #       stub_const('OtherClass', Struct.new)
-      #       stub_const('CONSTANT_HERE', 'is also denied')
+      #       stub_const('CONSTANT_HERE', 'I only exist during this example')
       #     end
       #   end
       #
       # @example
       #   # bad
       #   describe SomeClass do
-      #     class OtherClass < described_class
-      #       def do_something
+      #     class FooClass < described_class
+      #       def double_that
+      #         some_base_method * 2
       #       end
       #     end
+      #
+      #     it { expect(FooClass.new.double_that).to eq(4) }
       #   end
       #
-      #   # good
+      #   # good - anonymous class, no constant needs to be defined
+      #   let(:foo_class) do
+      #     Class.new(described_class) do
+      #       def double_that
+      #         some_base_method * 2
+      #       end
+      #     end
+      #
+      #     it { expect(foo_class.new.double_that).to eq(4) }
+      #   end
+      #
+      #   # good - constant is stubbed
       #   describe SomeClass do
       #     before do
-      #       fake_class = Class.new(described_class) do
-      #                      def do_something
-      #                      end
-      #                    end
-      #       stub_const('OtherClass', fake_class)
+      #       foo_class = Class.new(described_class) do
+      #                     def do_something
+      #                     end
+      #                   end
+      #       stub_const('FooClass', foo_class)
       #     end
+      #
+      #     it { expect(FooClass.new.double_that).to eq(4) }
       #   end
       #
       # @example
@@ -68,11 +84,11 @@ module RuboCop
       #   # good
       #   describe SomeClass do
       #     before do
-      #       fake_class = Class.new(described_class) do
-      #         def do_something
-      #         end
-      #       end
-      #       stub_const('SomeModule::SomeClass', fake_class)
+      #       foo_class = Class.new(described_class) do
+      #                     def do_something
+      #                     end
+      #                   end
+      #       stub_const('SomeModule::SomeClass', foo_class)
       #     end
       #   end
       class LeakyConstantDeclaration < Cop

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1506,35 +1506,51 @@ namespace name clashes.
 # bad
 describe SomeClass do
   OtherClass = Struct.new
-  CONSTANT_HERE = 'is also denied'
+  CONSTANT_HERE = 'I leak into global namespace'
 end
 
 # good
 describe SomeClass do
   before do
     stub_const('OtherClass', Struct.new)
-    stub_const('CONSTANT_HERE', 'is also denied')
+    stub_const('CONSTANT_HERE', 'I only exist during this example')
   end
 end
 ```
 ```ruby
 # bad
 describe SomeClass do
-  class OtherClass < described_class
-    def do_something
+  class FooClass < described_class
+    def double_that
+      some_base_method * 2
     end
   end
+
+  it { expect(FooClass.new.double_that).to eq(4) }
 end
 
-# good
+# good - anonymous class, no constant needs to be defined
+let(:foo_class) do
+  Class.new(described_class) do
+    def double_that
+      some_base_method * 2
+    end
+  end
+
+  it { expect(foo_class.new.double_that).to eq(4) }
+end
+
+# good - constant is stubbed
 describe SomeClass do
   before do
-    fake_class = Class.new(described_class) do
-                   def do_something
-                   end
-                 end
-    stub_const('OtherClass', fake_class)
+    foo_class = Class.new(described_class) do
+                  def do_something
+                  end
+                end
+    stub_const('FooClass', foo_class)
   end
+
+  it { expect(FooClass.new.double_that).to eq(4) }
 end
 ```
 ```ruby
@@ -1551,11 +1567,11 @@ end
 # good
 describe SomeClass do
   before do
-    fake_class = Class.new(described_class) do
-      def do_something
-      end
-    end
-    stub_const('SomeModule::SomeClass', fake_class)
+    foo_class = Class.new(described_class) do
+                  def do_something
+                  end
+                end
+    stub_const('SomeModule::SomeClass', foo_class)
   end
 end
 ```


### PR DESCRIPTION
As mentioned [here](https://github.com/rubocop-hq/rubocop-rspec/pull/765#issuecomment-502949406), it's not even necessary in some cases to stub a constant, a so-called "sacrificial class" will do.
The term was coined in [this article](http://blog.bitwrangler.com/2016/11/10/sacrificial-test-classes.html) originally mentioned in [this comment](https://github.com/rubocop-hq/rubocop-rspec/issues/197#issuecomment-261495168).

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).