### PR TITLE
Allow identical body with distinct described_class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add new `RSpec/VariableDefinition` cop. ([@tejasbubane][])
 * Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])
 * Add new `SpecSuffixOnly` option to `RSpec/FilePath` cop. ([@zdennis][])
+* Allow `RSpec/RepeatedExampleGroupBody` to differ only by described_class. ([@robotdana][])
 
 ## 1.39.0 (2020-05-01)
 
@@ -510,3 +511,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@tejasbubane]: https://github.com/tejasbubane
 [@twalpole]: https://github.com/twalpole
 [@zdennis]: https://github.com/zdennis
+[@robotdana]: https://github.com/robotdana

--- a/lib/rubocop/cop/rspec/repeated_example_group_body.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_body.rb
@@ -34,6 +34,15 @@ module RuboCop
       #      it { cool_predicate }
       #    end
       #
+      #    # good
+      #    context Array do
+      #      it { is_expected.to respond_to :each }
+      #    end
+      #
+      #    context Hash do
+      #      it { is_expected.to respond_to :each }
+      #    end
+      #
       class RepeatedExampleGroupBody < Cop
         MSG = 'Repeated %<group>s block body on line(s) %<loc>s'
 
@@ -43,6 +52,7 @@ module RuboCop
 
         def_node_matcher :metadata, '(block (send _ _ _ $...) ...)'
         def_node_matcher :body, '(block _ args $...)'
+        def_node_matcher :const_arg, '(block (send _ _ $const ...) ...)'
 
         def_node_matcher :skip_or_pending?, <<-PATTERN
           (block <(send nil? {:skip :pending}) ...>)
@@ -75,7 +85,7 @@ module RuboCop
         end
 
         def signature_keys(group)
-          [metadata(group), body(group)]
+          [metadata(group), body(group), const_arg(group)]
         end
 
         def message(group, repeats)

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2665,6 +2665,15 @@ end
 context 'when case y' do
   it { cool_predicate }
 end
+
+# good
+context Array do
+  it { is_expected.to respond_to :each }
+end
+
+context Hash do
+  it { is_expected.to respond_to :each }
+end
 ```
 
 ### References

--- a/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
@@ -74,6 +74,44 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
     RUBY
   end
 
+  it 'does not register offense if module arg is different' do
+    expect_no_offenses(<<-RUBY)
+      describe CSV::Row do
+        it { is_expected.to respond_to :headers }
+      end
+
+      describe CSV::Table do
+        it { is_expected.to respond_to :headers }
+      end
+    RUBY
+  end
+
+  it 'does not register offense when module arg namespace is different' do
+    expect_no_offenses(<<-RUBY)
+      describe CSV::Parser do
+        it { expect(described_class).to respond_to(:parse) }
+      end
+
+      describe URI::Parser do
+        it { expect(described_class).to respond_to(:parse) }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for when module arg and namespace are identical' do
+    expect_offense(<<-RUBY)
+      context Net::HTTP do
+      ^^^^^^^^^^^^^^^^^^^^ Repeated context block body on line(s) [5]
+        it { expect(described_class).to respond_to :start }
+      end
+
+      context Net::HTTP do
+      ^^^^^^^^^^^^^^^^^^^^ Repeated context block body on line(s) [1]
+        it { expect(described_class).to respond_to :start }
+      end
+    RUBY
+  end
+
   it 'does not register offense with several docstring' do
     expect_no_offenses(<<-RUBY)
       describe 'doing x', :json, 'request' do


### PR DESCRIPTION
const args are used for described_class and thus are part of the
'metadata' of an example.

```
describe Array do
  it_behaves_like 'list'
end

describe Set do
  it_behaves_like 'list'
end
```

should not be considered duplicate tests

i wasn't sure how to extract the constant with all its namespaces
as a list of symbols, so i just grab the whole constant node

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).