### PR TITLE
Remove unneeded disables

### DIFF
--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'CHANGELOG.md' do
       it 'has a valid URL' do
         issues.each do |issue|
           number = issue[:number].gsub(/\D/, '')
-          pattern = %r{^https://github\.com/.+/.+/(?:issues|pull)/#{number}$} # rubocop:disable Metrics/LineLength
+          pattern = %r{^https://github\.com/.+/.+/(?:issues|pull)/#{number}$}
           expect(issue[:url]).to match(pattern)
         end
       end

--- a/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do # rubocop:disable Metrics/LineLength
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for offending code' do


### PR DESCRIPTION
I don't know why this was not flagged before, but with 0.75.1 it produces UnneededCopDisableDirective offenses. Tested the new code with 0.68.1 (the minimum required version) as well, both versions of Rubocop are now happy 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] ~Added the new cop to `config/default.yml`.~
* [x] ~The cop documents examples of good and bad code.~
* [x] ~The tests assert both that bad code is reported and that good code is not reported.~
