### PR TITLE
Replace `should`-example with `expect`-example

### DIFF
--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -6,11 +6,11 @@ module RuboCop
       # Checks for explicitly referenced test subjects.
       #
       # RSpec lets you declare an "implicit subject" using `subject { ... }`
-      # which allows for tests like `it { should be_valid }`. If you need to
-      # reference your test subject you should explicitly name it using
-      # `subject(:your_subject_name) { ... }`. Your test subjects should be
-      # the most important object in your tests so they deserve a descriptive
-      # name.
+      # which allows for tests like `it { is_expected.to be_valid }`.
+      # If you need to reference your test subject you should explicitly
+      # name it using `subject(:your_subject_name) { ... }`. Your test subjects
+      # should be the most important object in your tests so they deserve
+      # a descriptive name.
       #
       # This cop can be configured in your configuration using the
       # `IgnoreSharedExamples` which will not report offenses for implicit
@@ -39,7 +39,7 @@ module RuboCop
       #   RSpec.describe Foo do
       #     subject(:user) { described_class.new }
       #
-      #     it { should be_valid }
+      #     it { is_expected.to be_valid }
       #   end
       class NamedSubject < Cop
         MSG = 'Name your test subject if you need '\

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2120,11 +2120,11 @@ Enabled | No
 Checks for explicitly referenced test subjects.
 
 RSpec lets you declare an "implicit subject" using `subject { ... }`
-which allows for tests like `it { should be_valid }`. If you need to
-reference your test subject you should explicitly name it using
-`subject(:your_subject_name) { ... }`. Your test subjects should be
-the most important object in your tests so they deserve a descriptive
-name.
+which allows for tests like `it { is_expected.to be_valid }`.
+If you need to reference your test subject you should explicitly
+name it using `subject(:your_subject_name) { ... }`. Your test subjects
+should be the most important object in your tests so they deserve
+a descriptive name.
 
 This cop can be configured in your configuration using the
 `IgnoreSharedExamples` which will not report offenses for implicit
@@ -2155,7 +2155,7 @@ end
 RSpec.describe Foo do
   subject(:user) { described_class.new }
 
-  it { should be_valid }
+  it { is_expected.to be_valid }
 end
 ```
 


### PR DESCRIPTION
In the docs for `RSpec/NamedSubject` we use `should`-style example as a good one. Since `expect`-style is a modern and enforced one, I guess it would be more correct to use `expect`-style examples.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).