### PR TITLE
Encourage users to customize the permitted word list in `RSpec/ContextWording` (was: Add `before` and `after` to default list)

### DIFF
--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -5,7 +5,11 @@ module RuboCop
     module RSpec
       # Checks that `context` docstring starts with an allowed prefix.
       #
-      # @see https://github.com/reachlocal/rspec-style-guide#context-descriptions
+      # The default list of prefixes is minimal. Users are encouraged to tailor
+      # the configuration to meet project needs. Other acceptable prefixes may
+      # include `if`, `unless`, `for`, `before`, `after`, or `during`.
+      #
+      # @see https://rspec.rubystyle.guide/#context-descriptions
       # @see http://www.betterspecs.org/#contexts
       #
       # @example `Prefixes` configuration

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -275,6 +275,10 @@ Enabled | No
 
 Checks that `context` docstring starts with an allowed prefix.
 
+The default list of prefixes is minimal. Users are encouraged to tailor
+the configuration to meet project needs. Other acceptable prefixes may
+include `if`, `unless`, `for`, `before`, `after`, or `during`.
+
 ### Examples
 
 #### `Prefixes` configuration


### PR DESCRIPTION
Add `before` and `after` to the `RSpec/ContextWording` default list. This allows for more expressive context descriptions.

Example:
```ruby
# bad
context 'record not yet saved'

# good
context 'when the record is not yet saved'

# even better
context 'before the record is saved'
```

Also add items that are mentioned in the documentation but not included in the default config: `if`, `unless`, `for`.

on-behalf-of: @Cofense <oss@cofense.com>


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
