### PR TITLE
Cleanup workaround

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -9,9 +9,15 @@ require 'rubocop-rspec'
 require 'rubocop/rspec/description_extractor'
 require 'rubocop/rspec/config_formatter'
 
-glob = File.join(__dir__, '..', 'lib', 'rubocop', 'cop', 'rspec',
+glob = File.join('lib', 'rubocop', 'cop', 'rspec',
                  '{,capybara,factory_bot,rails}', '*.rb')
-YARD.parse(Dir[glob], [])
+# Due to YARD's sensitivity to file require order (as of 0.9.25),
+# we have to prepend the list with our base cop, RuboCop::Cop::RSpec::Cop.
+# Otherwise, cop's parent class for cops loaded before our base cop class
+# are detected as RuboCop::Cop::Cop, and that complicates the detection
+# of their relation with RuboCop RSpec.
+rspec_cop_path = File.join('lib', 'rubocop', 'cop', 'rspec', 'cop.rb')
+YARD.parse(Dir[glob].prepend(rspec_cop_path), [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h
 current_config = YAML.load_file('config/default.yml')

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # @abstract parent class to rspec cops
+      # @abstract parent class to RSpec cops
       #
       # The criteria for whether rubocop-rspec analyzes a certain ruby file
       # is configured via `AllCops/RSpec`. For example, if you want to
@@ -11,12 +11,12 @@ module RuboCop
       # then you could add this to your configuration:
       #
       # @example configuring analyzed paths
-      #
-      #   AllCops:
-      #     RSpec:
-      #       Patterns:
-      #       - '_test.rb$'
-      #       - '(?:^|/)test/'
+      #   # .rubocop.yml
+      #   # AllCops:
+      #   #   RSpec:
+      #   #     Patterns:
+      #   #     - '_test.rb$'
+      #   #     - '(?:^|/)test/'
       class Cop < ::RuboCop::Cop::Cop
         include RuboCop::RSpec::Language
         include RuboCop::RSpec::Language::NodePattern

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -2,26 +2,6 @@
 
 module RuboCop
   module Cop
-    WorkaroundCop = Cop.dup
-
-    # Clone of the the normal RuboCop::Cop::Cop class so we can rewrite
-    # the inherited method without breaking functionality
-    class WorkaroundCop
-      # Remove the Cop.inherited method to be a noop. Our RSpec::Cop
-      # class will invoke the inherited hook instead
-      class << self
-        undef inherited
-        def inherited(*) end
-      end
-
-      # Special case `Module#<` so that the rspec support rubocop exports
-      # is compatible with our subclass
-      def self.<(other)
-        other.equal?(RuboCop::Cop::Cop) || super
-      end
-    end
-    private_constant(:WorkaroundCop)
-
     module RSpec
       # @abstract parent class to rspec cops
       #
@@ -37,7 +17,7 @@ module RuboCop
       #       Patterns:
       #       - '_test.rb$'
       #       - '(?:^|/)test/'
-      class Cop < WorkaroundCop
+      class Cop < ::RuboCop::Cop::Cop
         include RuboCop::RSpec::Language
         include RuboCop::RSpec::Language::NodePattern
 

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -21,7 +21,7 @@ module RuboCop
 
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
-        COP_CLASS_NAMES = %w[RuboCop::Cop RuboCop::Cop::RSpec::Cop].freeze
+        COP_CLASS_NAME = 'RuboCop::Cop::RSpec::Cop'
         RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'
 
         def initialize(yardoc)
@@ -68,9 +68,7 @@ module RuboCop
         end
 
         def cop_subclass?
-          # FIXME: simplify
-
-          COP_CLASS_NAMES.include?(yardoc.superclass.path)
+          yardoc.superclass.path == COP_CLASS_NAME
         end
 
         def abstract?

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -68,10 +68,8 @@ module RuboCop
         end
 
         def cop_subclass?
-          # YARD superclass resolution is a bit flaky: All classes loaded before
-          # RuboCop::Cop::WorkaroundCop are shown as having RuboCop::Cop as
-          # superclass, while all the following classes are listed as having
-          # RuboCop::Cop::RSpec::Cop as their superclass.
+          # FIXME: simplify
+
           COP_CLASS_NAMES.include?(yardoc.superclass.path)
         end
 

--- a/spec/rubocop/cop/rspec/cop_spec.rb
+++ b/spec/rubocop/cop/rspec/cop_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe RuboCop::Cop::RSpec::Cop do
   end
 
   let(:fake_cop) do
-    stub_const('RuboCop::RSpec', Module.new)
     # rubocop:disable Style/ClassAndModuleChildren
     # rubocop:disable RSpec/LeakyConstantDeclaration
     class RuboCop::RSpec::FakeCop < described_class

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -42,11 +42,19 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
     YARD::Registry.all
   end
 
+  let(:temp_class) do
+    temp = RuboCop::Cop::Cop.dup
+    temp.class_exec do
+      class << self
+        undef inherited
+        def inherited(*) end
+      end
+    end
+    temp
+  end
+
   def stub_cop_const(name)
-    stub_const(
-      "RuboCop::Cop::RSpec::#{name}",
-      Class.new(RuboCop::Cop.const_get(:WorkaroundCop))
-    )
+    stub_const("RuboCop::Cop::RSpec::#{name}", Class.new(temp_class))
   end
 
   before do


### PR DESCRIPTION
It seems that the workaround was exclusively used in the DescriptionExtractor spec.

Am I missing something?

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
* [x] ADDRESS FIXME notes