### PR TITLE
Fix `FactoryBot/FactoryClassName` to ignore `Hash` and `OpenStruct`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Improve message and description of `FactoryBot/FactoryClassName`. ([@ybiquitous][])
+* Fix `FactoryBot/FactoryClassName` to ignore `Hash` and `OpenStruct`. ([@jfragoulis][])
 
 ## 1.37.0 (2019-11-25)
 

--- a/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
         end
       RUBY
     end
+
+    it 'ignores passing Hash' do
+      expect_no_offenses(<<~RUBY)
+        factory :foo, class: Hash do
+        end
+      RUBY
+    end
+
+    it 'ignores passing OpenStruct' do
+      expect_no_offenses(<<~RUBY)
+        factory :foo, class: OpenStruct do
+        end
+      RUBY
+    end
   end
 
   context 'when not passing block' do


### PR DESCRIPTION
Hash and OpenStruct are used in factories widely.
Then factory should not force them into strings as they are built in language objects.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
