### PR TITLE
Fix autocorrect of multi-line docstrings in RSpec/ExampleWording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `RSpec/DescribedClass`'s error when a `described_class` is part of the namespace. ([@pirj][])
+* Fix `RSpec/ExampleWording` autocorrect of multi-line docstrings. ([@pirj][])
 
 ## 1.35.0 (2019-08-02)
 

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -159,6 +159,34 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
         end
       RUBY
     end
+
+    it 'flags \-separated multiline strings' do
+      expect_offense(<<-RUBY)
+        it 'should do something '\\
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+            'and correctly fix' do
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something and correctly fix' do
+        end
+      RUBY
+    end
+
+    it 'flags \-separated multiline interpolated strings' do
+      expect_offense(<<-'RUBY')
+        it "should do something "\
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+            "with #{object}" do
+        end
+      RUBY
+
+      expect_correction(<<-'RUBY')
+        it "does something with #{object}" do
+        end
+      RUBY
+    end
   end
 
   context 'when configuration is empty' do


### PR DESCRIPTION
\\-separated multi-line docstrings were incorrectly combined during auto-correction, e.g.:

```ruby
it 'should be flagged '\
   'but correctly fixed' do
end
```

was corrected to:

```ruby
it 'is flagged '\ 'but correctly fixed' do
end
```

fixes #792

### Not Done

To be honest, there's still one example left that won't be properly auto-corrected, specifically (notice both single and double braces):

```ruby
it 'should do something '\
    "with #{object}" do
end
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).