### PR TITLE
Fix implicit subjects mocked/stubbed not detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix documentation rake task to support Rubocop 0.75. ([@nickcampbell18][])
+* Fix `RSpec/SubjectStub` to detect implicit subjects stubbed. ([@QQism][])
 
 ## 1.36.0 (2019-09-27)
 
@@ -455,3 +456,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@nc-holodakg]: https://github.com/nc-holodakg
 [@onumis]: https://github.com/onumis
 [@nickcampbell18]: https://github.com/nickcampbell18
+[@QQism]: https://github.com/QQism

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -132,7 +132,10 @@ module RuboCop
         # @yieldparam subject_name [Symbol] name of subject being defined
         # @yieldparam parent [RuboCop::Node] parent of subject definition
         def find_subject(node, parent: nil, &block)
-          subject(node) { |name| yield(name, parent) }
+          # An implicit subject is defined by RSpec when no subject is declared
+          subject_name = subject(node) || :subject
+
+          yield(subject_name, parent) if parent
 
           node.each_child_node do |child|
             find_subject(child, parent: node, &block)

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -290,4 +290,15 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       end
     RUBY
   end
+
+  it 'flags when an implicit subject is mocked' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        it 'uses an implicit subject' do
+          expect(subject).to receive(:bar).and_return(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes #818.

[Implicit Subject](https://relishapp.com/rspec/rspec-core/v/3-8/docs/subject/implicitly-defined-subject) had not been detected by the `Rspec/SubjectStub`, which reported false negative cases.

As suggested by @pirj, there are solutions to recursively traverse through AST (either upward or downward). However, to the best of my knowledge, they might require a fair amount of changes how the cop is currently working and impact the runtime performance.

I've chosen the somewhat safe fix that reports the defaut `:subject` if there is no named nor unnamed subject declared.

Since it's my first PR, any suggestions and feedback are more than welcome.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).