### PR TITLE
Remove already removed `AggregateFailuresByDefault` from default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -324,7 +324,6 @@ RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
   Max: 1
-  AggregateFailuresByDefault: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleSubjects:

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2058,7 +2058,6 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 Max | `1` | Integer
-AggregateFailuresByDefault | `false` | Boolean
 
 ### References
 


### PR DESCRIPTION
`AggregateFailuresByDefault` option of `MultipleExpectations` has been removed in #760.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).