### PR TITLE
Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add support for subject detection after includes and example groups in `RSpec/LeadingSubject`. ([@pirj][])
 * Ignore trailing punctuation in context description prefix. ([@elliterate][])
 
+* Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][], [@pirj][])
+
 ## 1.42.0 (2020-07-09)
 
 * Update RuboCop dependency to 0.87.0 because of changes to internal APIs. ([@bquorning][], [@Darhazer][])
@@ -15,7 +17,6 @@
 * Extend the list of Rails spec types for `RSpec/DescribeClass`. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` to allow `#traits_for_enum` without a block. ([@harrylewis][])
 * Improve the performance of `FactoryBot/AttributeDefinedStatically`, `RSpec/InstanceVariable`, `RSpec/LetSetup`, `RSpec/NestedGroups` and `RSpec/ReturnFromStub`. ([@andrykonchin][])
-* Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][], [@pirj][])
 
 ## 1.40.0 (2020-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Ignore trailing punctuation in context description prefix. ([@elliterate][])
 
 * Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][], [@pirj][])
+* Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][])
+* Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
 
 ## 1.42.0 (2020-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Add support for subject detection after includes and example groups in `RSpec/LeadingSubject`. ([@pirj][])
 * Ignore trailing punctuation in context description prefix. ([@elliterate][])
 
-* Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][], [@pirj][])
 * Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][])
 * Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Extend the list of Rails spec types for `RSpec/DescribeClass`. ([@pirj][])
 * Fix `FactoryBot/AttributeDefinedStatically` to allow `#traits_for_enum` without a block. ([@harrylewis][])
 * Improve the performance of `FactoryBot/AttributeDefinedStatically`, `RSpec/InstanceVariable`, `RSpec/LetSetup`, `RSpec/NestedGroups` and `RSpec/ReturnFromStub`. ([@andrykonchin][])
+* Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][], [@pirj][])
 
 ## 1.40.0 (2020-06-11)
 
@@ -534,3 +535,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@andrykonchin]: https://github.com/andrykonchin
 [@harrylewis]: https://github.com/harrylewis
 [@elliterate]: https://github.com/elliterate
+[@mlarraz]: https://github.com/mlarraz

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -69,6 +69,7 @@ module RuboCop
             #{Examples::ALL.block_pattern}
             #{ExampleGroups::ALL.block_pattern}
             #{Includes::ALL.send_pattern}
+            #{Includes::ALL.block_pattern}
             (send nil? #custom_include? ...)
           }
         PATTERN

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -66,6 +66,8 @@ module RuboCop
             #{ExampleGroups::ALL.block_pattern}
             #{Includes::ALL.send_pattern}
             (send nil? #custom_include? ...)
+            (block (send _ :each) _ #contains_example?)
+            (begin <(block (send _ :each) _ #contains_example?) ...>)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -74,30 +74,21 @@ module RuboCop
           }
         PATTERN
 
-        def_node_matcher :examples_in_iterator?, <<~PATTERN
-          (block
-            {
-              (send _ :each)
-              (send _ :each_with_object _)
-              (send _ :each_with_index)
-              (send (send _ :each) :with_object _)
-              (send (send _ :each) :with_index)
-            }
-            _ #examples?
-          )
+        def_node_matcher :examples_inside_block?, <<~PATTERN
+          (block !#{Hooks::ALL.send_pattern} _ #examples?)
         PATTERN
 
-        def_node_matcher :examples_directly_or_in_iterator?, <<~PATTERN
+        def_node_matcher :examples_directly_or_in_block?, <<~PATTERN
           {
             #example_or_group_or_include?
-            #examples_in_iterator?
+            #examples_inside_block?
           }
         PATTERN
 
         def_node_matcher :examples?, <<~PATTERN
           {
-            #examples_directly_or_in_iterator?
-            (begin <#examples_directly_or_in_iterator? ...>)
+            #examples_directly_or_in_block?
+            (begin <#examples_directly_or_in_block? ...>)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -74,7 +74,16 @@ module RuboCop
         PATTERN
 
         def_node_matcher :examples_in_iterator?, <<~PATTERN
-          (block (send _ :each) _ #examples?)
+          (block
+            {
+              (send _ :each)
+              (send _ :each_with_object _)
+              (send _ :each_with_index)
+              (send (send _ :each) :with_object _)
+              (send (send _ :each) :with_index)
+            }
+            _ #examples?
+          )
         PATTERN
 
         def_node_matcher :examples_directly_or_in_iterator?, <<~PATTERN

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -39,7 +39,7 @@ module RuboCop
         #       name # => :thing
         #     end
         #
-        #   @param node [RuboCop::Node]
+        #   @param node [RuboCop::AST::Node]
         #
         #   @yield [Symbol] subject name
         def_node_matcher :subject, <<-PATTERN

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -36,9 +36,9 @@ module RuboCop
       #
       # Searches node and halts when a scope change is detected
       #
-      # @param node [RuboCop::Node] node to recursively search
+      # @param node [RuboCop::AST::Node] node to recursively search
       #
-      # @return [Array<RuboCop::Node>] discovered nodes
+      # @return [Array<RuboCop::AST::Node>] discovered nodes
       def find_all_in_scope(node, predicate)
         node.each_child_node.flat_map do |child|
           find_all(child, predicate)

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -14,7 +14,7 @@ module RuboCop
         def_node_matcher :spec_group?, spec_groups.block_pattern
 
         def_node_matcher :example_group_with_body?, <<-PATTERN
-          (block #{ExampleGroups::ALL.send_pattern} args [!nil?])
+          (block #{ExampleGroups::ALL.send_pattern} args !nil?)
         PATTERN
 
         def_node_matcher :example?, Examples::ALL.block_pattern

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
-  it 'flags an empty context' do
-    expect_offense(<<-RUBY)
+  it 'flags an empty example group' do
+    expect_offense(<<~RUBY)
       describe Foo do
         context 'when bar' do
         ^^^^^^^^^^^^^^^^^^ Empty example group detected.
@@ -22,17 +22,17 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   end
 
   it 'flags an empty top level describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
       ^^^^^^^^^^^^ Empty example group detected.
       end
     RUBY
   end
 
-  it 'flags examples improperly nested in invalid scopes' do
-    expect_offense(<<-RUBY)
-      describe Foo do
-      ^^^^^^^^^^^^ Empty example group detected.
+  it 'flags example group with examples defined in hooks' do
+    expect_offense(<<~RUBY)
+      context 'hook with implicit scope' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty example group detected.
         before do
           it 'yields a block when given' do
             value = nil
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   end
 
   it 'ignores example group with examples defined in iterator' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'RuboCop monthly' do
         [1, 2, 3].each do |page|
           it { expect(newspaper(page)).to have_ads }
@@ -56,8 +56,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
-  it 'ignores example group with examples defined in surrounded iterator' do
-    expect_no_offenses(<<-RUBY)
+  it 'ignores example group with examples defined in an iterator' do
+    expect_no_offenses(<<~RUBY)
       describe 'RuboCop weekly' do
         some_method
         [1, 2, 3].each do |page|
@@ -68,8 +68,22 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
-  it 'ignores example group with examples defined in nested iterator' do
-    expect_no_offenses(<<-RUBY)
+  it 'flags example group with no examples defined in an iterator' do
+    expect_offense(<<~RUBY)
+      describe 'RuboCop Sunday' do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Empty example group detected.
+        some_method
+        [1, 2, 3].each do |page|
+          no_examples_here
+          and_no_ads_either
+        end
+        more_surroundings
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in a nested iterator' do
+    expect_no_offenses(<<~RUBY)
       describe 'RuboCop daily' do
         some_method
         [1, 2, 3].each do |page|
@@ -84,8 +98,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
-  it 'does not flag include_examples' do
-    expect_no_offenses(<<-RUBY)
+  it 'ignores examples groups with includes' do
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         context "when something is true" do
           include_examples "some expectations"
@@ -102,8 +116,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
-  it 'does not flag methods matching example group names' do
-    expect_no_offenses(<<-RUBY)
+  it 'ignores methods matching example group names' do
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         it 'yields a block when given' do
           value = nil
@@ -116,8 +130,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
-  it 'does not recognize custom include methods by default' do
-    expect_offense(<<-RUBY)
+  it 'flags custom include methods by default' do
+    expect_offense(<<~RUBY)
       describe Foo do
         context "when I do something clever" do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty example group detected.
@@ -132,8 +146,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
       { 'CustomIncludeMethods' => %w[it_has_special_behavior] }
     end
 
-    it 'does not flag an otherwise empty example group' do
-      expect_no_offenses(<<-RUBY)
+    it 'ignores an empty example group with a custom include' do
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           context "when I do something clever" do
             it_has_special_behavior

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -139,8 +139,18 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
           include_context "some expectations"
         end
 
-        context "when a third thing is true" do
+        context "when the third thing is true" do
           it_behaves_like "some thingy"
+        end
+
+        context "when the fourth thing is true" do
+          it_behaves_like "some thingy" do
+            let(:a) { 'foo' }
+          end
+        end
+
+        context "when the fifth thing is true" do
+          it_behaves_like "some thingy", &block
         end
       end
     RUBY

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -82,6 +82,36 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
+  it 'ignores example group with examples defined in an obscure iterators' do
+    expect_no_offenses(<<~RUBY)
+      describe 'RuboCop Friday night' do
+        context 'with each.with_object' do
+          [1, 2, 3].each.with_object(0) do |page, price|
+            it { expect(newspaper(page)).to have_ads }
+          end
+        end
+
+        context 'with each.with_index' do
+          [1, 2, 3].each.with_index do |page, index|
+            it { expect(newspaper(page)).to have_ads }
+          end
+        end
+
+        context 'with each_with_object' do
+          [1, 2, 3].each_with_object(0) do |page, index|
+            it { expect(newspaper(page)).to have_ads }
+          end
+        end
+
+        context 'with each_with_index' do
+          [1, 2, 3].each_with_index do |page, index|
+            it { expect(newspaper(page)).to have_ads }
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'ignores example group with examples defined in a nested iterator' do
     expect_no_offenses(<<~RUBY)
       describe 'RuboCop daily' do

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
+  it 'flags examples improperly nested in invalid scopes' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+      ^^^^^^^^^^^^ Empty example group detected.
+        before do
+          it 'yields a block when given' do
+            value = nil
+
+            helper.feature('whatevs') { value = 5 }
+
+            expect(value).to be 5
+          end
+        end
+      end
+    RUBY
+  end
+
   it 'does not flag include_examples' do
     expect_no_offenses(<<-RUBY)
       describe Foo do
@@ -64,7 +81,6 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   it 'does not recognize custom include methods by default' do
     expect_offense(<<-RUBY)
       describe Foo do
-      ^^^^^^^^^^^^ Empty example group detected.
         context "when I do something clever" do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty example group detected.
           it_has_special_behavior

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -46,6 +46,44 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
     RUBY
   end
 
+  it 'ignores example group with examples defined in iterator' do
+    expect_no_offenses(<<-RUBY)
+      describe 'RuboCop monthly' do
+        [1, 2, 3].each do |page|
+          it { expect(newspaper(page)).to have_ads }
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in surrounded iterator' do
+    expect_no_offenses(<<-RUBY)
+      describe 'RuboCop weekly' do
+        some_method
+        [1, 2, 3].each do |page|
+          it { expect(newspaper(page)).to have_ads }
+        end
+        more_surroundings
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in nested iterator' do
+    expect_no_offenses(<<-RUBY)
+      describe 'RuboCop daily' do
+        some_method
+        [1, 2, 3].each do |page|
+          some_method
+          [1, 2, 3].each do |paragraph|
+            it { expect(newspaper(page, paragraph)).to have_ads }
+          end
+          more_surroundings
+        end
+        more_surroundings
+      end
+    RUBY
+  end
+
   it 'does not flag include_examples' do
     expect_no_offenses(<<-RUBY)
       describe Foo do


### PR DESCRIPTION
Fixes https://github.com/rubocop-hq/rubocop-rspec/issues/864.

Previously any example inside an example group would cause this Cop to pass, even if the example was inside an invalid scope.

Because RSpec will not execute any code inside an example group unless it has an example, there was no way to catch this error.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
