### PR TITLE
Add SpecSuffixOnly option to RSpec/FilePath cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add new `RSpec/VariableName` cop. ([@tejasbubane][])
 * Add new `RSpec/VariableDefinition` cop. ([@tejasbubane][])
 * Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])
+* Add new `SpecSuffixOnly` option to `RSpec/FilePath` cop. ([@zdennis][])
 
 ## 1.39.0 (2020-05-01)
 
@@ -508,3 +509,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@AlexWayfer]: https://github.com/AlexWayfer
 [@tejasbubane]: https://github.com/tejasbubane
 [@twalpole]: https://github.com/twalpole
+[@zdennis]: https://github.com/zdennis

--- a/config/default.yml
+++ b/config/default.yml
@@ -191,12 +191,13 @@ RSpec/ExpectOutput:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
 
 RSpec/FilePath:
-  Description: Checks that spec file paths are consistent with the test subject.
+  Description: Checks that spec file paths are consistent and well-formed.
   Enabled: true
   CustomTransform:
     RuboCop: rubocop
     RSpec: rspec
   IgnoreMethods: false
+  SpecSuffixOnly: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 
 RSpec/Focus:

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -3,10 +3,11 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks that spec file paths are consistent with the test subject.
+      # Checks that spec file paths are consistent and well-formed.
       #
-      # Checks the path of the spec file and enforces that it reflects the
-      # described class/module and its optionally called out method.
+      # By default, this checks that spec file paths are consistent with the
+      # test subject and and enforces that it reflects the described
+      # class/module and its optionally called out method.
       #
       # With the configuration option `IgnoreMethods` the called out method will
       # be ignored when determining the enforced path.
@@ -14,6 +15,10 @@ module RuboCop
       # With the configuration option `CustomTransform` modules or classes can
       # be specified that should not as usual be transformed from CamelCase to
       # snake_case (e.g. 'RuboCop' => 'rubocop' ).
+      #
+      # With the configuration option `SpecSuffixOnly` test files will only
+      # be checked to ensure they end in '_spec.rb'. This option disables
+      # checking for consistency in the test subject or test methods.
       #
       # @example
       #   # bad
@@ -33,6 +38,16 @@ module RuboCop
       #
       # @example when configuration is `IgnoreMethods: true`
       #   # bad
+      #   whatever_spec.rb         # describe MyClass
+      #
+      #   # good
+      #   my_class_spec.rb         # describe MyClass
+      #
+      #   # good
+      #   my_class_spec.rb         # describe MyClass, '#method'
+      #
+      # @example when configuration is `SpecSuffixOnly: true`
+      #   # good
       #   whatever_spec.rb         # describe MyClass
       #
       #   # good
@@ -70,7 +85,13 @@ module RuboCop
         end
 
         def glob_for((described_class, method_name))
+          return glob_for_spec_suffix_only? if spec_suffix_only?
+
           "#{expected_path(described_class)}#{name_glob(method_name)}*_spec.rb"
+        end
+
+        def glob_for_spec_suffix_only?
+          '*_spec.rb'
         end
 
         def name_glob(name)
@@ -110,6 +131,10 @@ module RuboCop
 
         def relevant_rubocop_rspec_file?(_file)
           true
+        end
+
+        def spec_suffix_only?
+          cop_config['SpecSuffixOnly']
         end
       end
     end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1164,10 +1164,11 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-Checks that spec file paths are consistent with the test subject.
+Checks that spec file paths are consistent and well-formed.
 
-Checks the path of the spec file and enforces that it reflects the
-described class/module and its optionally called out method.
+By default, this checks that spec file paths are consistent with the
+test subject and and enforces that it reflects the described
+class/module and its optionally called out method.
 
 With the configuration option `IgnoreMethods` the called out method will
 be ignored when determining the enforced path.
@@ -1175,6 +1176,10 @@ be ignored when determining the enforced path.
 With the configuration option `CustomTransform` modules or classes can
 be specified that should not as usual be transformed from CamelCase to
 snake_case (e.g. 'RuboCop' => 'rubocop' ).
+
+With the configuration option `SpecSuffixOnly` test files will only
+be checked to ensure they end in '_spec.rb'. This option disables
+checking for consistency in the test subject or test methods.
 
 ### Examples
 
@@ -1206,6 +1211,18 @@ my_class_spec.rb         # describe MyClass
 # good
 my_class_spec.rb         # describe MyClass, '#method'
 ```
+#### when configuration is `SpecSuffixOnly: true`
+
+```ruby
+# good
+whatever_spec.rb         # describe MyClass
+
+# good
+my_class_spec.rb         # describe MyClass
+
+# good
+my_class_spec.rb         # describe MyClass, '#method'
+```
 
 ### Configurable attributes
 
@@ -1213,6 +1230,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 CustomTransform | `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}` | 
 IgnoreMethods | `false` | Boolean
+SpecSuffixOnly | `false` | Boolean
 
 ### References
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -206,4 +206,21 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
       RUBY
     end
   end
+
+  context 'when configured with SpecSuffixOnly' do
+    let(:cop_config) { { 'SpecSuffixOnly' => true } }
+
+    it 'does not care about the described class' do
+      expect_no_offenses(<<-RUBY, 'whatever_spec.rb')
+        describe MyClass do; end
+      RUBY
+    end
+
+    it 'registers an offense when _spec.rb suffix is missing' do
+      expect_offense(<<-RUBY, 'whatever.rb')
+        describe MyClass do; end
+        ^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Add `SpecSuffixOnly` option to `RSpec/FilePath` cop which ensures spec files end with the minimal "_spec.rb" suffix only. This allows the cop to only find offenses on test files that do not have the "_spec.rb".

### Why this is useful

We want to use this cop to help ensure that all spec files have `_spec.rb` endings, but we don't want to conform to the opinion that all spec files need to be based on the class/module name being described. 

This helps prevent tests from getting missed which can happen with cross-functional teams where it can be easy for folks who touch multiple languages and tools to accidentally type in different filename suffixes common in other languages/tools. This change helps guard these files being named incorrectly and not being run by the test suite or CI.


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

