### PR TITLE
Improve `RSpec/DescribedClass` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Change message of `RSpec/LetSetup` cop to be more descriptive. ([@foton][])
 * Improve `RSpec/ExampleWording` to handle interpolated example messages. ([@nc-holodakg][])
 * Improve detection by allowing the use of `RSpec` as a top-level constant. ([@pirj][])
+* Fix `RSpec/DescribedClass`'s incorrect detection. ([@pirj][])
 
 ## 1.33.0 (2019-05-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Improve `RSpec/ExampleWording` to handle interpolated example messages. ([@nc-holodakg][])
 * Improve detection by allowing the use of `RSpec` as a top-level constant. ([@pirj][])
 * Fix `RSpec/DescribedClass`'s incorrect detection. ([@pirj][])
+* Improve `RSpec/DescribedClass`'s ability to detect inside modules and classes. ([@pirj][])
 
 ## 1.33.0 (2019-05-13)
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -48,7 +48,7 @@ module RuboCop
         def_node_matcher :scope_changing_syntax?, '{def class module}'
 
         def_node_matcher :described_constant, <<-PATTERN
-          (block (send _ :describe $(const ...)) (args) $_)
+          (block (send _ :describe $(const ...) ...) (args) $_)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -109,7 +109,7 @@ module RuboCop
         end
 
         def skip_blocks?
-          cop_config['SkipBlocks'].equal?(true)
+          cop_config['SkipBlocks']
         end
 
         def offensive?(node)

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -26,8 +26,6 @@ module RuboCop
       #     expect(Widget.count).to eq(1)
       #   end
       class LetSetup < Cop
-        include RuboCop::RSpec::TopLevelDescribe
-
         MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
         def_node_search :let_bang, <<-PATTERN

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -20,8 +20,6 @@ module RuboCop
       #   end
       #
       class SubjectStub < Cop
-        include RuboCop::RSpec::TopLevelDescribe
-
         MSG = 'Do not stub methods of the object under test.'
 
         # @!method subject(node)

--- a/lib/rubocop/rspec/top_level_describe.rb
+++ b/lib/rubocop/rspec/top_level_describe.rb
@@ -6,10 +6,6 @@ module RuboCop
     module TopLevelDescribe
       extend NodePattern::Macros
 
-      def_node_matcher :described_constant, <<-PATTERN
-        (block $(send _ :describe $(const ...)) (args) $_)
-      PATTERN
-
       def on_send(node)
         return unless respond_to?(:on_top_level_describe)
         return unless top_level_describe?(node)

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   context 'when SkipBlocks is `true`' do
     let(:cop_config) { { 'SkipBlocks' => true } }
 
-    it 'does not flag violations within non-rspec blocks' do
+    it 'ignores violations within non-rspec blocks' do
       expect_offense(<<-RUBY)
         describe MyClass do
           controller(ApplicationController) do
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   context 'when EnforcedStyle is :described_class' do
     let(:cop_config) { { 'EnforcedStyle' => :described_class } }
 
-    it 'checks for the use of the described class' do
+    it 'flags for the use of the described class' do
       expect_offense(<<-RUBY)
         describe MyClass do
           include MyClass
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'checks for the use of described class with namespace' do
+    it 'flags the use of described class with namespace' do
       expect_offense(<<-RUBY)
         describe MyNamespace::MyClass do
           subject { MyNamespace::MyClass }
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'does not flag violations within a class scope change' do
+    it 'ignores violations within a class scope change' do
       expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'does not flag violations within a hook scope change' do
+    it 'ignores violations within a hook scope change' do
       expect_no_offenses(<<-RUBY)
         describe do
           before do
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'checks for the use of described class with module' do
+    it 'flags the use of described class with module' do
       pending
 
       expect_offense(<<-RUBY)
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   context 'when EnforcedStyle is :explicit' do
     let(:cop_config) { { 'EnforcedStyle' => :explicit } }
 
-    it 'checks for the use of the described_class' do
+    it 'flags the use of the described_class' do
       expect_offense(<<-RUBY)
         describe MyClass do
           include described_class
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'does not flag violations within a class scope change' do
+    it 'ignores violations within a class scope change' do
       expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'does not flag violations within a hook scope change' do
+    it 'ignores violations within a hook scope change' do
       expect_no_offenses(<<-RUBY)
         describe do
           before do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
                   ^^^^^^^ Use `described_class` instead of `MyClass`.
           end
 
-          before(:each) do
+          before do
             MyClass
             ^^^^^^^ Use `described_class` instead of `MyClass`.
 

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
+    it 'flags with metadata' do
+      expect_offense(<<-RUBY)
+        describe MyClass, some: :metadata do
+          subject { MyClass }
+                    ^^^^^^^ Use `described_class` instead of `MyClass`.
+        end
+      RUBY
+    end
+
     it 'ignores described class as string' do
       expect_no_offenses(<<-RUBY)
         describe MyClass do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
                    ^^^^^^^ Use `described_class` instead of `MyClass`.
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        describe MyClass do
+          include described_class
+
+          subject { described_class.do_something }
+
+          before { described_class.do_something }
+        end
+      RUBY
     end
 
     it 'ignores described class as string' do
@@ -187,18 +197,6 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
         end
       RUBY
     end
-
-    include_examples 'autocorrect',
-                     'describe(Foo) { include Foo }',
-                     'describe(Foo) { include described_class }'
-
-    include_examples 'autocorrect',
-                     'describe(Foo) { subject { Foo.do_action } }',
-                     'describe(Foo) { subject { described_class.do_action } }'
-
-    include_examples 'autocorrect',
-                     'describe(Foo) { before { Foo.do_action } }',
-                     'describe(Foo) { before { described_class.do_action } }'
   end
 
   context 'when EnforcedStyle is :explicit' do
@@ -215,6 +213,16 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
 
           before { described_class.do_something }
                    ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe MyClass do
+          include MyClass
+
+          subject { MyClass.do_something }
+
+          before { MyClass.do_something }
         end
       RUBY
     end
@@ -257,27 +265,18 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    include_examples 'autocorrect',
-                     'describe(Foo) { include described_class }',
-                     'describe(Foo) { include Foo }'
+    it 'autocorrects corresponding' do
+      expect_offense(<<-RUBY)
+        describe(Foo) { include described_class }
+                                ^^^^^^^^^^^^^^^ Use `Foo` instead of `described_class`.
+        describe(Bar) { include described_class }
+                                ^^^^^^^^^^^^^^^ Use `Bar` instead of `described_class`.
+      RUBY
 
-    include_examples 'autocorrect',
-                     'describe(Foo) { subject { described_class.do_action } }',
-                     'describe(Foo) { subject { Foo.do_action } }'
-
-    include_examples 'autocorrect',
-                     'describe(Foo) { before { described_class.do_action } }',
-                     'describe(Foo) { before { Foo.do_action } }'
-
-    original = <<-RUBY
-      describe(Foo) { include described_class }
-      describe(Bar) { include described_class }
-    RUBY
-    corrected = <<-RUBY
-      describe(Foo) { include Foo }
-      describe(Bar) { include Bar }
-    RUBY
-
-    include_examples 'autocorrect', original, corrected
+      expect_correction(<<-RUBY)
+        describe(Foo) { include Foo }
+        describe(Bar) { include Bar }
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) do
-    { 'EnforcedStyle' => enforced_style }
-  end
+  let(:cop_config) { {} }
 
-  shared_examples 'SkipBlocks enabled' do
+  context 'when SkipBlocks is `true`' do
+    let(:cop_config) { { 'SkipBlocks' => true } }
+
     it 'does not flag violations within non-rspec blocks' do
       expect_offense(<<-RUBY)
         describe MyClass do
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
   end
 
-  shared_examples 'SkipBlocks disabled' do
+  context 'when SkipBlocks is `false`' do
     it 'flags violations within all blocks' do
       expect_offense(<<-RUBY)
         describe MyClass do
@@ -51,32 +51,8 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
     end
   end
 
-  context 'when SkipBlocks is `true`' do
-    let(:cop_config) { { 'SkipBlocks' => true } }
-
-    include_examples 'SkipBlocks enabled'
-  end
-
-  context 'when SkipBlocks anything besides `true`' do
-    let(:cop_config) { { 'SkipBlocks' => 'yes' } }
-
-    include_examples 'SkipBlocks disabled'
-  end
-
-  context 'when SkipBlocks is not set' do
-    let(:cop_config) { {} }
-
-    include_examples 'SkipBlocks disabled'
-  end
-
-  context 'when SkipBlocks is `false`' do
-    let(:cop_config) { { 'SkipBlocks' => false } }
-
-    include_examples 'SkipBlocks disabled'
-  end
-
   context 'when EnforcedStyle is :described_class' do
-    let(:enforced_style) { :described_class }
+    let(:cop_config) { { 'EnforcedStyle' => :described_class } }
 
     it 'checks for the use of the described class' do
       expect_offense(<<-RUBY)
@@ -226,7 +202,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
   end
 
   context 'when EnforcedStyle is :explicit' do
-    let(:enforced_style) { :explicit }
+    let(:cop_config) { { 'EnforcedStyle' => :explicit } }
 
     it 'checks for the use of the described_class' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -117,14 +117,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
       RUBY
     end
 
-    it 'only takes class from top level describes' do
+    it 'takes class from innermost describe' do
       expect_offense(<<-RUBY)
         describe MyClass do
           describe MyClass::Foo do
             subject { MyClass::Foo }
+                      ^^^^^^^^^^^^ Use `described_class` instead of `MyClass::Foo`.
 
             let(:foo) { MyClass }
-                        ^^^^^^^ Use `described_class` instead of `MyClass`.
           end
         end
       RUBY


### PR DESCRIPTION
Previously, `RSpec/DescribedClass` proposed to replace `A` in the following code to `described_class`:

```ruby
RSpec.describe A do
  describe B do
    subject { B }
    let(:a) { A }
  end
end
```

It is incorrect since RSpec 3.0, which has introduced a breaking change, and the innermost example group with a class argument populates `described_class`, not the outermost.
[Related RSpec CHANGELOG](https://github.com/rspec/rspec-core/blob/master/Changelog.md#300rc1--2014-05-18).
Unfortunately, [RSpec documentation was outdated](https://github.com/rspec/rspec-core/issues/2627), but now it's [fixed](https://github.com/rspec/rspec-core/pull/2629).

Fixes #604, #785
Relates to (fixes?) #735

## NOT DONE (deliberately)

 - examples, detection for `explicit` style
 - detection of the other example group (`example_group`, `feature`, `context`, ...)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).