### PR TITLE
Support (multiple) spec file extensions other than '_spec.rb' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## spec-file-extensions (branch)
+* Fix `RSpec/FilePath` to support spec file extensions other than `_spec.rb`. ([@cwilbur][])
+
 ## Master (Unreleased)
 
 * Fix `RSpec/InstanceVariable` detection inside custom matchers. ([@pirj][])
@@ -425,6 +428,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@andyw8]: https://github.com/andyw8
 [@backus]: https://github.com/backus
 [@bquorning]: https://github.com/bquorning
+[@cwilbur]: https://github.com/cwilbur
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@geniou]: https://github.com/geniou
 [@jaredbeck]: https://github.com/jaredbeck

--- a/config/default.yml
+++ b/config/default.yml
@@ -191,6 +191,8 @@ RSpec/FilePath:
     RuboCop: rubocop
     RSpec: rspec
   IgnoreMethods: false
+  SpecFileExtensions:
+  - _spec.rb
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 
 RSpec/Focus:

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1132,6 +1132,12 @@ With the configuration option `CustomTransform` modules or classes can
 be specified that should not as usual be transformed from CamelCase to
 snake_case (e.g. 'RuboCop' => 'rubocop' ).
 
+With the configuration option `SpecFileExtensions`
+alternate extensions for spec files may be specified
+as a list of strings.  The default is the
+formerly-hardcoded `[ '_spec.rb' ]`, but any string
+can be used as an extension.
+
 ### Examples
 
 ```ruby
@@ -1162,6 +1168,48 @@ my_class_spec.rb         # describe MyClass
 # good
 my_class_spec.rb         # describe MyClass, '#method'
 ```
+#### when `SpecFileExtensions` contains `.spec.rb`
+
+```ruby
+# bad
+my_class_spec.rb         # describe MyClass
+
+# good
+my_class.spec.rb         # describe MyClass
+
+# good
+my_class_method.spec.rb  # describe MyClass, '#method'
+
+# good
+my_class/method.spec.rb  # describe MyClass, '#method'
+```
+#### when `SpecFileExtensions` contains `[ '.spec.rb', _spec.rb' ]`
+
+```ruby
+# bad
+my_class_test.rb         # describe MyClass
+
+# bad
+my_class.test.rb         # describe MyClass
+
+# good
+my_class_spec.rb         # describe MyClass
+
+# good
+my_class.spec.rb         # describe MyClass
+
+# good
+my_class_method_spec.rb  # describe MyClass, '#method'
+
+# good
+my_class_method.spec.rb  # describe MyClass, '#method'
+
+# good
+my_class/method_spec.rb  # describe MyClass, '#method'
+
+# good
+my_class/method.spec.rb  # describe MyClass, '#method'
+```
 
 ### Configurable attributes
 
@@ -1169,6 +1217,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 CustomTransform | `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}` | 
 IgnoreMethods | `false` | Boolean
+SpecFileExtensions | `_spec.rb` | Array
 
 ### References
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -197,4 +197,46 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
       RUBY
     end
   end
+
+  context 'when configured with a variant SpecFileExtensions' do
+    extensions = ['.spec.rb']
+    extension_glob = '*.spec.rb'
+
+    let(:cop_config) { { 'SpecFileExtensions' => extensions } }
+
+    it 'still registers an offense for a file missing .spec' do
+      expect_offense(<<-RUBY, 'user.rb')
+        describe User do; end
+        ^^^^^^^^^^^^^ Spec path should end with `user#{extension_glob}`.
+      RUBY
+    end
+
+    it 'registers an offense for a file ending _spec.rb' do
+      expect_offense(<<-RUBY, 'user_spec.rb')
+        describe User do; end
+        ^^^^^^^^^^^^^ Spec path should end with `user#{extension_glob}`.
+      RUBY
+    end
+  end
+
+  context 'when configured with a list of SpecFileExtensions' do
+    extensions = ['_spec.rb', '.spec.rb']
+    extension_glob = '*{_spec.rb,.spec.rb}'
+    let(:cop_config) { { 'SpecFileExtensions' => extensions } }
+
+    it 'still registers an offense for a file missing _spec' do
+      expect_offense(<<-RUBY, 'user.rb')
+        describe User do; end
+        ^^^^^^^^^^^^^ Spec path should end with `user#{extension_glob}`.
+      RUBY
+    end
+
+    extensions.each do |ext|
+      it "allows the configured extension #{ext}" do
+        expect_no_offenses(<<-RUBY, 'user' + ext)
+          describe User do; end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rubocop::Rspec tries to validate that spec file names are sensibly named.  

Unfortunately, the only extension that Rubocop::Rspec recognizes for spec files is `_spec.rb`.  I've been using `.spec.rb` for a while, and it irked me that there was no configuration option to allow alternate extensions.  So I created one.

I altered the cop `RSpec/FilePath`, adding a configuration field `SpecFileExtensions` that should contain an array of strings. These are treated as literal strings, with file-glob metacharacters escaped, and joined using the `{opt_one,opt_two,opt_three}` syntax for file globs.

I kept the default behavior as it was before; using `.spec.rb` is something I strongly prefer but not something I necessarily want to impose upon thousands of others.  The behavior will only change if a value is provided for `SpecFileExtensions`.

* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
