### PR TITLE
Add AllowedExplicitMatchers config option for RSpec/PredicateMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix documentation rake task to support Rubocop 0.75. ([@nickcampbell18][])
 * Fix `RSpec/SubjectStub` to detect implicit subjects stubbed. ([@QQism][])
 * Fix `RSpec/Pending` not flagging `skip` with string values. ([@pirj][])
+* Add `AllowedExplicitMatchers` config option for `RSpec/PredicateMatcher`. ([@mkrawc][])
 
 ## 1.36.0 (2019-09-27)
 
@@ -460,3 +461,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@nickcampbell18]: https://github.com/nickcampbell18
 [@QQism]: https://github.com/QQism
 [@kellysutton]: https://github.com/kellysutton
+[@mkrawc]: https://github.com/mkrawc

--- a/config/default.yml
+++ b/config/default.yml
@@ -368,6 +368,7 @@ RSpec/PredicateMatcher:
   Enabled: true
   Strict: true
   EnforcedStyle: inflected
+  AllowedExplicitMatchers: []
   SupportedStyles:
   - inflected
   - explicit

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -138,6 +138,10 @@ module RuboCop
 
         private
 
+        def allowed_explicit_matchers
+          cop_config.fetch('AllowedExplicitMatchers', []) + BUILT_IN_MATCHERS
+        end
+
         def check_explicit(node) # rubocop:disable Metrics/MethodLength
           predicate_matcher_block?(node) do |_actual, matcher|
             add_offense(
@@ -178,7 +182,7 @@ module RuboCop
         def predicate_matcher_name?(name)
           name = name.to_s
 
-          return false if BUILT_IN_MATCHERS.include?(name)
+          return false if allowed_explicit_matchers.include?(name)
 
           name.start_with?('be_', 'have_') && !name.end_with?('?')
         end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2430,6 +2430,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 Strict | `true` | Boolean
 EnforcedStyle | `inflected` | `inflected`, `explicit`
+AllowedExplicitMatchers | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -5,8 +5,10 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
 
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style,
-      'Strict' => strict }
+      'Strict' => strict,
+      'AllowedExplicitMatchers' => allowed_explicit_matchers }
   end
+  let(:allowed_explicit_matchers) { [] }
 
   context 'when enforced style is `inflected`' do
     let(:enforced_style) { 'inflected' }
@@ -268,6 +270,16 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
           expect(foo).to be_within(0.1).of(10.0)
           expect(foo).to exist
         RUBY
+      end
+
+      context 'when custom matchers are allowed' do
+        let(:allowed_explicit_matchers) { ['have_http_status'] }
+
+        it 'accepts custom allowed explicit matchers' do
+          expect_no_offenses(<<-RUBY)
+            expect(foo).to have_http_status(:ok)
+          RUBY
+        end
       end
 
       it 'accepts non-predicate matcher' do


### PR DESCRIPTION
Add AllowedExplicitMatchers config option for RSpec/PredicateMatcher as suggested in https://github.com/rubocop-hq/rubocop-rspec/issues/806


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
