### PR TITLE
Do not require gem in Gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gem install rubocop-rspec
 or if you use bundler put this in your `Gemfile`
 
 ```
-gem 'rubocop-rspec'
+gem 'rubocop-rspec', require: false
 ```
 
 ## Usage


### PR DESCRIPTION
Since rubocop and its extension used only in development in command line
Fix #857

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).