### PR TITLE
Add earliest supported RuboCop CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,20 @@ jobs:
       - run: rake spec
       - run: rake internal_investigation
 
+  earliest-supported-rubocop:
+    docker:
+      - image: circleci/ruby
+    steps:
+      - checkout
+      - run:
+          name: Use earliest supported RuboCop
+          command: |
+            RUBOCOP_VERSION=$(grep -E "add_runtime_dependency 'rubocop'" < rubocop-rspec.gemspec | sed -e "s/^[^0-9]*//" -e "s/'$//")
+            echo "gem 'rubocop', '$RUBOCOP_VERSION'" > Gemfile.local
+      - run: bundle install --no-cache
+      - run: rake spec
+      - run: rake internal_investigation
+
   # JRuby
   jruby:
     docker:
@@ -135,6 +149,8 @@ workflows:
       - ruby-2.6-rubocop:
           requires: [confirm_config_and_documentation]
       - edge-rubocop:
+          requires: [confirm_config_and_documentation]
+      - earliest-supported-rubocop:
           requires: [confirm_config_and_documentation]
       - jruby
       - code-climate


### PR DESCRIPTION
Add a job to be making sure the changes in pull requests are still compatible with the earliest supported RuboCop version.

For `earliest-supported-rubocop` job `bundle install` step reports:
```
Fetching rubocop 0.68.1
Installing rubocop 0.68.1
```

Fixes #283

- [ ] make the check mandatory on GitHub

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [-] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).