### PR TITLE
Scattered let autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
 * Drop support for ruby 2.3. ([@bquorning][])
 * Fix multiple cops to detect `let` with proc argument. ([@tejasbubane][])
+* Add autocorrect support for `RSpec/ScatteredLet`. ([@Darhazer][])
 
 ## 1.38.1 (2020-02-15)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -416,6 +416,7 @@ RSpec/ScatteredLet:
   Description: Checks for let scattered across the example group.
   Enabled: true
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
+  VersionChanged: '1.39'
 
 RSpec/ScatteredSetup:
   Description: Checks for setup scattered across multiple hooks in an example group.

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -22,6 +22,7 @@ require_relative 'rubocop/rspec/align_let_brace'
 require_relative 'rubocop/rspec/factory_bot'
 require_relative 'rubocop/rspec/final_end_location'
 require_relative 'rubocop/rspec/blank_line_separation'
+require_relative 'rubocop/rspec/corrector/move_node'
 
 RuboCop::RSpec::Inject.defaults!
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -35,6 +35,15 @@ module RuboCop
           check_let_declarations(node.body)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            first_let = find_first_let(node.parent)
+            RuboCop::RSpec::Corrector::MoveNode.new(
+              node, corrector, processed_source
+            ).move_after(first_let)
+          end
+        end
+
         private
 
         def check_let_declarations(body)
@@ -46,6 +55,10 @@ module RuboCop
 
             add_offense(node)
           end
+        end
+
+        def find_first_let(node)
+          node.children.find { |child| let?(child) }
         end
       end
     end

--- a/lib/rubocop/rspec/corrector/move_node.rb
+++ b/lib/rubocop/rspec/corrector/move_node.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module RSpec
+    module Corrector
+      # Helper methods to move a node
+      class MoveNode
+        include RuboCop::Cop::RangeHelp
+        include RuboCop::RSpec::FinalEndLocation
+
+        attr_reader :original, :corrector, :processed_source
+
+        def initialize(node, corrector, processed_source)
+          @original = node
+          @corrector = corrector
+          @processed_source = processed_source # used by RangeHelp
+        end
+
+        def move_before(other) # rubocop:disable Metrics/AbcSize
+          position = other.loc.expression
+          indent = "\n" + ' ' * other.loc.column
+
+          corrector.insert_before(position, source(original) + indent)
+          corrector.remove(node_range_with_surrounding_space(original))
+        end
+
+        def move_after(other)
+          position = final_end_location(other)
+          indent = "\n" + ' ' * other.loc.column
+
+          corrector.insert_after(position, indent + source(original))
+          corrector.remove(node_range_with_surrounding_space(original))
+        end
+
+        private
+
+        def source(node)
+          node_range(node).source
+        end
+
+        def node_range(node)
+          node.loc.expression.with(end_pos: final_end_location(node).end_pos)
+        end
+
+        def node_range_with_surrounding_space(node)
+          range = node_range(node)
+          range_by_whole_lines(range, include_final_newline: true)
+        end
+      end
+    end
+  end
+end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2723,7 +2723,7 @@ EnforcedStyle | `and_return` | `and_return`, `block`
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 Checks for let scattered across the example group.
 
@@ -2750,6 +2750,12 @@ describe Foo do
   let!(:baz) { 3 }
 end
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+VersionChanged | `1.39` | String
 
 ### References
 

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -7,16 +7,86 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
-        subject { User }
+        it { expect(subject.foo).to eq(a) }
         let(:b) { b }
         ^^^^^^^^^^^^^ Group all let/let! blocks in the example group together.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        it { expect(subject.foo).to eq(a) }
+      end
+    RUBY
+  end
+
+  it 'works with heredocs' do
+    expect_offense(<<-RUBY)
+      describe User do
+        let(:a) { <<-BAR }
+          hello
+          world
+        BAR
+        it { expect(subject.foo).to eq(a) }
+        let(:b) { <<-BAZ }
+        ^^^^^^^^^^^^^^^^^^ Group all let/let! blocks in the example group together.
+          again
+        BAZ
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe User do
+        let(:a) { <<-BAR }
+          hello
+          world
+        BAR
+        let(:b) { <<-BAZ }
+          again
+        BAZ
+        it { expect(subject.foo).to eq(a) }
+      end
+    RUBY
+  end
+
+  it 'flags `let` at different nesting levels' do
+    expect_offense(<<-RUBY)
+      describe User do
+        let(:a) { a }
+        it { expect(subject.foo).to eq(a) }
+
+        describe '#property' do
+          let(:c) { c }
+
+          it { expect(subject.property).to eq c }
+
+          let(:d) { d }
+          ^^^^^^^^^^^^^ Group all let/let! blocks in the example group together.
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe User do
+        let(:a) { a }
+        it { expect(subject.foo).to eq(a) }
+
+        describe '#property' do
+          let(:c) { c }
+          let(:d) { d }
+
+          it { expect(subject.property).to eq c }
+
+        end
       end
     RUBY
   end
 
   it 'doesnt flag `let!` in the middle of multiple `let`s' do
     expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
+      describe User do
         subject { User }
 
         let(:a) { a }
@@ -26,13 +96,40 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
     RUBY
   end
 
+  it 'flags scattered `let!`s' do
+    expect_offense(<<-RUBY)
+      describe User do
+        let!(:a) { a }
+        it { expect(subject.foo).to eq(a) }
+        let!(:c) { c }
+        ^^^^^^^^^^^^^^ Group all let/let! blocks in the example group together.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe User do
+        let!(:a) { a }
+        let!(:c) { c }
+        it { expect(subject.foo).to eq(a) }
+      end
+    RUBY
+  end
+
   it 'flags `let` with proc argument' do
     expect_offense(<<-RUBY)
-      RSpec.describe User do
+      describe User do
         let(:a) { a }
-        subject { User }
+        it { expect(subject.foo).to eq(a) }
         let(:user, &args[:build_user])
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Group all let/let! blocks in the example group together.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe User do
+        let(:a) { a }
+        let(:user, &args[:build_user])
+        it { expect(subject.foo).to eq(a) }
       end
     RUBY
   end


### PR DESCRIPTION
I realized that we don't have an autocorrect support for scattered let, but it's quite easy to do, as we already move nodes around. 

I also refactored the autocorrect part, as I had to copy/paste 3 methods one more time, and we had enough copies already.

It seems that rubocop-rspec deals with the structure much more than rubocop itself - I found only one cop there that would benefit from the new helper, that's why I left it as part of rubocop-rspec instead.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
