### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,16 +21,6 @@ jobs:
       - run: bundle install
       - run: rake confirm_config documentation_syntax_check confirm_documentation
 
-  # Ruby 2.3
-  ruby-2.3-rspec:
-    docker:
-      - image: circleci/ruby:2.3
-    <<: *rspec
-  ruby-2.3-rubocop:
-    docker:
-      - image: circleci/ruby:2.3
-    <<: *rubocop
-
   # Ruby 2.4
   ruby-2.4-rspec:
     docker:
@@ -128,10 +118,6 @@ workflows:
       - confirm_config_and_documentation
 
       # Use `requires: [confirm_config_and_documentation]` to trick Circle CI into starting the slow jruby job early.
-      - ruby-2.3-rspec:
-          requires: [confirm_config_and_documentation]
-      - ruby-2.3-rubocop:
-          requires: [confirm_config_and_documentation]
       - ruby-2.4-rspec:
           requires: [confirm_config_and_documentation]
       - ruby-2.4-rubocop:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
+* Drop support for ruby 2.3. ([@bquorning][])
 
 ## 1.38.1 (2020-02-15)
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.3.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[


### PR DESCRIPTION
Ruby 2.3 has been EOL’ed for a while, and RuboCop recently merged in a PR to drop Ruby 2.3 support. I don’t think it makes sense for RuboCop-RSpec to support Ruby 2.3 now.

See https://github.com/rubocop-hq/rubocop/pull/7869 (and last year’s https://github.com/rubocop-hq/rubocop-rspec/pull/764)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).