### PR TITLE
Ignore String constants by `RSpec/Describe`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Before submitting the PR make sure the following are checked:
 * [ ] Feature branch is up-to-date with `master` (if not - rebase it).
 * [ ] Squashed related commits together.
 * [ ] Added tests.
+* [ ] Updated documentation.
 * [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
 * [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
+* Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
 
 ## 1.38.1 (2020-02-15)
 
@@ -494,3 +495,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@elebow]: https://github.com/elebow
 [@eitoball]: https://github.com/eitoball
 [@aried3r]: https://github.com/aried3r
+[@AlexWayfer]: https://github.com/AlexWayfer

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -333,6 +333,11 @@ end
 
 # good
 describe TestedClass do
+  subject { described_class }
+end
+
+describe 'TestedClass::VERSION' do
+  subject { Object.const_get(self.class.description) }
 end
 
 describe "A feature example", type: :feature do

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -51,6 +51,75 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     RUBY
   end
 
+  context 'when argument is a String literal' do
+    it 'ignores class without namespace' do
+      expect_no_offenses(<<-RUBY)
+        describe 'Thing' do
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'ignores class with namespace' do
+      expect_no_offenses(<<-RUBY)
+        describe 'Some::Thing' do
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'ignores value constants' do
+      expect_no_offenses(<<-RUBY)
+        describe 'VERSION' do
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'ignores value constants with namespace' do
+      expect_no_offenses(<<-RUBY)
+        describe 'Some::VERSION' do
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'ignores top-level constants with `::` at start' do
+      expect_no_offenses(<<-RUBY)
+        describe '::Some::VERSION' do
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'checks `camelCase`' do
+      expect_offense(<<-RUBY)
+        describe 'activeRecord' do
+                 ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'checks numbers at start' do
+      expect_offense(<<-RUBY)
+        describe '2Thing' do
+                 ^^^^^^^^ The first argument to describe should be the class or module being tested.
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+
+    it 'checks empty strings' do
+      expect_offense(<<-RUBY)
+        describe '' do
+                 ^^ The first argument to describe should be the class or module being tested.
+          subject { Object.const_get(self.class.description) }
+        end
+      RUBY
+    end
+  end
+
   it 'ignores request specs' do
     expect_no_offenses(<<-RUBY)
       describe 'my new feature', type: :request do


### PR DESCRIPTION
Resolve #889 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
