### PR TITLE
Improve message and description of `FactoryBot/FactoryClassName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Improve message and description of `FactoryBot/FactoryClassName`. ([@ybiquitous][])
+
 ## 1.37.0 (2019-11-25)
 
 * Implement `RSpec/DescribedClassModuleWrapping` to disallow RSpec statements within a module. ([@kellysutton][])
@@ -466,3 +468,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@kellysutton]: https://github.com/kellysutton
 [@mkrawc]: https://github.com/mkrawc
 [@jfragoulis]: https://github.com/jfragoulis
+[@ybiquitous]: https://github.com/ybiquitous

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -6,6 +6,11 @@ module RuboCop
       module FactoryBot
         # Use string value when setting the class attribute explicitly.
         #
+        # This cop would promote faster tests by lazy-loading of
+        # application files. Also, this could help you suppress potential bugs
+        # in combination with external libraries by avoiding a preload of
+        # application files from the factory files.
+        #
         # @example
         #   # bad
         #   factory :foo, class: Foo do
@@ -15,7 +20,8 @@ module RuboCop
         #   factory :foo, class: 'Foo' do
         #   end
         class FactoryClassName < Cop
-          MSG = "Pass '%<class_name>s' instead of %<class_name>s."
+          MSG = "Pass '%<class_name>s' string instead of `%<class_name>s` " \
+                'constant.'
 
           def_node_matcher :class_name, <<~PATTERN
             (send _ :factory _ (hash <(pair (sym :class) $(const ...)) ...>))

--- a/manual/cops_factorybot.md
+++ b/manual/cops_factorybot.md
@@ -86,6 +86,11 @@ Enabled | Yes
 
 Use string value when setting the class attribute explicitly.
 
+This cop would promote faster tests by lazy-loading of
+application files. Also, this could help you suppress potential bugs
+in combination with external libraries by avoiding a preload of
+application files from the factory files.
+
 ### Examples
 
 ```ruby

--- a/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
     it 'flags passing a class' do
       expect_offense(<<~RUBY)
         factory :foo, class: Foo do
-                             ^^^ Pass 'Foo' instead of Foo.
+                             ^^^ Pass 'Foo' string instead of `Foo` constant.
         end
       RUBY
 
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
     it 'flags passing a class from global namespace' do
       expect_offense(<<~RUBY)
         factory :foo, class: ::Foo do
-                             ^^^^^ Pass 'Foo' instead of Foo.
+                             ^^^^^ Pass 'Foo' string instead of `Foo` constant.
         end
       RUBY
 
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
     it 'flags passing a subclass' do
       expect_offense(<<~RUBY)
         factory :foo, class: Foo::Bar do
-                             ^^^^^^^^ Pass 'Foo::Bar' instead of Foo::Bar.
+                             ^^^^^^^^ Pass 'Foo::Bar' string instead of `Foo::Bar` constant.
         end
       RUBY
 
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
     it 'flags passing a class' do
       expect_offense(<<~RUBY)
         factory :foo, class: Foo
-                             ^^^ Pass 'Foo' instead of Foo.
+                             ^^^ Pass 'Foo' string instead of `Foo` constant.
       RUBY
 
       expect_correction(<<~RUBY)


### PR DESCRIPTION
When I saw the cop's message first, I did not know how to fix my code.
This modification aims to increase the message's readability by explicitly describing "string" and "constant".

Next, I could not understand also why the cop warned when I saw its document.
So, this also adds the cop's rationale to its document. This rationale is based on the PR #839 description.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

