### PR TITLE
[WIP] catch RSpec/ExpectInHook offenses in the setup block

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,8 @@ AllCops:
     Patterns:
     - _spec.rb
     - "(?:^|/)spec/"
+    CustomHooks:
+      - custom_hook
   RSpec/FactoryBot:
     Patterns:
     - spec/factories.rb

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -83,7 +83,7 @@ module RuboCop
       end
 
       module Hooks
-        ALL = SelectorSet.new(
+        BUILTIN = SelectorSet.new(
           %i[
             prepend_before
             before
@@ -92,8 +92,14 @@ module RuboCop
             prepend_after
             after
             append_after
+            setup
           ]
         )
+
+        custom_hooks = CONFIG.dig('AllCops', 'RSpec', 'CustomHooks') || []
+        CUSTOM = SelectorSet.new(custom_hooks.map(&:to_sym))
+
+        ALL = BUILTIN + CUSTOM
 
         module Scopes
           ALL = SelectorSet.new(

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -76,4 +76,22 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       end
     RUBY
   end
+
+  it 'adds an offense for `expect` with block in `setup` hook' do
+    expect_offense(<<-RUBY)
+      setup do
+        expect { something }.to eq('foo')
+        ^^^^^^ Do not use `expect` in `setup` hook
+      end
+    RUBY
+  end
+
+  it 'adds an offense for `expect` with block in custom `custom_hook` hook' do
+    expect_offense(<<-RUBY)
+      custom_hook do
+        expect { something }.to eq('foo')
+        ^^^^^^ Do not use `expect` in `custom_hook` hook
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Allow catch RSpec/ExpectInHook offenses in the setup block.
Separate hooks to `BUILTIIN` and `CUSTOM`. Custom hooks will be loaded from from `AllCops/RSpec/CustomHooks`

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
