### PR TITLE
Remove redundant files from gem distribution

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -25,13 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
   spec.files = Dir[
-    '{config,lib,spec}/**/*',
-    '*.md',
-    '*.gemspec',
-    'Gemfile',
-    'Rakefile'
+    'lib/**/*',
+    'config/default.yml',
+    '*.md'
   ]
-  spec.test_files = spec.files.grep(%r{^spec/})
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
   spec.metadata = {


### PR DESCRIPTION
It's hard to tell why spec files were shipped with a gem, but that doesn't seem to be necessary.

Shipping of Gemfile (that is intended to be used for local development), and especially gemspec file is unnecessary as well.

Rakefile is not useful except for local RuboCop-RSpec development.

There doesn't seem to be any mention of `test_files` option in [gem specification reference](https://guides.rubygems.org/specification-reference/#extra_rdoc_files),
most probably it's a legacy option.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).