### PR TITLE
CI with Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,16 @@ jobs:
       - image: circleci/ruby:2.6
     <<: *rubocop
 
+  # Ruby 2.7
+  ruby-2.7-rspec:
+    docker:
+      - image: circleci/ruby:2.7
+    <<: *rspec
+  ruby-2.7-rubocop:
+    docker:
+      - image: circleci/ruby:2.7
+    <<: *rubocop
+
   edge-rubocop:
     docker:
       - image: circleci/ruby
@@ -133,6 +143,10 @@ workflows:
       - ruby-2.6-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.6-rubocop:
+          requires: [confirm_config_and_documentation]
+      - ruby-2.7-rspec:
+          requires: [confirm_config_and_documentation]
+      - ruby-2.7-rubocop:
           requires: [confirm_config_and_documentation]
       - edge-rubocop:
           requires: [confirm_config_and_documentation]


### PR DESCRIPTION
Ruby 2.7 is ready, so let’s test our PRs against it.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
