### PR TITLE
RepeatedDescription detects not only string descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/RepeatedDescription` to detect descriptions with interpolation and methods. ([@lazycoder9][])
+
 ## 1.38.0 (2020-02-11)
 
 * Fix `RSpec/InstanceVariable` detection inside custom matchers. ([@pirj][])

--- a/lib/rubocop/rspec/example.rb
+++ b/lib/rubocop/rspec/example.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Wrapper for RSpec examples
     class Example < Concept
-      def_node_matcher :extract_doc_string,     '(send _ _ $str ...)'
+      def_node_matcher :extract_doc_string,     '(send _ _ $_ ...)'
       def_node_matcher :extract_metadata,       '(send _ _ _ $...)'
       def_node_matcher :extract_implementation, '(block send args $_)'
 

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -117,4 +117,48 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
       end
     RUBY
   end
+
+  it 'does not flag descriptions with different interpolated variables' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        it "does \#{x}" do
+        end
+
+        it "does \#{y}" do
+        end
+      end
+    RUBY
+  end
+
+  it 'registers offense for repeated description in same iterator' do
+    expect_offense(<<-RUBY)
+      describe 'doing x' do
+        %i[foo bar].each do |type|
+          it "does a thing \#{type}" do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          end
+
+          it "does a thing \#{type}" do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'registers offense if same method used in docstring' do
+    expect_offense(<<-RUBY)
+      describe 'doing x' do
+        it(description) do
+        ^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          # ...
+        end
+
+        it(description) do
+        ^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+          # ...
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe RuboCop::RSpec::Example do
       .to eq(s(:str, 'does x'))
   end
 
+  it 'extracts interpolated doc string' do
+    expect(example("it(\"does \#{x}\")").doc_string)
+      .to eq(s(:dstr, s(:str, 'does '), s(:begin, s(:send, nil, :x))))
+  end
+
+  it 'extracts method doc string' do
+    expect(example('it(description)').doc_string)
+      .to eq(s(:send, nil, :description))
+  end
+
   it 'returns nil for examples without doc strings' do
     expect(example('it { foo }').doc_string).to be(nil)
   end


### PR DESCRIPTION
Added to `RSpec/RepeatedDescription` cop ability to detect descriptions with interpolation and methods

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
