### PR TITLE
Rename Rails department to RSpecRails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,3 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
-
-RSpec/FilePath:
-  Exclude:
-    - spec/rubocop/cop/rspec/rspec_rails/**/*.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,3 +48,7 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
+
+RSpec/FilePath:
+  Exclude:
+    - spec/rubocop/cop/rspec/rspec_rails/**/*.rb

--- a/bin/build_config
+++ b/bin/build_config
@@ -10,7 +10,7 @@ require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 
 glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec',
-                 '{,capybara,factory_bot,rails}', '*.rb')
+                 '{,capybara,factory_bot,rspec_rails}', '*.rb')
 YARD.parse(Dir[glob], [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h

--- a/config/default.yml
+++ b/config/default.yml
@@ -474,11 +474,11 @@ FactoryBot/CreateList:
   - n_times
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
-Rails/HttpStatus:
+RSpecRails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true
   EnforcedStyle: symbolic
   SupportedStyles:
   - numeric
   - symbolic
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RSpecRails/HttpStatus

--- a/config/default.yml
+++ b/config/default.yml
@@ -185,6 +185,7 @@ RSpec/FilePath:
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
+    RSpecRails: rspec_rails
   IgnoreMethods: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 

--- a/lib/rubocop/cop/rspec/rspec_rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rspec_rails/http_status.rb
@@ -5,7 +5,7 @@ require 'rack/utils'
 module RuboCop
   module Cop
     module RSpec
-      module Rails
+      module RSpecRails
         # Enforces use of symbolic or numeric value to describe HTTP status.
         #
         # @example `EnforcedStyle: symbolic` (default)

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -7,9 +7,9 @@ require_relative 'rspec/factory_bot/attribute_defined_statically'
 require_relative 'rspec/factory_bot/create_list'
 
 begin
-  require_relative 'rspec/rails/http_status'
+  require_relative 'rspec/rspec_rails/http_status'
 rescue LoadError # rubocop:disable Lint/HandleExceptions
-  # Rails/HttpStatus cannot be loaded if rack/utils is unavailable.
+  # RSpecRails/HttpStatus cannot be loaded if rack/utils is unavailable.
 end
 
 require_relative 'rspec/align_left_let_brace'

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -6,7 +6,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      NAMESPACES = /^(RSpec|Capybara|FactoryBot|Rails)/.freeze
+      NAMESPACES = /^(RSpec|Capybara|FactoryBot|RSpecRails)/.freeze
       STYLE_GUIDE_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
 
       def initialize(config, descriptions)

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -83,8 +83,8 @@
 * [RSpec/VoidExpect](cops_rspec.md#rspecvoidexpect)
 * [RSpec/Yield](cops_rspec.md#rspecyield)
 
-#### Department [Rails](cops_rails.md)
+#### Department [RSpecRails](cops_rspecrails.md)
 
-* [Rails/HttpStatus](cops_rails.md#railshttpstatus)
+* [RSpecRails/HttpStatus](cops_rspecrails.md#rspecrailshttpstatus)
 
 <!-- END_COP_LIST -->

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1135,7 +1135,7 @@ my_class_spec.rb         # describe MyClass, '#method'
 
 Name | Default value | Configurable values
 --- | --- | ---
-CustomTransform | `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}` | 
+CustomTransform | `{"RuboCop"=>"rubocop", "RSpec"=>"rspec", "RSpecRails"=>"rspec_rails"}` | 
 IgnoreMethods | `false` | Boolean
 
 ### References

--- a/manual/cops_rspecrails.md
+++ b/manual/cops_rspecrails.md
@@ -1,6 +1,6 @@
-# Rails
+# RSpecRails
 
-## Rails/HttpStatus
+## RSpecRails/HttpStatus
 
 Enabled by default | Supports autocorrection
 --- | ---
@@ -45,4 +45,4 @@ EnforcedStyle | `symbolic` | `numeric`, `symbolic`
 
 ### References
 
-* [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus)
+* [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RSpecRails/HttpStatus](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RSpecRails/HttpStatus)

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe 'config/default.yml' do
       'rspec' => 'RSpec',
       'capybara' => 'Capybara',
       'factory_bot' => 'FactoryBot',
-      'rails' => 'Rails'
+      'rspec_rails' => 'RSpecRails'
     }
   end
 
   let(:cop_names) do
     glob = SpecHelper::ROOT.join('lib', 'rubocop', 'cop', 'rspec',
-                                 '{,capybara,factory_bot,rails}', '*.rb')
+                                 '{,capybara,factory_bot,rspec_rails}', '*.rb')
     cop_names =
       Pathname.glob(glob).map do |file|
         file_name = file.basename('.rb').to_s
@@ -47,7 +47,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   it 'sorts configuration keys alphabetically' do
-    namespaces.each do |_path, prefix|
+    namespaces.each_value do |prefix|
       expected = config_keys.select { |key| key.start_with?(prefix) }.sort
       actual = default_config.keys.select { |key| key.start_with?(prefix) }
       actual.each_with_index do |key, idx|

--- a/spec/rubocop/cop/rspec/rspec_rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rspec_rails/http_status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
+RSpec.describe RuboCop::Cop::RSpec::RSpecRails::HttpStatus, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is `symbolic`' do


### PR DESCRIPTION
Rubocop provides Rails/HttpStatus cop to lint `render` (and its friends) methods in controllers. That causes conflicts with RSpec/Rails/HttpStatus and makes one of them dysfunctional depending on `require` order.

This patchset renames `RuboCop::Cop::RSpec::Rails::HttpStatus` to `RuboCop::Cop::RSpec::RSpecRails::HttpStatus`, which both resolves namespacing conflict and makes department name better match with gem it aims to (rspec-rails).

---

Resolves: #611 