### PR TITLE
Fix documentation rake tasks to support Rubocop 0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix documentation rake task to support Rubocop 0.75. ([@nickcampbell18][])
+
 ## 1.36.0 (2019-09-27)
 
 * Fix `RSpec/DescribedClass`'s error when `described_class` is used as part of a constant. ([@pirj][])
@@ -452,3 +454,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@foton]: https://github.com/foton
 [@nc-holodakg]: https://github.com/nc-holodakg
 [@onumis]: https://github.com/onumis
+[@nickcampbell18]: https://github.com/nickcampbell18

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -82,7 +82,7 @@ module RuboCop
           end
         end
 
-        def is_expected_range(source_map) # rubocop:disable PredicateName
+        def is_expected_range(source_map) # rubocop:disable Naming/PredicateName
           Parser::Source::Range.new(
             source_map.expression.source_buffer,
             source_map.expression.begin_pos,

--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'CHANGELOG.md' do
       it 'has a valid URL' do
         issues.each do |issue|
           number = issue[:number].gsub(/\D/, '')
-          pattern = %r{^https://github\.com/.+/.+/(?:issues|pull)/#{number}$} # rubocop:disable LineLength
+          pattern = %r{^https://github\.com/.+/.+/(?:issues|pull)/#{number}$} # rubocop:disable Metrics/LineLength
           expect(issue[:url]).to match(pattern)
         end
       end

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -21,13 +21,15 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
 
   let(:fake_cop) do
     stub_const('RuboCop::RSpec', Module.new)
-    # rubocop:disable ClassAndModuleChildren, RSpec/LeakyConstantDeclaration
+    # rubocop:disable Style/ClassAndModuleChildren
+    # rubocop:disable RSpec/LeakyConstantDeclaration
     class RuboCop::RSpec::FakeCop < described_class
       def on_send(node)
         add_offense(node, message: 'I flag everything')
       end
     end
-    # rubocop:enable ClassAndModuleChildren, RSpec/LeakyConstantDeclaration
+    # rubocop:enable Style/ClassAndModuleChildren
+    # rubocop:enable RSpec/LeakyConstantDeclaration
     RuboCop::RSpec::FakeCop
   end
 


### PR DESCRIPTION
Rubocop 0.75 changed the arity of the [`MessageAnnotator`](https://github.com/rubocop-hq/rubocop/commit/95b86f8a704da6e989302f37b057e130a2418c01), so this commit changes the documentation task to support both the old and new versions.