### PR TITLE
Change potentially offensive terminology

### DIFF
--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -107,7 +107,7 @@ module RuboCop
             MSG = 'Prefer `%<prefer>s` over `%<current>s` ' \
                   'to describe HTTP status code.'
 
-            WHITELIST_STATUS = %i[error success missing redirect].freeze
+            ALLOWED_STATUSES = %i[error success missing redirect].freeze
 
             attr_reader :node
             def initialize(node)
@@ -115,7 +115,7 @@ module RuboCop
             end
 
             def offensive?
-              !node.int_type? && !whitelisted_symbol?
+              !node.int_type? && !allowed_symbol?
             end
 
             def message
@@ -136,8 +136,8 @@ module RuboCop
               node.value
             end
 
-            def whitelisted_symbol?
-              node.sym_type? && WHITELIST_STATUS.include?(node.value)
+            def allowed_symbol?
+              node.sym_type? && ALLOWED_STATUSES.include?(node.value)
             end
           end
         end

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
   context 'when configured' do
     let(:cop_config) { { 'Prefixes' => %w[if] } }
 
-    it 'finds context without whitelisted prefixes at the beginning' do
+    it 'finds context without allowed prefixes at the beginning' do
       expect_offense(<<-RUBY)
         context 'when display name is present' do
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Start context description with 'if'.
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
       RUBY
     end
 
-    it 'skips descriptions with whitelisted prefixes at the beginning' do
+    it 'skips descriptions with allowed prefixes at the beginning' do
       expect_no_offenses(<<-RUBY)
         context 'if display name is present' do
         end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
       RUBY
     end
 
-    it 'does not register an offense when using whitelisted symbols' do
+    it 'does not register an offense when using allowed symbols' do
       expect_no_offenses(<<-RUBY)
         it { is_expected.to have_http_status :error }
         it { is_expected.to have_http_status :success }


### PR DESCRIPTION
I think the few places we use the term “whitelist”, we really don't need to. Changing to use “allowed” etc. instead.

RuboCop did similar changes in https://github.com/rubocop-hq/rubocop/pull/7469.

/cc @bbatsov @koic 

None of the changes are in public API, so I didn’t add to the changelog.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
