### PR TITLE
Workaround for cc-test-reporter with SimpleCov 0.18

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -41,6 +41,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
-  spec.add_development_dependency 'simplecov'
+  # Workaround for cc-test-reporter with SimpleCov 0.18.
+  # Stop upgrading SimpleCov until the following issue will be resolved.
+  # https://github.com/codeclimate/test-reporter/issues/418
+  spec.add_development_dependency 'simplecov', '< 0.18'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
This PR fixes the following build error when using cc-test-reporter with SimpleCov 0.18.

```consle
% #!/bin/bash -eo pipefail
  ./cc-test-reporter before-build
  rake coverage
  ./cc-test-reporter after-build --exit-code $?

(snip)

Coverage report generated for RSpec to
/home/circleci/project/coverage. 5051 / 5064 LOC (99.74%) covered.
Error: json: cannot unmarshal object into Go struct field input.coverage
of type []formatters.NullInt
```

https://circleci.com/gh/rubocop-hq/rubocop-rspec/10604

This patch is a workaround until the following issue will be resolved.
codeclimate/test-reporter#418

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
