### PR TITLE
Bump version to 1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.40.0 (2020-06-11)
+
 * Add new `RSpec/VariableName` cop. ([@tejasbubane][])
 * Add new `RSpec/VariableDefinition` cop. ([@tejasbubane][])
 * Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -231,6 +231,7 @@ RSpec/FilePath:
   IgnoreMethods: false
   SpecSuffixOnly: false
   VersionAdded: '1.2'
+  VersionChanged: '1.40'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 
 RSpec/Focus:

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.39.0'
+      STRING = '1.40.0'
     end
   end
 end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -1156,7 +1156,7 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 1.2 | -
+Enabled | Yes | No | 1.2 | 1.40
 
 Checks that spec file paths are consistent and well-formed.
 


### PR DESCRIPTION
Please double check:

- Did I miss any new process re. `VersionAdded`/`VersionChanged`?
- Do we have any PRs that should be merged before cutting a release?

Changelog since last release:

* Add new `RSpec/VariableName` cop. ([@tejasbubane][])
* Add new `RSpec/VariableDefinition` cop. ([@tejasbubane][])
* Expand `Capybara/VisibilityMatcher` to support more than just `have_selector`. ([@twalpole][])
* Add new `SpecSuffixOnly` option to `RSpec/FilePath` cop. ([@zdennis][])
* Allow `RSpec/RepeatedExampleGroupBody` to differ only by described_class. ([@robotdana][])
* Fix `RSpec/FilePath` detection across sibling directories. ([@rolfschmidt][])
* Substantial performance inprovement of `RSpec/SubjectStub`. ([@andrykonchin][])

[@andyw8]: https://github.com/andyw8
[@backus]: https://github.com/backus
[@bquorning]: https://github.com/bquorning
[@deivid-rodriguez]: https://github.com/deivid-rodriguez
[@geniou]: https://github.com/geniou
[@jaredbeck]: https://github.com/jaredbeck
[@jawshooah]: https://github.com/jawshooah
[@nevir]: https://github.com/nevir
[@nijikon]: https://github.com/nijikon
[@pstengel]: https://github.com/pstengel
[@miguelfteixeira]: https://github.com/miguelfteixeira
[@mlarraz]: https://github.com/mlarraz
[@renanborgescampos]: https://github.com/renanborgescampos
[@jaredmoody]: https://github.com/jaredmoody
[@baberthal]: https://github.com/baberthal
[@jeffreyc]: https://github.com/jeffreyc
[@clupprich]: https://github.com/clupprich
[@onk]: https://github.com/onk
[@Darhazer]: https://github.com/Darhazer
[@redross]: https://github.com/redross
[@cfabianski]: https://github.com/cfabianski
[@dgollahon]: https://github.com/dgollahon
[@rspeicher]: https://github.com/rspeicher
[@jonatas]: https://github.com/jonatas
[@pocke]: https://github.com/pocke
[@bmorrall]: https:/github.com/bmorrall
[@zverok]: https:/github.com/zverok
[@timrogers]: https://github.com/timrogers
[@yevhene]: https://github.com/yevhene
[@walf443]: https://github.com/walf443
[@pirj]: https://github.com/pirj
[@telmofcosta]: https://github.com/telmofcosta
[@EliseFitz15]: https://github.com/EliseFitz15
[@anthony-robin]: https://github.com/anthony-robin
[@jojos003]: https://github.com/jojos003
[@abrom]: https://github.com/abrom
[@patrickomatic]: https://github.com/patrickomatic
[@tdeo]: https://github.com/tdeo
[@composerinteralia]: https://github.com/composerinteralia
[@seanpdoyle]: https://github.com/seanpdoyle
[@vzvu3k6k]: https://github.com/vzvu3k6k
[@BrentWheeldon]: https://github.com/BrentWheeldon
[@daveworth]: https://github.com/daveworth
[@RST-J]: https://github.com/RST-J
[@ypresto]: https://github.com/ypresto
[@mkenyon]: https://github.com/mkenyon
[@gsamokovarov]: https://github.com/gsamokovarov
[@schmijos]: https://github.com/schmijos
[@foton]: https://github.com/foton
[@nc-holodakg]: https://github.com/nc-holodakg
[@onumis]: https://github.com/onumis
[@nickcampbell18]: https://github.com/nickcampbell18
[@QQism]: https://github.com/QQism
[@kellysutton]: https://github.com/kellysutton
[@mkrawc]: https://github.com/mkrawc
[@jfragoulis]: https://github.com/jfragoulis
[@ybiquitous]: https://github.com/ybiquitous
[@dduugg]: https://github.com/dduugg
[@lazycoder9]: https://github.com/lazycoder9
[@elebow]: https://github.com/elebow
[@eitoball]: https://github.com/eitoball
[@aried3r]: https://github.com/aried3r
[@AlexWayfer]: https://github.com/AlexWayfer
[@tejasbubane]: https://github.com/tejasbubane
[@twalpole]: https://github.com/twalpole
[@zdennis]: https://github.com/zdennis
[@robotdana]: https://github.com/robotdana
[@rolfschmidt]: https://github.com/rolfschmidt
[@andrykonchin]: https://github.com/andrykonchin

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
