### PR TITLE
Improve detection for ExampleWording cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Improve `aggregate_failures` metadata detection of `RSpec/MultipleExpectations`. ([@pirj][])
 * Improve `RSpec/SubjectStub` detection and message. ([@pirj][])
 * Change message of `RSpec/LetSetup` cop to be more descriptive. ([@foton][])
+* Improve `RSpec/ExampleWording` to handle interpolated example messages. ([@nc-holodakg][])
 
 ## 1.33.0 (2019-05-13)
 
@@ -425,3 +426,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@gsamokovarov]: https://github.com/gsamokovarov
 [@schmijos]: https://github.com/schmijos
 [@foton]: https://github.com/foton
+[@nc-holodakg]: https://github.com/nc-holodakg

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -36,10 +36,12 @@ module RuboCop
         SHOULD_PREFIX = /\Ashould(?:n't)?\b/i.freeze
         IT_PREFIX     = /\Ait /i.freeze
 
-        def_node_matcher(
-          :it_description,
-          '(block (send _ :it $(str $_) ...) ...)'
-        )
+        def_node_matcher :it_description, <<-PATTERN
+          (block (send _ :it ${
+            (str $_)
+            (dstr (str $_ ) ...)
+          } ...) ...)
+        PATTERN
 
         def on_block(node)
           it_description(node) do |description_node, message|

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -28,6 +28,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
       RUBY
     end
 
+    it 'finds interpolated description with `should` at the beginning' do
+      expect_offense(<<-'RUBY')
+        it "should do #{:stuff}" do
+            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-'RUBY')
+        it "does #{:stuff}" do
+        end
+      RUBY
+    end
+
     it 'finds description with `Should` at the beginning' do
       expect_offense(<<-RUBY)
         it 'Should do something' do
@@ -106,6 +119,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
       RUBY
     end
 
+    it 'finds leading it in interpolated description' do
+      expect_offense(<<-'RUBY')
+        it "it does #{action}" do
+            ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+        end
+      RUBY
+
+      expect_correction(<<-'RUBY')
+        it "does #{action}" do
+        end
+      RUBY
+    end
+
     it "skips words beginning with 'it'" do
       expect_no_offenses(<<-RUBY)
         it 'itemizes items' do
@@ -123,6 +149,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
     it 'skips descriptions starting with words that begin with `should`' do
       expect_no_offenses(<<-RUBY)
         it 'shoulders the burden' do
+        end
+      RUBY
+    end
+
+    it 'skips interpolated description without literal `should` at the start' do
+      expect_no_offenses(<<-'RUBY')
+        it "#{should} not be here" do
         end
       RUBY
     end


### PR DESCRIPTION
By matching against interpolated strings (`dstr`), examples such as

``` ruby
  it "should do #{action}" do
    expect(foobar).to receive(action)
  end
```

will now be flagged.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
