### PR TITLE
Bump version to 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.36.0 (2019-09-27)
+
 * Fix `RSpec/DescribedClass`'s error when `described_class` is used as part of a constant. ([@pirj][])
 * Fix `RSpec/ExampleWording` autocorrect of multi-line docstrings. ([@pirj][])
 * Add `RSpec/ContextMethod` cop, to detect method names in `context`. ([@geniou][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master (Unreleased)
 
-* Fix `RSpec/DescribedClass`'s error when a `described_class` is part of the namespace. ([@pirj][])
+* Fix `RSpec/DescribedClass`'s error when `described_class` is used as part of a constant. ([@pirj][])
 * Fix `RSpec/ExampleWording` autocorrect of multi-line docstrings. ([@pirj][])
 * Add `RSpec/ContextMethod` cop, to detect method names in `context`. ([@geniou][])
 * Update RuboCop dependency to 0.68.1 with support for children matching node pattern syntax. ([@pirj][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.35.0'
+      STRING = '1.36.0'
     end
   end
 end


### PR DESCRIPTION
I think it’s time for a new release. @rubocop-hq/rubocop-rspec @pirj Do we have any PRs that you with to merge before releasing a new version?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
