### PR TITLE
Fix a case for DescribedClass cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/DescribedClass`'s error when a local variable is part of the namespace. ([@pirj][])
+
 ## 1.34.0 (2019-07-23)
 
 * Remove `AggregateFailuresByDefault` config option of `RSpec/MultipleExpectations`. ([@pirj][])

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -166,10 +166,10 @@ module RuboCop
           # rubocop:enable InternalAffairs/NodeDestructuring
           if !namespace
             [name]
-          elsif namespace.cbase_type?
-            [nil, name]
-          else
+          elsif namespace.const_type?
             [*const_name(namespace), name]
+          elsif namespace.lvar_type? || namespace.cbase_type?
+            [nil, name]
           end
         end
 

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -255,6 +255,18 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
         end
       RUBY
     end
+
+    it 'ignores if a local variable is part of the namespace' do
+      expect_no_offenses(<<-RUBY)
+        describe Broken do
+          [Foo, Bar].each do |klass|
+            describe klass::Baz.name do
+              it { }
+            end
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is :explicit' do


### PR DESCRIPTION
If a local variable was part of the described class's namespace, the cop was failing.

fixes #790


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).