### PR TITLE
RSpec/SubjectStub. Refactor and decrease complexity

### DIFF
--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -22,6 +22,8 @@ module RuboCop
       #   end
       #
       class SubjectStub < Cop
+        include RuboCop::RSpec::TopLevelDescribe
+
         MSG = 'Do not stub methods of the object under test.'
 
         # @!method subject(node)
@@ -75,23 +77,15 @@ module RuboCop
             } ...)
         PATTERN
 
-        def on_block(node)
-          return unless example_group?(node)
-          return unless (processed_example_groups & node.ancestors).empty?
+        def on_top_level_describe(node, _args)
+          @explicit_subjects = find_all_explicit_subjects(node.parent)
 
-          processed_example_groups << node
-          @explicit_subjects = find_all_explicit_subjects(node)
-
-          find_subject_expectations(node) do |stub|
+          find_subject_expectations(node.parent) do |stub|
             add_offense(stub)
           end
         end
 
         private
-
-        def processed_example_groups
-          @processed_example_groups ||= Set.new
-        end
 
         def find_all_explicit_subjects(node)
           node.each_descendant(:block).each_with_object({}) do |child, h|

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -102,14 +102,10 @@ module RuboCop
         end
 
         def find_all_named_subjects(node)
-          named_subjects = {}
-
-          node.each_descendant(:block) do |child|
+          node.each_descendant(:block).each_with_object({}) do |child, h|
             name = subject(child)
-            named_subjects[child.parent.parent] = name if name
+            h[child.parent.parent] = name if name
           end
-
-          named_subjects
         end
 
         def find_subject_expectations(node, subject_name = nil, &block)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -96,17 +96,19 @@ module RuboCop
         def find_all_explicit_subjects(node)
           node.each_descendant(:block).each_with_object({}) do |child, h|
             name = subject(child)
-            if name
-              h[child.parent.parent] ||= []
-              h[child.parent.parent] << name
+            next unless name
+
+            outer_example_group = child.each_ancestor.find do |a|
+              example_group?(a)
             end
+
+            h[outer_example_group] ||= []
+            h[outer_example_group] << name
           end
         end
 
         def find_subject_expectations(node, subject_names = [], &block)
-          if example_group?(node) && @explicit_subjects[node]
-            subject_names = @explicit_subjects[node]
-          end
+          subject_names = @explicit_subjects[node] if @explicit_subjects[node]
 
           expectation_detected = (subject_names + [:subject]).any? do |name|
             message_expectation?(node, name)

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module RuboCop
   module Cop
     module RSpec
@@ -74,71 +76,58 @@ module RuboCop
         PATTERN
 
         def on_block(node)
+          # process only describe/context/... example groups
           return unless example_group?(node)
 
-          find_subject_stub(node) do |stub|
+          # skip already processed example group
+          # it's processed if is nested in one of the processed example groups
+          return unless (processed_example_groups & node.ancestors).empty?
+
+          # add example group to already processed
+          processed_example_groups << node
+
+          # find all custom subjects e.g. subject(:foo) { ... }
+          @named_subjects = find_all_named_subjects(node)
+
+          # look for method expectation matcher
+          find_subject_expectations(node) do |stub|
             add_offense(stub)
           end
         end
 
         private
 
-        # Find subjects within tree and then find (send) nodes for that subject
-        #
-        # @param node [RuboCop::Node] example group
-        #
-        # @yield [RuboCop::Node] message expectations for subject
-        def find_subject_stub(node, &block)
-          find_subject(node) do |subject_name, context|
-            find_subject_expectation(context, subject_name, &block)
-          end
+        def processed_example_groups
+          @processed_example_groups ||= Set[]
         end
 
-        # Find a subject message expectation
-        #
-        # @param node [RuboCop::Node]
-        # @param subject_name [Symbol] name of subject
-        #
-        # @yield [RuboCop::Node] message expectation
-        def find_subject_expectation(node, subject_name, &block)
-          # Do not search node if it is an example group with its own subject.
-          return if example_group?(node) && redefines_subject?(node)
+        def find_all_named_subjects(node)
+          named_subjects = {}
 
-          # Yield the current node if it is a message expectation.
-          yield(node) if message_expectation?(node, subject_name)
+          node.each_descendant(:block) do |child|
+            name = subject(child)
+            named_subjects[child.parent.parent] = name if name
+          end
+
+          named_subjects
+        end
+
+        def find_subject_expectations(node, subject_name = nil, &block)
+          # if it's a new example group - check whether new named subject is
+          # defined there
+          if example_group?(node)
+            subject_name = @named_subjects[node] || subject_name
+          end
+
+          # check default :subject and then named one (if it's present)
+          expectation_detected = message_expectation?(node, :subject) || \
+            (subject_name && message_expectation?(node, subject_name))
+
+          return yield(node) if expectation_detected
 
           # Recurse through node's children looking for a message expectation.
           node.each_child_node do |child|
-            find_subject_expectation(child, subject_name, &block)
-          end
-        end
-
-        # Check if node's children contain a subject definition
-        #
-        # @param node [RuboCop::Node]
-        #
-        # @return [Boolean]
-        def redefines_subject?(node)
-          node.each_child_node.any? do |child|
-            subject(child) || redefines_subject?(child)
-          end
-        end
-
-        # Find a subject definition
-        #
-        # @param node [RuboCop::Node]
-        # @param parent [RuboCop::Node,nil]
-        #
-        # @yieldparam subject_name [Symbol] name of subject being defined
-        # @yieldparam parent [RuboCop::Node] parent of subject definition
-        def find_subject(node, parent: nil, &block)
-          # An implicit subject is defined by RSpec when no subject is declared
-          subject_name = subject(node) || :subject
-
-          yield(subject_name, parent) if parent
-
-          node.each_child_node do |child|
-            find_subject(child, parent: node, &block)
+            find_subject_expectations(child, subject_name, &block)
           end
         end
       end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when subject is stubbed and there are several named subjects ' \
-     'in the same example group', :wip do
+     'in the same example group' do
     expect_offense(<<-RUBY)
       describe Foo do
         subject(:foo) { described_class.new }

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'flags when subject is stubbed and there are several named subjects ' \
+     'in the same example group', :wip do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject(:foo) { described_class.new }
+        subject(:bar) { described_class.new }
+        subject(:baz) { described_class.new }
+
+        before do
+          allow(bar).to receive(:bar).and_return(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+
+        it 'uses expect twice' do
+          expect(foo.bar).to eq(baz)
+        end
+      end
+    RUBY
+  end
+
   it 'flags when subject is mocked' do
     expect_offense(<<-RUBY)
       describe Foo do


### PR DESCRIPTION
`RSpec/SubjectStub` takes about 35% of all the time spent in cops if run Rubocop on Rubocop's  own source code. 

PR addresses the performance problem mentioned in the https://github.com/rubocop-hq/rubocop/issues/8022 issue.

### Profiler reports

Profiler report (`stackprof`) before optimizaition:

```
stackprof tmp/stackprof-cpu-rubocop.master.with-config.dump --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'

RuboCop::Cop::Commissioner#trigger_responding_cops (/Users/andrykonchin/projects/rubocop/lib/rubocop/cop/commissioner.rb:50)
  samples:   756 self (2.8%)  /   17379 total (65.3%)
  callers:
    17379  (  100.0%)  block (2 levels) in <class:Commissioner>
    17332  (   99.7%)  RuboCop::Cop::Commissioner#trigger_responding_cops
    16630  (   95.7%)  RuboCop::Cop::Commissioner#with_cop_error_handling
  callees (16623 total):
    17332  (  104.3%)  RuboCop::Cop::Commissioner#trigger_responding_cops
    16652  (  100.2%)  RuboCop::Cop::Commissioner#with_cop_error_handling
    5934  (   35.7%)  RuboCop::Cop::RSpec::SubjectStub#on_block
    1998  (   12.0%)  RuboCop::Cop::Layout::SpaceAroundMethodCallOperator#on_send
     374  (    2.2%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
...
```

Profiler report (`stackprof`) afeter optimizaition:

```
stackprof tmp/stackprof-cpu-rubocop.master.with-config.rspec-optimized.dump --method 'RuboCop::Cop::Commissioner#trigger_responding_cops'

RuboCop::Cop::Commissioner#trigger_responding_cops (/Users/andrykonchin/projects/rubocop/lib/rubocop/cop/commissioner.rb:50)
  samples:   851 self (3.6%)  /   13455 total (56.9%)
  callers:
    13455  (  100.0%)  block (2 levels) in <class:Commissioner>
    13398  (   99.6%)  RuboCop::Cop::Commissioner#trigger_responding_cops
    12598  (   93.6%)  RuboCop::Cop::Commissioner#with_cop_error_handling
  callees (12604 total):
    13398  (  106.3%)  RuboCop::Cop::Commissioner#trigger_responding_cops
    12626  (  100.2%)  RuboCop::Cop::Commissioner#with_cop_error_handling
    2143  (   17.0%)  RuboCop::Cop::Layout::SpaceAroundMethodCallOperator#on_send
     395  (    3.1%)  RuboCop::Cop::Layout::SpaceInsideArrayLiteralBrackets#on_array
     305  (    2.4%)  RuboCop::Cop::Layout::SpaceBeforeFirstArg#on_send
     279  (    2.2%)  RuboCop::Cop::Style::RedundantSelf#on_block
     266  (    2.1%)  RuboCop::RSpec::TopLevelDescribe#on_send
     226  (    1.8%)  RuboCop::Cop::Layout::SpaceInsideReferenceBrackets#on_send
     200  (    1.6%)  RuboCop::Cop::Style::TrailingMethodEndStatement#on_def
     200  (    1.6%)  RuboCop::Cop::Layout::FirstArgumentIndentation#on_send
     191  (    1.5%)  RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically#on_block
     175  (    1.4%)  RuboCop::Cop::Layout::SpaceAroundMethodCallOperator#on_const
     164  (    1.3%)  RuboCop::Cop::Layout::IndentationConsistency#on_begin
     136  (    1.1%)  RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces#on_hash
     130  (    1.0%)  RuboCop::Cop::Layout::DefEndAlignment#on_send
     113  (    0.9%)  RuboCop::Cop::Interpolation#on_dstr
     109  (    0.9%)  RuboCop::Cop::RSpec::SubjectStub#on_block
...
```

Samples number decreased from 65.3% to 56.9% and the cop samples (relative to `RuboCop::Cop::Commissioner#trigger_responding_cops` method execution) decreased from 35.7% to  0.9%.

### Total execution time

Before:
```
time bundle exec exe/rubocop --cache false --out rubocop.out .
bundle exec exe/rubocop --cache false --out rubocop.out .  83.46s user 0.40s system 99% cpu 1:24.40 total
```

After:
```
time bundle exec exe/rubocop --cache false --out rubocop.out .
bundle exec exe/rubocop --cache false --out rubocop.out .  62.60s user 0.35s system 99% cpu 1:03.21 total
```

Total execution time decreased from 1:24.40 to 1:03.21.

### Rubocop version

In performance tests was used the following Rubocop master commit:

```
ommit 7bafa099902871d9e6dc91800390a5c32e8d086b (HEAD -> master)
Author: Bozhidar Batsov <bozhidar@batsov.com>
Date:   Sat May 30 14:05:28 2020 +0300

    [Docs] Fix a couple of references to the docs folder
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).