### PR TITLE
WIP: Add autocorrect to RSpec/NamedSubject cop

### DIFF
--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -59,6 +59,13 @@ module RuboCop
         def_node_search :subject_usage, '$(send nil? :subject)'
 
         def on_block(node)
+          add_offense(node) if node.parent.nil? && use_implicit_subject?(node)
+
+          RuboCop::RSpec::ExampleGroup.new(node).subjects.each do |subject|
+            next if named_subject?(subject)
+            add_offense(subject)
+          end
+
           return if !rspec_block?(node) || ignored_shared_example?(node)
 
           subject_usage(node) do |subject_node|
@@ -69,6 +76,104 @@ module RuboCop
         def ignored_shared_example?(node)
           cop_config['IgnoreSharedExamples'] &&
             node.each_ancestor(:block).any?(&method(:shared_example?))
+        end
+
+        def autocorrect(node)
+          if node.parent.nil? && use_implicit_subject?(node)
+            correct_by_adding_explicit_subject(node)
+          elsif subject_definition?(node)
+            correct_subject_definition(node)
+          else
+            correct_subject_usage(node)
+          end
+        end
+
+        private
+
+        def named_subject?(node)
+          node.send_node.arguments?
+        end
+
+        def subject_definition?(node)
+          node.type == :block
+        end
+
+        def correct_subject_definition(node)
+          lambda do |corrector|
+            name = subject_name(node.ancestors.last)
+            next unless name
+
+            repacement = "subject(:#{name})"
+            corrector.replace(node.send_node.loc.selector, repacement)
+          end
+        end
+
+        def correct_by_adding_explicit_subject(node)
+          lambda do |corrector|
+            name = subject_name(node)
+            next unless name
+
+            top_block = node.children[2]
+            next unless top_block
+
+            repacement = "\n  subject(:#{name}) { described_class.new }\n"
+            corrector.insert_after(
+              top_block.loc.expression,
+              repacement
+            )
+          end
+        end
+
+        def correct_subject_usage(node)
+          lambda do |corrector|
+            name = find_subject_usage_name(node)
+            next unless name
+
+            corrector.replace(node.loc.selector, name)
+          end
+        end
+
+        def find_subject_usage_name(node)
+          node.each_ancestor do |ancestor|
+            return subject_name(ancestor) if ancestor.parent.nil?
+
+            RuboCop::RSpec::ExampleGroup.new(ancestor).subjects.each do |subject|
+              if named_subject?(subject)
+                subject_name = subject.send_node.arguments.first.source
+                usage_name = subject_name.dup.tap {|s| s[0] = '' } # remove first ':' character
+                return usage_name
+              end
+            end
+          end
+
+          nil
+        end
+
+        def subject_name(node)
+          top_call = node.node_parts.first
+          top_call_first_arg = top_call.arguments.first
+          return if top_call_first_arg.nil?
+
+          klass_name_with_namespace = top_call_first_arg.source
+          klass_name = klass_name_with_namespace.split('::').last
+          underscore(klass_name).downcase
+        end
+
+        def underscore(camel_cased_word)
+          return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+          word = camel_cased_word.to_s.gsub("::", "/")
+          word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+          word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+          word.tr!("-", "_")
+          word.downcase!
+          word
+        end
+
+        def use_implicit_subject?(node)
+          return false if RuboCop::RSpec::ExampleGroup.new(node).subjects.any?
+          return true if subject_usage(node)
+
+          node.children.any? { |child| use_implicit_subject?(child) }
         end
       end
     end

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -3,11 +3,56 @@
 RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
   subject(:cop) { described_class.new(config) }
 
+  it 'adds subject if it used without definition' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Admin::User do
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Name your test subject if you need to reference it explicitly.
+        specify do
+          expect(subject).to validate_presence_of(:login)
+                 ^^^^^^^ Name your test subject if you need to reference it explicitly.
+        end
+
+        describe '#mark_as_synced!' do
+          subject { create(:admin_user) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Name your test subject if you need to reference it explicitly.
+
+          specify do
+            expect(subject.confirmed_at).to eq(nil)
+                   ^^^^^^^ Name your test subject if you need to reference it explicitly.
+            expect { subject.confirm! }.to change { subject.confirmed_at }.from(nil)
+                     ^^^^^^^ Name your test subject if you need to reference it explicitly.
+                                                    ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Admin::User do
+        specify do
+          expect(user).to validate_presence_of(:login)
+        end
+
+        describe '#mark_as_synced!' do
+          subject(:user) { create(:admin_user) }
+
+          specify do
+            expect(user.confirmed_at).to eq(nil)
+            expect { user.confirm! }.to change { user.confirmed_at }.from(nil)
+          end
+        end
+  subject(:user) { described_class }
+
+      end
+    RUBY
+  end
+
   shared_examples_for 'checking subject outside of shared examples' do
     it 'checks `it` and `specify` for explicit subject usage' do
       expect_offense(<<-RUBY)
         RSpec.describe User do
           subject { described_class.new }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Name your test subject if you need to reference it explicitly.
 
           it "is valid" do
             expect(subject.valid?).to be(true)
@@ -20,12 +65,27 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
           end
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          subject(:user) { described_class.new }
+
+          it "is valid" do
+            expect(user.valid?).to be(true)
+          end
+
+          specify do
+            expect(user.valid?).to be(true)
+          end
+        end
+      RUBY
     end
 
     it 'checks before and after for explicit subject usage' do
       expect_offense(<<-RUBY)
         RSpec.describe User do
           subject { described_class.new }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Name your test subject if you need to reference it explicitly.
 
           before(:each) do
             do_something_with(subject)
@@ -38,16 +98,41 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
           end
         end
       RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          subject(:user) { described_class.new }
+
+          before(:each) do
+            do_something_with(user)
+          end
+
+          after do
+            do_something_with(user)
+          end
+        end
+      RUBY
     end
 
     it 'checks around(:each) for explicit subject usage' do
       expect_offense(<<-RUBY)
         RSpec.describe User do
           subject { described_class.new }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Name your test subject if you need to reference it explicitly.
 
           around(:each) do |test|
             do_something_with(subject)
                               ^^^^^^^ Name your test subject if you need to reference it explicitly.
+          end
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          subject(:user) { described_class.new }
+
+          around(:each) do |test|
+            do_something_with(user)
           end
         end
       RUBY
@@ -86,6 +171,26 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
             it "is new" do
               expect(subject).to be_new_record
                      ^^^^^^^ Name your test subject if you need to reference it explicitly.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          subject(:new_user) { described_class.new }
+
+          shared_examples_for 'a valid new user' do
+            it "is a User" do
+              expect(new_user).to be_a(User)
+            end
+
+            it "is valid" do
+              expect(new_user.valid?).to be(true)
+            end
+
+            it "is new" do
+              expect(new_user).to be_new_record
             end
           end
         end


### PR DESCRIPTION
I'm working on autocorrect for `RSpec/NamedSubject` cop

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* (n/a) Added the new cop to `config/default.yml`.
* (n/a) The cop documents examples of good and bad code.
* (n/a) The tests assert both that bad code is reported and that good code is not reported.
