### PR TITLE
Fix `FilePath` detection when absolute path includes test subject 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
+
 ## 1.38.1 (2020-02-15)
 
 * Fix `RSpec/RepeatedDescription` to detect descriptions with interpolation and methods. ([@lazycoder9][])
@@ -489,3 +491,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@dduugg]: https://github.com/dduugg
 [@lazycoder9]: https://github.com/lazycoder9
 [@elebow]: https://github.com/elebow
+[@eitoball]: https://github.com/eitoball

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -103,7 +103,9 @@ module RuboCop
         end
 
         def filename_ends_with?(glob)
-          File.fnmatch?("*#{glob}", processed_source.buffer.name)
+          filename =
+            RuboCop::PathUtil.relative_path(processed_source.buffer.name)
+          File.fnmatch?("*#{glob}", filename)
         end
 
         def relevant_rubocop_rspec_file?(_file)

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'uses relative path' do
+    allow(RuboCop::PathUtil)
+      .to receive(:relative_path).and_return('spec/models/bar_spec.rb')
+    expect_offense(<<-RUBY, '/home/foo/spec/models/bar_spec.rb')
+      describe Foo do; end
+      ^^^^^^^^^^^^ Spec path should end with `foo*_spec.rb`.
+    RUBY
+  end
+
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 


### PR DESCRIPTION
This PR should fix `FilePath` cop when test subject is accidentally included in absolute path of file that being examined. For example, if file contains following spec,

```ruby
RSpec.describe Foo do; end
```

and the absolute path name is like `/home/foo/src/spec/models/bar_spec.rb`.

I think this case should be warned, but currently it is passed because glob pattern `foo*_spec.rb` matches.

This PR changes to use relative path from project root so that it wouldn't match this case.


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
