### PR TITLE
Use rubocop-rspec's version while generating new cop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,7 +81,14 @@ task :new_cop, [:cop] do |_task, args|
   generator.write_source
   generator.write_spec
   generator.inject_require(root_file_path: 'lib/rubocop/cop/rspec_cops.rb')
-  generator.inject_config(config_file_path: 'config/default.yml')
+  generator.inject_config(config_file_path: 'config/default.yml',
+                          version_added: bump_minor_version)
 
   puts generator.todo
+end
+
+def bump_minor_version
+  major, minor, _patch = RuboCop::RSpec::Version::STRING.split('.')
+
+  "#{major}.#{minor.succ}.0"
 end


### PR DESCRIPTION
Default rake task for creating new cop adds rubocop's version to
config file, use rubocop-rspec's version instead.

Waiting for https://github.com/rubocop-hq/rubocop/pull/7897 to be merged.