### PR TITLE
Fix an offenses when using RuboCop 0.81.0

### DIFF
--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RuboCop
-  module Cop # rubocop:disable Style/Documentation
+  module Cop
     WorkaroundCop = Cop.dup
 
     # Clone of the the normal RuboCop::Cop::Cop class so we can rewrite

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -9,7 +9,7 @@ require_relative 'rspec/factory_bot/factory_class_name'
 
 begin
   require_relative 'rspec/rails/http_status'
-rescue LoadError # rubocop:disable Lint/SuppressedException
+rescue LoadError
   # Rails/HttpStatus cannot be loaded if rack/utils is unavailable.
 end
 


### PR DESCRIPTION
RuboCop 0.81 has been released.
https://github.com/rubocop-hq/rubocop/releases/tag/v0.81.0

This PR fixes the following offenses when using RuboCop 0.81.0.

```console
% cd path/to/rubocop-rspec
% bundle exec rake internal_investigation
(snip)

Offenses:

lib/rubocop/cop/rspec/cop.rb:4:14: W: Lint/RedundantCopDisableDirective:
Unnecessary disabling of Style/Documentation.
module Cop # rubocop:disable Style/Documentation
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec_cops.rb:12:18: W: Lint/RedundantCopDisableDirective:
Unnecessary disabling of Lint/SuppressedException.
rescue LoadError # rubocop:disable Lint/SuppressedException
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

202 files inspected, 2 offenses detected
rake aborted!
Command failed with status (1): [bundle exec rubocop --require
rubocop-rspe...]
/Users/koic/src/github.com/rubocop-hq/rubocop-rspec/Rakefile:32:in
`block in <top (required)>'
/Users/koic/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'
Tasks: TOP => internal_investigation
(See full trace by running task with --trace)
```

https://circleci.com/gh/rubocop-hq/rubocop-rspec/11350

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

