### PR TITLE
Fix RSpec/MessageChain "better" docs.

### DIFF
--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       #   # better
       #   thing = Thing.new(baz: 42)
-      #   allow(foo).to receive(bar: thing)
+      #   allow(foo).to receive(:bar).and_return(thing)
       #
       class MessageChain < Cop
         MSG = 'Avoid stubbing using `%<method>s`.'

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1846,7 +1846,7 @@ allow(foo).to receive_message_chain(:bar, :baz).and_return(42)
 
 # better
 thing = Thing.new(baz: 42)
-allow(foo).to receive(bar: thing)
+allow(foo).to receive(:bar).and_return(thing)
 ```
 
 ### References


### PR DESCRIPTION
The original code results in an error because `receive` takes a single argument of the method name which it tries to symbolize.

```
     NoMethodError:
       undefined method `to_sym' for {:bar=>#<Thing:0x00007ff34792c178 @baz=42>}:Hash
       Did you mean?  to_s
                      to_set
```

I believe what it's trying to do is `allow(foo).to receive(:bar).and_return(thing)`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] N/A Added tests.
* [x] N/A Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
