### PR TITLE
Adds an autocorrect to `RSpec/ExpectActual`, swapping the arguments to `expect` and matcher when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix `RSpec/InstanceVariable` detection inside custom matchers. ([@pirj][])
 * Fix `RSpec/ScatteredSetup` to distinguish hooks with different metadata. ([@pirj][])
-* Add autocorrect support for `RSpec/ExpectActual` cop. ([@dduugg][])
+* Add autocorrect support for `RSpec/ExpectActual` cop. ([@dduugg][], [@pirj][])
 
 ## 1.37.1 (2019-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `RSpec/InstanceVariable` detection inside custom matchers. ([@pirj][])
 * Fix `RSpec/ScatteredSetup` to distinguish hooks with different metadata. ([@pirj][])
+* Add autocorrect support for `RSpec/ExpectActual` cop. ([@dduugg][])
 
 ## 1.37.1 (2019-12-16)
 
@@ -475,3 +476,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mkrawc]: https://github.com/mkrawc
 [@jfragoulis]: https://github.com/jfragoulis
 [@ybiquitous]: https://github.com/ybiquitous
+[@dduugg]: https://github.com/dduugg

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -60,7 +60,7 @@ module RuboCop
           lambda do |corrector|
             return if matcher.method_name != :eq
 
-            swap_order(corrector, argument, matcher.arguments.first)
+            swap(corrector, argument, matcher.arguments.first)
           end
         end
 
@@ -81,9 +81,9 @@ module RuboCop
             node.each_child_node.all?(&method(:literal?))
         end
 
-        def swap_order(corrector, lhs_arg, rhs_arg)
-          corrector.replace(lhs_arg.source_range, rhs_arg.source)
-          corrector.replace(rhs_arg.source_range, lhs_arg.source)
+        def swap(corrector, actual, expected)
+          corrector.replace(actual.source_range, expected.source)
+          corrector.replace(expected.source_range, actual.source)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -49,6 +49,17 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            expectation = node.parent.parent
+            rhs = expectation.children.last
+            return unless rhs.is_a?(RuboCop::AST::MethodDispatchNode)
+            return if rhs.method_name != :eq
+
+            swap_order(corrector, node, rhs.children.last)
+          end
+        end
+
         private
 
         # This is not implement using a NodePattern because it seems
@@ -64,6 +75,11 @@ module RuboCop
         def complex_literal?(node)
           COMPLEX_LITERALS.include?(node.type) &&
             node.each_child_node.all?(&method(:literal?))
+        end
+
+        def swap_order(corrector, lhs_arg, rhs_arg)
+          corrector.replace(lhs_arg.source_range, rhs_arg.source)
+          corrector.replace(rhs_arg.source_range, lhs_arg.source)
         end
       end
     end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -977,7 +977,7 @@ IgnoredWords | `[]` | Array
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 Checks for `expect(...)` calls containing literal values.
 

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(123)
+          expect(bar).to eq(12.3)
+          expect(bar).to eq(1i)
+          expect(bar).to eq(1r)
+        end
+      end
+    RUBY
   end
 
   it 'flags boolean literal values within expect(...)' do
@@ -28,6 +39,15 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
                  ^^^^ Provide the actual you are testing to `expect(...)`.
           expect(false).to eq(bar)
                  ^^^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(true)
+          expect(bar).to eq(false)
         end
       end
     RUBY
@@ -44,6 +64,15 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq("foo")
+          expect(bar).to eq(:foo)
+        end
+      end
+    RUBY
   end
 
   it 'flags literal nil value within expect(...)' do
@@ -52,6 +81,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         it 'uses expect incorrectly' do
           expect(nil).to eq(bar)
                  ^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(nil)
         end
       end
     RUBY
@@ -80,6 +117,15 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq([123])
+          expect(bar).to eq([[123]])
+        end
+      end
+    RUBY
   end
 
   it 'flags hashes containing only literal values within expect(...)' do
@@ -90,6 +136,15 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
                  ^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
           expect(foo: 1, bar: [{}]).to eq(bar)
                  ^^^^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(foo: 1, bar: 2)
+          expect(bar).to eq(foo: 1, bar: [{}])
         end
       end
     RUBY
@@ -106,6 +161,15 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         end
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(1..2)
+          expect(bar).to eq(1...2)
+        end
+      end
+    RUBY
   end
 
   it 'flags regexps containing only literal values within expect(...)' do
@@ -114,6 +178,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         it 'uses expect incorrectly' do
           expect(/foo|bar/).to eq(bar)
                  ^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(/foo|bar/)
         end
       end
     RUBY
@@ -133,6 +205,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
         end
       end
     RUBY
+  end
+
+  it 'flags but does not autocorrect violations without eq' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect([1,2,3]).to include(a)
+                 ^^^^^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_no_corrections
   end
 
   context 'when inspecting rspec-rails routing specs' do

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -207,7 +207,93 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
     RUBY
   end
 
-  it 'flags but does not autocorrect violations without eq' do
+  it 'ignores `be` with no argument' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        it 'uses expect legitimately' do
+          expect(1).to be
+        end
+      end
+    RUBY
+  end
+
+  it 'flags `be` with an argument' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(true).to be(a)
+                 ^^^^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(a).to be(true)
+        end
+      end
+    RUBY
+  end
+
+  it 'flags `be ==`' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(1).to be == a
+                 ^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(a).to be == 1
+        end
+      end
+    RUBY
+  end
+
+  it 'flags with `eql` matcher' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(1).to eql(bar)
+                 ^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eql(1)
+        end
+      end
+    RUBY
+  end
+
+  it 'flags with `equal` matcher' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(1).to equal(bar)
+                 ^ Provide the actual you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to equal(1)
+        end
+      end
+    RUBY
+  end
+
+  it 'flags but does not autocorrect violations for other matchers' do
     expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do


### PR DESCRIPTION
Based on #855 by @dduugg

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).