### PR TITLE
Fix pending cop when skip is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Implement `RSpec/DescribedClassModuleWrapping` to disallow RSpec statements within a module. ([@kellysutton][])
 * Fix documentation rake task to support Rubocop 0.75. ([@nickcampbell18][])
 * Fix `RSpec/SubjectStub` to detect implicit subjects stubbed. ([@QQism][])
+* Fix `RSpec/Pending` not flagging `skip` with string values. ([@pirj][])
 
 ## 1.36.0 (2019-09-27)
 

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -42,7 +42,7 @@ module RuboCop
         def_node_matcher :skipped_in_metadata?, <<-PATTERN
           {
             (send _ _ <#skip_or_pending? ...>)
-            (send _ _ ... (hash <(pair #skip_or_pending? true) ...>))
+            (send _ _ ... (hash <(pair #skip_or_pending? { true str }) ...>))
           }
         PATTERN
 

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -108,6 +108,14 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     RUBY
   end
 
+  it 'flags blocks with skip: string metadata' do
+    expect_offense(<<-RUBY)
+      it 'test', skip: 'skipped because of being slow' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
+      end
+    RUBY
+  end
+
   it 'flags pending blocks' do
     expect_offense(<<-RUBY)
       pending 'test' do


### PR DESCRIPTION
```ruby
feature "something", skip: "Running tests this way is unreliable" do
```
was not flagged as a pending spec.

Fixes #840

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).