### PR TITLE
Upgrade Rubocop to 0.75+ to fix documentation rake tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Upgrade Rubocop to at least 0.75 to fix documentation rake tasks
+
 ## 1.36.0 (2019-09-27)
 
 * Fix `RSpec/DescribedClass`'s error when `described_class` is used as part of a constant. ([@pirj][])

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.68.1'
+  spec.add_runtime_dependency 'rubocop', '>= 0.75.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -140,7 +140,8 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def references(config, cop)
     cop_config = config.for_cop(cop)
-    urls = RuboCop::Cop::MessageAnnotator.new(config, cop_config, {}).urls
+    urls = RuboCop::Cop::MessageAnnotator.new(config, cop.name, cop_config, {})
+      .urls
     return '' if urls.empty?
 
     content = h3('References')


### PR DESCRIPTION
This PR fixes the failure found in #827 (and master as well presumably), pinning the Rubocop version to 0.75 and updating the documentation rake task to match the changes to [`MessageAnnotator`](https://github.com/rubocop-hq/rubocop/commit/95b86f8a704da6e989302f37b057e130a2418c01).