### PR TITLE
Bump version to 1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.39.0 (2020-05-01)
+
 * Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
 * Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
 * Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.38.1'
+      STRING = '1.39.0'
     end
   end
 end


### PR DESCRIPTION
Changelog since last release:

* Fix `RSpec/FilePath` detection when absolute path includes test subject. ([@eitoball][])
* Add new `Capybara/VisibilityMatcher` cop. ([@aried3r][])
* Ignore String constants by `RSpec/Describe`. ([@AlexWayfer][])
* Drop support for ruby 2.3. ([@bquorning][])
* Fix multiple cops to detect `let` with proc argument. ([@tejasbubane][])
* Add autocorrect support for `RSpec/ScatteredLet`. ([@Darhazer][])
* Add new `RSpec/EmptyHook` cop. ([@tejasbubane][])

[@eitoball]: https://github.com/eitoball
[@aried3r]: https://github.com/aried3r
[@AlexWayfer]: https://github.com/AlexWayfer
[@bquorning]: https://github.com/bquorning
[@tejasbubane]: https://github.com/tejasbubane
[@Darhazer]: https://github.com/Darhazer

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
