### PR TITLE
Use rubocop-dev gem to untangle dev and runtime dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 
 source 'https://rubygems.org'
 
+gem 'rubocop', github: 'pirj/rubocop', branch: 'use-rubocop-dev'
+gem 'rubocop-dev', github: 'pirj/rubocop-dev'
+
 gemspec
 
 local_gemfile = 'Gemfile.local'

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
+  spec.add_development_dependency 'rubocop-dev'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require 'rubocop'
 
-require 'rubocop/rspec/support'
+require 'rubocop/dev/rspec/support'
 
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'


### PR DESCRIPTION
For testing RuboCop RSpec with the earliest RuboCop version supported (for cases when users avoid updating RuboCop dependency to evade new offences), and still be able to use the new additions to spec support code, separate spec support code from RuboCop runtime code.

Related: #815
Based on the idea from https://github.com/rubocop-hq/rubocop-rspec/pull/815#issuecomment-529005581
Extracted: https://github.com/pirj/rubocop-dev

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
* [ ] Remove temporary commit, use the gem when it's published to RubyGems and owned by RuboCop HQ org