### PR TITLE
Introduce FactoryGirl/FactoryClassName cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `RSpec/SubjectStub` to detect implicit subjects stubbed. ([@QQism][])
 * Fix `RSpec/Pending` not flagging `skip` with string values. ([@pirj][])
 * Add `AllowedExplicitMatchers` config option for `RSpec/PredicateMatcher`. ([@mkrawc][])
+* Add `FactoryBot/FactoryClassName` cop. ([@jfragoulis][])
 
 ## 1.36.0 (2019-09-27)
 
@@ -462,3 +463,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@QQism]: https://github.com/QQism
 [@kellysutton]: https://github.com/kellysutton
 [@mkrawc]: https://github.com/mkrawc
+[@jfragoulis]: https://github.com/jfragoulis

--- a/config/default.yml
+++ b/config/default.yml
@@ -480,6 +480,11 @@ FactoryBot/CreateList:
   - n_times
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
+FactoryBot/FactoryClassName:
+  Description: Use string value when setting the class attribute explicitly.
+  Enabled: true
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
+
 Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
   Enabled: true

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module FactoryBot
+        # Use string value when setting the class attribute explicitly.
+        #
+        # @example
+        #   # bad
+        #   factory :foo, class: Foo do
+        #   end
+        #
+        #   # good
+        #   factory :foo, class: 'Foo' do
+        #   end
+        class FactoryClassName < Cop
+          MSG = "Pass '%<class_name>s' instead of %<class_name>s."
+
+          def_node_matcher :class_name, <<~PATTERN
+            (send _ :factory _ (hash <(pair (sym :class) $(const ...)) ...>))
+          PATTERN
+
+          def on_send(node)
+            class_name(node) do |cn|
+              add_offense(cn, message: format(MSG, class_name: cn.const_name))
+            end
+          end
+
+          def autocorrect(node)
+            lambda do |corrector|
+              corrector.replace(node.loc.expression, "'#{node.source}'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -5,6 +5,7 @@ require_relative 'rspec/capybara/feature_methods'
 
 require_relative 'rspec/factory_bot/attribute_defined_statically'
 require_relative 'rspec/factory_bot/create_list'
+require_relative 'rspec/factory_bot/factory_class_name'
 
 begin
   require_relative 'rspec/rails/http_status'

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -8,6 +8,7 @@
 
 * [FactoryBot/AttributeDefinedStatically](cops_factorybot.md#factorybotattributedefinedstatically)
 * [FactoryBot/CreateList](cops_factorybot.md#factorybotcreatelist)
+* [FactoryBot/FactoryClassName](cops_factorybot.md#factorybotfactoryclassname)
 
 #### Department [RSpec](cops_rspec.md)
 

--- a/manual/cops_factorybot.md
+++ b/manual/cops_factorybot.md
@@ -77,3 +77,27 @@ EnforcedStyle | `create_list` | `create_list`, `n_times`
 ### References
 
 * [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList)
+
+## FactoryBot/FactoryClassName
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+Use string value when setting the class attribute explicitly.
+
+### Examples
+
+```ruby
+# bad
+factory :foo, class: Foo do
+end
+
+# good
+factory :foo, class: 'Foo' do
+end
+```
+
+### References
+
+* [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName)

--- a/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
+  subject(:cop) { described_class.new }
+
+  context 'when passing block' do
+    it 'flags passing a class' do
+      expect_offense(<<~RUBY)
+        factory :foo, class: Foo do
+                             ^^^ Pass 'Foo' instead of Foo.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        factory :foo, class: 'Foo' do
+        end
+      RUBY
+    end
+
+    it 'flags passing a class from global namespace' do
+      expect_offense(<<~RUBY)
+        factory :foo, class: ::Foo do
+                             ^^^^^ Pass 'Foo' instead of Foo.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        factory :foo, class: '::Foo' do
+        end
+      RUBY
+    end
+
+    it 'flags passing a subclass' do
+      expect_offense(<<~RUBY)
+        factory :foo, class: Foo::Bar do
+                             ^^^^^^^^ Pass 'Foo::Bar' instead of Foo::Bar.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        factory :foo, class: 'Foo::Bar' do
+        end
+      RUBY
+    end
+
+    it 'ignores passing class name' do
+      expect_no_offenses(<<~RUBY)
+        factory :foo, class: 'Foo' do
+        end
+      RUBY
+    end
+  end
+
+  context 'when not passing block' do
+    it 'flags passing a class' do
+      expect_offense(<<~RUBY)
+        factory :foo, class: Foo
+                             ^^^ Pass 'Foo' instead of Foo.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        factory :foo, class: 'Foo'
+      RUBY
+    end
+
+    it 'ignores passing class name' do
+      expect_no_offenses(<<~RUBY)
+        factory :foo, class: 'Foo'
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
The cop ensures that when creating factories and passing the class
name explicitly, we do not pass the class itself.

Although FactoryBot allows passing the class, we find that by doing so,
application models are loaded before the application itself gets loaded
(during factory definition).

This affects libraries like simplecov in that they fail to capture those files.

Example:

```ruby
# bad
factory :foo, class: Foo do
end

# good
factory :foo, class: 'Foo' do
end
```

### Checklist

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
