### PR TITLE
Improve detection by allowing the use of ::RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Improve `RSpec/SubjectStub` detection and message. ([@pirj][])
 * Change message of `RSpec/LetSetup` cop to be more descriptive. ([@foton][])
 * Improve `RSpec/ExampleWording` to handle interpolated example messages. ([@nc-holodakg][])
+* Improve detection by allowing the use of `RSpec` as a top-level constant. ([@pirj][])
 
 ## 1.33.0 (2019-05-13)
 

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # RSpec public API methods that are commonly used in cops
     module Language
-      RSPEC = '{(const nil? :RSpec) nil?}'
+      RSPEC = '{(const {nil? cbase} :RSpec) nil?}'
 
       # Set of method selectors
       class SelectorSet

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     RUBY
   end
 
+  it 'supports ::RSpec.describe' do
+    expect_no_offenses(<<-RUBY)
+      ::RSpec.describe Foo do
+      end
+    RUBY
+  end
+
   it 'checks describe statements after a require' do
     expect_offense(<<-RUBY)
       require 'spec_helper'

--- a/spec/rubocop/rspec/language/selector_set_spec.rb
+++ b/spec/rubocop/rspec/language/selector_set_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::RSpec::Language::SelectorSet do
   describe '#send_pattern' do
     it 'builds a send matching pattern' do
       expect(selector_set.send_pattern).to eql(
-        '(send {(const nil? :RSpec) nil?} {:foo :bar} ...)'
+        '(send {(const {nil? cbase} :RSpec) nil?} {:foo :bar} ...)'
       )
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::RSpec::Language::SelectorSet do
   describe '#block_pattern' do
     it 'builds a block matching pattern' do
       expect(selector_set.block_pattern).to eql(
-        '(block (send {(const nil? :RSpec) nil?} {:foo :bar} ...) ...)'
+        '(block (send {(const {nil? cbase} :RSpec) nil?} {:foo :bar} ...) ...)'
       )
     end
   end


### PR DESCRIPTION
Previously, `on_top_level_describe` would trigger an event with any receiver of `describe`, but the cops using it would not detect anything except `RSpec` and an empty receiver.

Fixes #776

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).