### PR TITLE
Take metadata into account in `RSpec/RepeatedDescription` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `RSpec/RepeatedExampleGroupBody` cop. ([@lazycoder9][])
 * Add `RSpec/RepeatedExampleGroupDescription` cop. ([@lazycoder9][])
 * Add block name and other lines to `RSpec/ScatteredSetup` message. ([@elebow][])
+* Fix `RSpec/RepeatedDescription` to take into account example metadata. ([@lazycoder9][])
 
 ## 1.37.1 (2019-12-16)
 

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -29,6 +29,17 @@ module RuboCop
       #       end
       #     end
       #
+      #     # good
+      #     RSpec.describe User do
+      #       it 'is valid' do
+      #         # ...
+      #       end
+      #
+      #       it 'is valid', :flag do
+      #         # ...
+      #       end
+      #     end
+      #
       class RepeatedDescription < Cop
         MSG = "Don't repeat descriptions within an example group."
 
@@ -47,13 +58,17 @@ module RuboCop
           grouped_examples =
             RuboCop::RSpec::ExampleGroup.new(node)
               .examples
-              .group_by(&:doc_string)
+              .group_by { |example| example_signature(example) }
 
           grouped_examples
-            .select { |description, group| description && group.size > 1 }
+            .select { |signatures, group| signatures.any? && group.size > 1 }
             .values
             .flatten
             .map(&:definition)
+        end
+
+        def example_signature(example)
+          [example.metadata, example.doc_string]
         end
       end
     end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2526,6 +2526,17 @@ RSpec.describe User do
     # ...
   end
 end
+
+# good
+RSpec.describe User do
+  it 'is valid' do
+    # ...
+  end
+
+  it 'is valid', :flag do
+    # ...
+  end
+end
 ```
 
 ### References

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -73,4 +73,48 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
       end
     RUBY
   end
+
+  it 'does not flag examples if metadata is different' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        it 'do something' do
+          # ...
+        end
+
+        it 'do something', :flag do
+          # ...
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag examples with same metadata and different description' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        it 'do something', :flag do
+          # ...
+        end
+
+        it 'do another thing', :flag do
+          # ...
+        end
+      end
+    RUBY
+  end
+
+  it 'registers offense for repeated description and metadata' do
+    expect_offense(<<-RUBY)
+      describe 'doing x' do
+        it 'do something', :flag do
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          # ...
+        end
+
+        it 'do something', :flag do
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          # ...
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Close #873 
`RSpec/RepeatedDescription` will take metadata into account and will not flag examples like below
```ruby
it 'is valid' 
    # ...
end

it 'is valid', :flag do
    # ...
end
```


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
