### PR TITLE
Fix RuboCop builds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -21,7 +21,14 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.3.0'
+
+  # RuboCop RSpec does require Ruby 2.3+ to run. In development and on CI,
+  # RuboCop RSpec flexibly depends on RuboCop, with a minimum version of
+  # 0.68. RuboCop only supports Ruby 2.4+ as a TargetRubyVersion starting
+  # from version 0.82, while its version 0.68 does support Ruby 2.3. We
+  # keep support for codebases that use Ruby 2.3 and RuboCop pre-0.82.
+  spec.required_ruby_version =
+    '>= 2.3.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.require_paths = ['lib']
   spec.files = Dir[


### PR DESCRIPTION
Bump TargetRubyVersion to 2.4 as latest RuboCop version, 0.82, dropped support for 2.3 in TargetRubyVersion.

RuboCop has updated its lowest supported Ruby version syntax to 2.4 in version 0.82, and our builds pick the most recent release on CI, and this was failing all RuboCop checks.

    Gemspec/RequiredRubyVersion: required_ruby_version (2.3, declared in rubocop-rspec.gemspec) and TargetRubyVersion (2.4, which may be specified in .rubocop.yml) should be equal.

No, it shouldn't be equal. We're an extension that has support for earlier RuboCop versions and thus earlier Ruby versions.
---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).