### PR TITLE
Support multiple matchers for Capybara/VisibilityMatcher cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add new `RSpec/VariableName` cop. ([@tejasbubane][])
 * Add new `RSpec/VariableDefinition` cop. ([@tejasbubane][])
+* Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])
 
 ## 1.39.0 (2020-05-01)
 
@@ -506,3 +507,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@aried3r]: https://github.com/aried3r
 [@AlexWayfer]: https://github.com/AlexWayfer
 [@tejasbubane]: https://github.com/tejasbubane
+[@twalpole]: https://github.com/twalpole

--- a/manual/cops_capybara.md
+++ b/manual/cops_capybara.md
@@ -109,18 +109,13 @@ symbol values, `:all`, `:hidden` or `:visible`.
 ```ruby
 # bad
 expect(page).to have_selector('.foo', visible: false)
-
-# bad
-expect(page).to have_selector('.foo', visible: true)
-
-# good
-expect(page).to have_selector('.foo', visible: :all)
-
-# good
-expect(page).to have_selector('.foo', visible: :hidden)
+expect(page).to have_css('.foo', visible: true)
+expect(page).to have_link('my link', visible: false)
 
 # good
 expect(page).to have_selector('.foo', visible: :visible)
+expect(page).to have_css('.foo', visible: :all)
+expect(page).to have_link('my link', visible: :hidden)
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
@@ -17,6 +17,33 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::VisibilityMatcher do
     RUBY
   end
 
+  it 'recognizes multiple matchers' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css('.profile', visible: false)
+                                           ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_xpath('.//profile', visible: false)
+                                               ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_link('news', visible: false)
+                                        ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_button('login', visible: false)
+                                           ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_field('name', visible: false)
+                                         ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_select('sauce', visible: false)
+                                           ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_table('arrivals', visible: false)
+                                             ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_checked_field('cat', visible: false)
+                                                ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_unchecked_field('cat', visible: false)
+                                                  ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_text('My homepage', visible: false)
+                                               ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_content('Success', visible: false)
+                                              ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+    RUBY
+  end
+
   it 'registers an offense when using a selector`' do
     expect_offense(<<-RUBY)
       expect(page).to have_selector(:css, '.my_element', visible: false)


### PR DESCRIPTION
Expand the Capybara/VisibilityMatcher cop to match all relevant Capybara matcher methods rather than just `have_selector`

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).