### PR TITLE
Add missing `SkipBlocks` option documentation for `RSpec/DescribedClass`

### DIFF
--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -8,7 +8,8 @@ module RuboCop
       # If the first argument of describe is a class, the class is exposed to
       # each example via described_class.
       #
-      # This cop can be configured using the `EnforcedStyle` option
+      # This cop can be configured using the `EnforcedStyle` and `SkipBlocks`
+      # options.
       #
       # @example `EnforcedStyle: described_class`
       #   # bad
@@ -30,6 +31,27 @@ module RuboCop
       #   # good
       #   describe MyClass do
       #     subject { MyClass.do_something }
+      #   end
+      #
+      # There's a known caveat with rspec-rails's `controller` helper that
+      # runs its block in a different context, and `described_class` is not
+      # available to it. `SkipBlocks` option excludes detection in all
+      # non-RSpec related blocks.
+      #
+      # To narrow down this setting to only a specific directory, it is
+      # possible to use an overriding configuration file local to that
+      # directory.
+      #
+      # @example `SkipBlocks: true`
+      #   # spec/controllers/.rubocop.yml
+      #   # RSpec/DescribedClass:
+      #   #   SkipBlocks: true
+      #
+      #   # acceptable
+      #   describe MyConcern do
+      #     controller(ApplicationController) do
+      #       include MyConcern
+      #     end
       #   end
       #
       class DescribedClass < Cop

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -369,7 +369,17 @@ Checks that tests use `described_class`.
 If the first argument of describe is a class, the class is exposed to
 each example via described_class.
 
-This cop can be configured using the `EnforcedStyle` option
+This cop can be configured using the `EnforcedStyle` and `SkipBlocks`
+options.
+
+There's a known caveat with rspec-rails's `controller` helper that
+runs its block in a different context, and `described_class` is not
+available to it. `SkipBlocks` option excludes detection in all
+non-RSpec related blocks.
+
+To narrow down this setting to only a specific directory, it is
+possible to use an overriding configuration file local to that
+directory.
 
 ### Examples
 
@@ -397,6 +407,20 @@ end
 # good
 describe MyClass do
   subject { MyClass.do_something }
+end
+```
+#### `SkipBlocks: true`
+
+```ruby
+# spec/controllers/.rubocop.yml
+# RSpec/DescribedClass:
+#   SkipBlocks: true
+
+# acceptable
+describe MyConcern do
+  controller(ApplicationController) do
+    include MyConcern
+  end
 end
 ```
 


### PR DESCRIPTION
The reason for existence and use case for `SkipBlocks` option were unclear.

Users were still suffering from `RSpec/DescribedClass` detecting offences in specs with `rspec-rails`'s `controller do`:

```ruby
RSpec.describe SomeConcern, type: :controller do
  controller(ApplicationController) do
    include SomeConcern
            ^^^^^^^^^^^ Use `described_class` instead of `SomeConcern`.
  end
  # ...
end
```

This change adds documentation mentioning specifically this case, and elaborates how to configure it so that `RSpec/DescirbedClass` is still able to detect offences in blocks not suffering from this problem.

Fixes #795
Related to #59

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).