### PR TITLE
Add IgnoreSharedGroups to RSpec/ExpectInHook cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
+* Add `IgnoreShardGroups` option to `RSpec/ExpectInHook` cop. ([@jonatas][])
 
 ## 1.38.1 (2020-02-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
 * Add `IgnoreShardGroups` option to `RSpec/ExpectInHook` cop. ([@jonatas][])
+* Add `IgnoreSharedGroups` option to `RSpec/ExpectInHook` cop. ([@jonatas][])
 
 ## 1.38.1 (2020-02-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
-* Add `IgnoreShardGroups` option to `RSpec/ExpectInHook` cop. ([@jonatas][])
 * Add `IgnoreSharedGroups` option to `RSpec/ExpectInHook` cop. ([@jonatas][])
 
 ## 1.38.1 (2020-02-15)

--- a/config/default.yml
+++ b/config/default.yml
@@ -177,6 +177,7 @@ RSpec/ExpectChange:
 RSpec/ExpectInHook:
   Enabled: true
   Description: Do not use `expect` in hooks such as `before`.
+  IgnoreSharedGroups: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
 
 RSpec/ExpectOutput:

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -5,6 +5,9 @@ module RuboCop
     module RSpec
       # Do not use `expect` in hooks such as `before`.
       #
+      # With `IgnoreSharedGroups` the cop will ignore expectations in hooks
+      # directly in shared groups.
+      #
       # @example
       #   # bad
       #   before do

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -36,8 +36,8 @@ module RuboCop
 
         def on_block(node)
           return unless hook?(node)
-          return if node.body.nil?
-          return if ignore_shared_groups? && nested_in_shared_group?(node)
+          return unless node.body
+          return if ignore_shared_groups? && directly_in_shared_group?(node)
 
           expectation(node.body) do |expect|
             add_offense(expect, location: :selector,
@@ -47,8 +47,8 @@ module RuboCop
 
         private
 
-        def nested_in_shared_group?(node)
-          node.each_ancestor(:block).any?(&method(:shared_group?))
+        def directly_in_shared_group?(node)
+          shared_group?(node.each_ancestor(:block).first)
         end
 
         def ignore_shared_groups?

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -9,6 +9,8 @@ module RuboCop
 
         def_node_matcher :example_group?, ExampleGroups::ALL.block_pattern
 
+        def_node_matcher :shared_group?, SharedGroups::ALL.block_pattern
+
         def_node_matcher :example_group_with_body?, <<-PATTERN
           (block #{ExampleGroups::ALL.send_pattern} args [!nil?])
         PATTERN

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1071,6 +1071,9 @@ Enabled | No
 
 Do not use `expect` in hooks such as `before`.
 
+With `IgnoreSharedGroups` the cop will ignore expectations in hooks
+directly in shared groups.
+
 ### Examples
 
 ```ruby

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1089,6 +1089,16 @@ it do
   expect(something).to eq 'foo'
 end
 ```
+#### `IgnoreSharedGroups: true`
+
+```ruby
+# good
+shared_example 'some shared setup' do
+  after do
+    expect_any_instance_of(Something).to receive(:foo)
+  end
+end
+```
 
 ### References
 

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1100,6 +1100,12 @@ shared_example 'some shared setup' do
 end
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+IgnoreSharedGroups | `false` | Boolean
+
 ### References
 
 * [https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook](https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook)

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -82,20 +82,22 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook, :config do
 
     it 'does not accepts `expect` in `shared_examples`' do
       expect_offense(<<-RUBY)
-        shared_examples 'for shared setup' do
-          before do
-            expect(object).to receive(:message)
-            ^^^^^^ Do not use `expect` in `before` hook
-            expect_any_instance_of(something).to receive(:foo)
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
-          end
+      shared_examples 'for shared setup' do
+        before do
+          expect(object).to receive(:message)
+          ^^^^^^ Do not use `expect` in `before` hook
+          expect_any_instance_of(something).to receive(:foo)
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
         end
+      end
+        expect(object).to receive(:message)
+        expect_any_instance_of(something).to receive(:foo)
       RUBY
     end
   end
 
   context 'with config IgnoreSharedGroups set to true' do
-    let(:cop_config) { { 'IgnoreSharedGroups' => true} }
+    let(:cop_config) { { 'IgnoreSharedGroups' => true } }
 
     it 'accepts `expect` in `shared_examples`' do
       expect_no_offenses(<<-RUBY)
@@ -105,6 +107,24 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook, :config do
           expect_any_instance_of(something).to receive(:foo)
         end
       end
+      RUBY
+    end
+
+    it 'accepts `expect` in `shared_examples` on any level' do
+      expect_no_offenses(<<-RUBY)
+        shared_examples 'some shared examples' do
+          describe '#some_method' do
+            context 'in some case' do
+              after do
+                expect_any_instance_of(Something).to receive(:foo)
+              end
+
+              it 'does that' do
+                something.perform
+              end
+            end
+          end
+        end
       RUBY
     end
   end

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -80,14 +80,18 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook, :config do
   context 'with config IgnoreSharedGroups set to false' do
     let(:cop_config) { { 'IgnoreSharedGroups' => false } }
 
-    it 'does not accepts `expect` in `shared_examples`' do
+    it 'flags `expect` in shared groups' do
       expect_offense(<<-RUBY)
         shared_examples 'for shared setup' do
           before do
             expect(object).to receive(:message)
             ^^^^^^ Do not use `expect` in `before` hook
+          end
+        end
+        shared_context 'with an expectation' do
+          after(:example) do
             expect_any_instance_of(something).to receive(:foo)
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `after` hook
           end
         end
       RUBY

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -82,16 +82,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook, :config do
 
     it 'does not accepts `expect` in `shared_examples`' do
       expect_offense(<<-RUBY)
-      shared_examples 'for shared setup' do
-        before do
-          expect(object).to receive(:message)
-          ^^^^^^ Do not use `expect` in `before` hook
-          expect_any_instance_of(something).to receive(:foo)
-          ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
+        shared_examples 'for shared setup' do
+          before do
+            expect(object).to receive(:message)
+            ^^^^^^ Do not use `expect` in `before` hook
+            expect_any_instance_of(something).to receive(:foo)
+            ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `before` hook
+          end
         end
-      end
-        expect(object).to receive(:message)
-        expect_any_instance_of(something).to receive(:foo)
       RUBY
     end
   end
@@ -99,28 +97,25 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook, :config do
   context 'with config IgnoreSharedGroups set to true' do
     let(:cop_config) { { 'IgnoreSharedGroups' => true } }
 
-    it 'accepts `expect` in `shared_examples`' do
+    it 'ignores `expect` in hook directly in `shared_examples`' do
       expect_no_offenses(<<-RUBY)
-      shared_examples 'for shared setup' do
-        before do
-          expect(object).to receive(:message)
-          expect_any_instance_of(something).to receive(:foo)
+        shared_examples 'for shared setup' do
+          before do
+            expect(object).to receive(:message)
+            expect_any_instance_of(something).to receive(:foo)
+          end
         end
-      end
       RUBY
     end
 
-    it 'accepts `expect` in `shared_examples` on any level' do
-      expect_no_offenses(<<-RUBY)
+    it 'flags `expect` in `shared_examples` inside an example group' do
+      expect_offense(<<-RUBY)
         shared_examples 'some shared examples' do
           describe '#some_method' do
             context 'in some case' do
               after do
                 expect_any_instance_of(Something).to receive(:foo)
-              end
-
-              it 'does that' do
-                something.perform
+                ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `after` hook
               end
             end
           end


### PR DESCRIPTION
Added this small option for shared examples, since we don't have a proper syntax to cover shared hooks that have mocks and stubs.

They seem quite useful, I'm not sure if that is true for the entire community. Anyway, it would be great if we have some better syntax in the RSpec to allow set some previous expectations about method calls.

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* (n/a) Added the new cop to `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
