### PR TITLE
Fix specs for code transparently fixed with RuboCop 0.84 update

### DIFF
--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'flags violations for `background`' do
     expect_offense(<<-RUBY)
       describe 'some feature' do

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) { { 'EnabledMethods' => [] } }
-
   it 'flags violations for `background`' do
     expect_offense(<<-RUBY)
       describe 'some feature' do

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Prefixes' => %w[when with] } }
 
   it 'skips describe blocks' do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { {} }
 
   context 'when SkipBlocks is `true`' do

--- a/spec/rubocop/cop/rspec/dialect_spec.rb
+++ b/spec/rubocop/cop/rspec/dialect_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Dialect, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     {
       'PreferredMethods' => {

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'flags an empty context' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'flags a missing empty line after `it`' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -3,8 +3,6 @@
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) { { 'AllowConsecutiveOneLiners' => true } }
-
   it 'flags a missing empty line after `it`' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) { { 'Max' => 3 } }
 
   it 'ignores non-spec blocks' do

--- a/spec/rubocop/cop/rspec/example_without_description_spec.rb
+++ b/spec/rubocop/cop/rspec/example_without_description_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
   context 'when configuration is empty' do
     include_examples 'autocorrect',
                      'it "should have trait" do end',
-                     'it "haves trait" do end'
+                     'it "has trait" do end'
 
     include_examples 'autocorrect',
                      'it "should only fail" do end',

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
   context 'with configuration' do
     let(:cop_config) do
       {
-        'CustomTransform' => { 'have' => 'has' },
-        'IgnoredWords'    => %w[only really]
+        'IgnoredWords' => %w[only really]
       }
     end
 

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -1,198 +1,180 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
-  context 'with configuration' do
-    let(:cop_config) do
-      {
-        'IgnoredWords' => %w[only really]
-      }
-    end
-
-    it 'ignores non-example blocks' do
-      expect_no_offenses('foo "should do something" do; end')
-    end
-
-    it 'finds description with `should` at the beginning' do
-      expect_offense(<<-RUBY)
-        it 'should do something' do
-            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it 'does something' do
-        end
-      RUBY
-    end
-
-    it 'finds interpolated description with `should` at the beginning' do
-      expect_offense(<<-'RUBY')
-        it "should do #{:stuff}" do
-            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-'RUBY')
-        it "does #{:stuff}" do
-        end
-      RUBY
-    end
-
-    it 'finds description with `Should` at the beginning' do
-      expect_offense(<<-RUBY)
-        it 'Should do something' do
-            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it 'does something' do
-        end
-      RUBY
-    end
-
-    it 'finds description with `shouldn\'t` at the beginning' do
-      expect_offense(<<-RUBY)
-        it "shouldn't do something" do
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it "does not do something" do
-        end
-      RUBY
-    end
-
-    it 'finds description with `SHOULDN\'T` at the beginning' do
-      expect_offense(<<-RUBY)
-        it "SHOULDN'T do something" do
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it "DOES NOT do something" do
-        end
-      RUBY
-    end
-
-    it 'flags a lone should' do
-      expect_offense(<<-RUBY)
-        it 'should' do
-            ^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it '' do
-        end
-      RUBY
-    end
-
-    it 'flags a lone should not' do
-      expect_offense(<<-RUBY)
-        it 'should not' do
-            ^^^^^^^^^^ Do not use should when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it 'does not' do
-        end
-      RUBY
-    end
-
-    it 'finds leading its' do
-      expect_offense(<<-RUBY)
-        it "it does something" do
-            ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it "does something" do
-        end
-      RUBY
-    end
-
-    it 'finds leading it in interpolated description' do
-      expect_offense(<<-'RUBY')
-        it "it does #{action}" do
-            ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
-        end
-      RUBY
-
-      expect_correction(<<-'RUBY')
-        it "does #{action}" do
-        end
-      RUBY
-    end
-
-    it "skips words beginning with 'it'" do
-      expect_no_offenses(<<-RUBY)
-        it 'itemizes items' do
-        end
-      RUBY
-    end
-
-    it 'skips descriptions without `should` at the beginning' do
-      expect_no_offenses(<<-RUBY)
-        it 'finds no should here' do
-        end
-      RUBY
-    end
-
-    it 'skips descriptions starting with words that begin with `should`' do
-      expect_no_offenses(<<-RUBY)
-        it 'shoulders the burden' do
-        end
-      RUBY
-    end
-
-    it 'skips interpolated description without literal `should` at the start' do
-      expect_no_offenses(<<-'RUBY')
-        it "#{should} not be here" do
-        end
-      RUBY
-    end
-
-    it 'flags \-separated multiline strings' do
-      expect_offense(<<-RUBY)
-        it 'should do something '\\
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-            'and correctly fix' do
-        end
-      RUBY
-
-      expect_correction(<<-RUBY)
-        it 'does something and correctly fix' do
-        end
-      RUBY
-    end
-
-    it 'flags \-separated multiline interpolated strings' do
-      expect_offense(<<-'RUBY')
-        it "should do something "\
-            ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
-            "with #{object}" do
-        end
-      RUBY
-
-      expect_correction(<<-'RUBY')
-        it "does something with #{object}" do
-        end
-      RUBY
-    end
+  it 'ignores non-example blocks' do
+    expect_no_offenses('foo "should do something" do; end')
   end
 
-  context 'when configuration is empty' do
-    include_examples 'autocorrect',
-                     'it "should have trait" do end',
-                     'it "has trait" do end'
+  it 'finds description with `should` at the beginning' do
+    expect_offense(<<-RUBY)
+      it 'should do something' do
+          ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
 
-    include_examples 'autocorrect',
-                     'it "should only fail" do end',
-                     'it "onlies fail" do end'
+    expect_correction(<<-RUBY)
+      it 'does something' do
+      end
+    RUBY
+  end
+
+  it 'finds interpolated description with `should` at the beginning' do
+    expect_offense(<<-'RUBY')
+      it "should do #{:stuff}" do
+          ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-'RUBY')
+      it "does #{:stuff}" do
+      end
+    RUBY
+  end
+
+  it 'finds description with `Should` at the beginning' do
+    expect_offense(<<-RUBY)
+      it 'Should do something' do
+          ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it 'does something' do
+      end
+    RUBY
+  end
+
+  it 'finds description with `shouldn\'t` at the beginning' do
+    expect_offense(<<-RUBY)
+      it "shouldn't do something" do
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it "does not do something" do
+      end
+    RUBY
+  end
+
+  it 'finds description with `SHOULDN\'T` at the beginning' do
+    expect_offense(<<-RUBY)
+      it "SHOULDN'T do something" do
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it "DOES NOT do something" do
+      end
+    RUBY
+  end
+
+  it 'flags a lone should' do
+    expect_offense(<<-RUBY)
+      it 'should' do
+          ^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it '' do
+      end
+    RUBY
+  end
+
+  it 'flags a lone should not' do
+    expect_offense(<<-RUBY)
+      it 'should not' do
+          ^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it 'does not' do
+      end
+    RUBY
+  end
+
+  it 'finds leading its' do
+    expect_offense(<<-RUBY)
+      it "it does something" do
+          ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it "does something" do
+      end
+    RUBY
+  end
+
+  it 'finds leading it in interpolated description' do
+    expect_offense(<<-'RUBY')
+      it "it does #{action}" do
+          ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<-'RUBY')
+      it "does #{action}" do
+      end
+    RUBY
+  end
+
+  it "skips words beginning with 'it'" do
+    expect_no_offenses(<<-RUBY)
+      it 'itemizes items' do
+      end
+    RUBY
+  end
+
+  it 'skips descriptions without `should` at the beginning' do
+    expect_no_offenses(<<-RUBY)
+      it 'finds no should here' do
+      end
+    RUBY
+  end
+
+  it 'skips descriptions starting with words that begin with `should`' do
+    expect_no_offenses(<<-RUBY)
+      it 'shoulders the burden' do
+      end
+    RUBY
+  end
+
+  it 'skips interpolated description without literal `should` at the start' do
+    expect_no_offenses(<<-'RUBY')
+      it "#{should} not be here" do
+      end
+    RUBY
+  end
+
+  it 'flags \-separated multiline strings' do
+    expect_offense(<<-RUBY)
+      it 'should do something '\\
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+          'and correctly fix' do
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it 'does something and correctly fix' do
+      end
+    RUBY
+  end
+
+  it 'flags \-separated multiline interpolated strings' do
+    expect_offense(<<-'RUBY')
+      it "should do something "\
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+          "with #{object}" do
+      end
+    RUBY
+
+    expect_correction(<<-'RUBY')
+      it "does something with #{object}" do
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'with configuration' do
     let(:cop_config) do
       {

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'flags numeric literal values within expect(...)' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'registers an offense for a bad path' do
     expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
       describe MyClass, 'foo' do; end

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is is_expected' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'is_expected' }

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -131,8 +131,6 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   context 'when configured with AssignmentOnly', :config do
-    subject(:cop) { described_class.new(config) }
-
     let(:cop_config) do
       { 'AssignmentOnly' => true }
     end

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/message_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/message_expectation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MessageExpectation, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is allow' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'allow' }

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is have_received' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'have_received' }

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'without configuration' do
     let(:cop_config) { {} }
 

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
-  subject(:cop) { described_class.new(config) }
-
   shared_examples_for 'checking subject outside of shared examples' do
     it 'checks `it` and `specify` for explicit subject usage' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'flags nested contexts' do
     expect_offense(<<-RUBY)
       describe MyClass do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is `not_to`' do
     let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style,
       'Strict' => strict,

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is `symbolic`' do
     let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
-  subject(:cop) { described_class.new(config) }
-
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/variable_definition_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_definition_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::VariableDefinition, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when EnforcedStyle is `symbols`' do
     let(:cop_config) { { 'EnforcedStyle' => 'symbols' } }
 

--- a/spec/rubocop/cop/rspec/variable_name_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::VariableName, :config do
-  subject(:cop) { described_class.new(config) }
-
   context 'when configured for `snake_case`' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -55,25 +55,25 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
     end
   end
 
-  it 'doubles that have no name specified' do
-    expect_offense(<<-RUBY)
-      it do
-        foo = double
-              ^^^^^^ Prefer using verifying doubles over normal doubles.
-      end
-    RUBY
-  end
+  context 'when configured not to ignore nameless doubles' do
+    let(:cop_config) { { 'IgnoreNameless' => false } }
 
-  context 'when configured to ignore nameless doubles' do
-    let(:cop_config) { { 'IgnoreNameless' => true } }
-
-    it 'ignores doubles that have no name specified' do
-      expect_no_offenses(<<-RUBY)
+    it 'flags doubles that have no name specified' do
+      expect_offense(<<-RUBY)
         it do
           foo = double
+                ^^^^^^ Prefer using verifying doubles over normal doubles.
         end
       RUBY
     end
+  end
+
+  it 'ignores doubles that have no name specified' do
+    expect_no_offenses(<<-RUBY)
+      it do
+        foo = double
+      end
+    RUBY
   end
 
   it 'ignores instance_doubles' do

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
-  subject(:cop) { described_class.new(config) }
-
   it 'finds a `double` instead of an `instance_double`' do
     expect_offense(<<-RUBY)
       it do


### PR DESCRIPTION
It seems that RuboCop comes with certain fixes that improve how RuboCop RSpec itself works!

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).