### PR TITLE
Improve autocorrect for Capybara/CurrentPathExpectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `RSpec/ContextMethod` cop, to detect method names in `context`. ([@geniou][])
 * Update RuboCop dependency to 0.68.1 with support for children matching node pattern syntax. ([@pirj][])
 * Add `RSpec/EmptyLineAfterExample` cop to check that there is an empty line after example blocks. ([@pirj][])
+* Fix `Capybara/CurrentPathExpectation` auto-corrector, to include option `ignore_query: true`. ([@onumis][])
 
 ## 1.35.0 (2019-08-02)
 
@@ -446,3 +447,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@schmijos]: https://github.com/schmijos
 [@foton]: https://github.com/foton
 [@nc-holodakg]: https://github.com/nc-holodakg
+[@onumis]: https://github.com/onumis

--- a/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
@@ -31,19 +31,38 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation do
 
   include_examples 'autocorrect',
                    'expect(current_path).to eq expected_path',
-                   'expect(page).to have_current_path expected_path'
+                   'expect(page).to have_current_path expected_path, '\
+                   'ignore_query: true'
+
+  include_examples 'autocorrect',
+                   'expect(current_path).to eq(expected_path)',
+                   'expect(page).to have_current_path(expected_path, '\
+                   'ignore_query: true)'
+
+  include_examples 'autocorrect',
+                   'expect(current_path).to(eq(expected_path))',
+                   'expect(page).to(have_current_path(expected_path, '\
+                   'ignore_query: true))'
+
+  include_examples 'autocorrect',
+                   'expect(current_path).to eq(expected_path(f: :b))',
+                   'expect(page).to have_current_path(expected_path(f: :b), '\
+                   'ignore_query: true)'
 
   include_examples 'autocorrect',
                    'expect(page.current_path).to eq(foo(bar).path)',
-                   'expect(page).to have_current_path(foo(bar).path)'
+                   'expect(page).to have_current_path(foo(bar).path, '\
+                   'ignore_query: true)'
 
   include_examples 'autocorrect',
                    'expect(current_path).not_to eq expected_path',
-                   'expect(page).to have_no_current_path expected_path'
+                   'expect(page).to have_no_current_path expected_path, '\
+                   'ignore_query: true'
 
   include_examples 'autocorrect',
                    'expect(current_path).to_not eq expected_path',
-                   'expect(page).to have_no_current_path expected_path'
+                   'expect(page).to have_no_current_path expected_path, '\
+                   'ignore_query: true'
 
   include_examples 'autocorrect',
                    'expect(page.current_path).to match(/regexp/i)',


### PR DESCRIPTION
`expect(page.current_path).to eq(EXPECTED_VALUE)` is not directly equivalent to `expect(page).to have_current_path(EXPECTED_VALUE)`
In particular, `have_current_path` with no options will include the querystring on the path, while `page.current_path` does not.

This fix ensures the option `ignore_query: true` is set on `have_current_path` expect when `EXPECTED_VALUE` is a string or regexp.
In those cases, it should be safe to not use this param.

Fixes #798 