### PR TITLE
Change the old `Rspec` syntax in the example in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 * Add [observed_nesting/max_nesting] info to `RSpec/NestedGroups` messages. ([@dgollahon][])
 * Add `RSpec/ItBehavesLike` cop. ([@dgollahon][])
 * Add `RSpec/SharedContext` cop. ([@Darhazer][])
-* `Rspec/MultipleExpectations`: Count aggregate_failures block as single expectation. ([@Darhazer][])
+* `RSpec/MultipleExpectations`: Count aggregate_failures block as single expectation. ([@Darhazer][])
 * Fix `ExpectActual` cop flagging `rspec-rails` routing specs. ([@backus][])
 * Fix `FilePath` cop not registering offenses for files like `spec/blog/user.rb` when it should be `spec/blog/user_spec.rb`. ([@backus][])
 
@@ -317,7 +317,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 * Update to rubocop 0.37.2. ([@nijikon][])
 * Update ruby versions we test against. ([@nijikon][])
 * Add `RSpec::NotToNot` cop. ([@miguelfteixeira][])
-* Add `Rspec/AnyInstance` cop. ([@mlarraz][])
+* Add `RSpec/AnyInstance` cop. ([@mlarraz][])
 
 ## 1.3.1
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ is a feature of RSpec itself – you can read about it in the [RSpec Documentati
 Enforcing
 
 ```ruby
-Rspec.describe MyClass do
+RSpec.describe MyClass do
   ...
 end
 ```


### PR DESCRIPTION
`Rspec` is an RSpec pre-3.0 syntax, later replaced with `RSpec`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).