### PR TITLE
Fix `RSpec/FilePath` detection across sibling directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])
 * Add new `SpecSuffixOnly` option to `RSpec/FilePath` cop. ([@zdennis][])
 * Allow `RSpec/RepeatedExampleGroupBody` to differ only by described_class. ([@robotdana][])
+* Fix `RSpec/FilePath` detection across sibling directories. ([@rolfschmidt][])
 
 ## 1.39.0 (2020-05-01)
 
@@ -512,3 +513,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@twalpole]: https://github.com/twalpole
 [@zdennis]: https://github.com/zdennis
 [@robotdana]: https://github.com/robotdana
+[@rolfschmidt]: https://github.com/rolfschmidt

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -126,6 +126,7 @@ module RuboCop
         def filename_ends_with?(glob)
           filename =
             RuboCop::PathUtil.relative_path(processed_source.buffer.name)
+              .gsub('../', '')
           File.fnmatch?("*#{glob}", filename)
         end
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -179,6 +179,24 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'uses relative path for sibling directory project' do
+    allow(RuboCop::PathUtil)
+      .to receive(:relative_path)
+      .and_return('../ext-project/spec/models/bar_spec.rb')
+    expect_no_offenses(<<-RUBY, '/home/ext-project/spec/models/bar_spec.rb')
+      describe Bar do; end
+    RUBY
+  end
+
+  it 'uses relative path for different path project' do
+    allow(RuboCop::PathUtil)
+      .to receive(:relative_path)
+      .and_return('../../opt/ext-project/spec/models/bar_spec.rb')
+    expect_no_offenses(<<-RUBY, '/opt/ext-project/spec/models/bar_spec.rb')
+      describe Bar do; end
+    RUBY
+  end
+
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 


### PR DESCRIPTION
Hi,
i saw your pull request https://github.com/rubocop-hq/rubocop-rspec/pull/869 and we use some of our ruby projects as a kind of plugins for our main repository where we use the rubocop config from. So the relative path for the external projects seems to be wrong currently.

Would you be kind enough to take a look at it and help me to get my projects tidied :-D

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
