### PR TITLE
Add a job to be making sure the changes in pull requests are compatible with the latest released RuboCop version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,19 @@ jobs:
       - image: circleci/ruby:2.6
     <<: *rubocop
 
+  edge-rubocop:
+    docker:
+      - image: circleci/ruby
+    steps:
+      - checkout
+      - run:
+          name: Use latest RuboCop from `master`
+          command: |
+            echo "gem 'rubocop', github: 'rubocop-hq/rubocop'" > Gemfile.local
+      - run: bundle install --no-cache
+      - run: rake spec
+      - run: rake internal_investigation
+
   # JRuby
   jruby:
     docker:
@@ -120,6 +133,8 @@ workflows:
       - ruby-2.6-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.6-rubocop:
+          requires: [confirm_config_and_documentation]
+      - edge-rubocop:
           requires: [confirm_config_and_documentation]
       - jruby
       - code-climate


### PR DESCRIPTION
For `edge-rubocop` job `bundle install` step reports:
```
Fetching git://github.com/rubocop-hq/rubocop.git
```

Fixes #283

- [ ] I suggest making this check mandatory on GitHub

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [-] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).