### PR TITLE
Fix syntax errors in RSpec/ExpectChange docs/specs

### DIFF
--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -12,22 +12,22 @@ module RuboCop
       #
       # @example `EnforcedStyle: block`
       #   # bad
-      #   expect(run).to change(Foo, :bar)
+      #   expect { run }.to change(Foo, :bar)
       #
       #   # good
-      #   expect(run).to change { Foo.bar }
+      #   expect { run }.to change { Foo.bar }
       #
       # @example `EnforcedStyle: method_call`
       #   # bad
-      #   expect(run).to change { Foo.bar }
-      #   expect(run).to change { foo.baz }
+      #   expect { run }.to change { Foo.bar }
+      #   expect { run }.to change { foo.baz }
       #
       #   # good
-      #   expect(run).to change(Foo, :bar)
-      #   expect(run).to change(foo, :baz)
+      #   expect { run }.to change(Foo, :bar)
+      #   expect { run }.to change(foo, :baz)
       #   # also good when there are arguments or chained method calls
-      #   expect(run).to change { Foo.bar(:count) }
-      #   expect(run).to change { user.reload.name }
+      #   expect { run }.to change { Foo.bar(:count) }
+      #   expect { run }.to change { user.reload.name }
       #
       class ExpectChange < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -938,24 +938,24 @@ This cop can be configured using the `EnforcedStyle` option.
 
 ```ruby
 # bad
-expect(run).to change(Foo, :bar)
+expect { run }.to change(Foo, :bar)
 
 # good
-expect(run).to change { Foo.bar }
+expect { run }.to change { Foo.bar }
 ```
 #### `EnforcedStyle: method_call`
 
 ```ruby
 # bad
-expect(run).to change { Foo.bar }
-expect(run).to change { foo.baz }
+expect { run }.to change { Foo.bar }
+expect { run }.to change { foo.baz }
 
 # good
-expect(run).to change(Foo, :bar)
-expect(run).to change(foo, :baz)
+expect { run }.to change(Foo, :bar)
+expect { run }.to change(foo, :baz)
 # also good when there are arguments or chained method calls
-expect(run).to change { Foo.bar(:count) }
-expect(run).to change { user.reload.name }
+expect { run }.to change { Foo.bar(:count) }
+expect { run }.to change { user.reload.name }
 ```
 
 ### Configurable attributes


### PR DESCRIPTION
`expect(run)` is not a valid target for `change` matcher unless one uses the obscure implicit block expectation syntax:

    subject(:run) { -> { do_something } }

Otherwise it errors out:

     Failure/Error: expect(1).to change { rand }
       expected `rand` to have changed, but was not given a block

Fixes #814

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).