### PR TITLE
Extend list of Rails spec types for DescribeClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Extend the list of Rails spec types for `RSpec/DescribeClass`. ([@pirj][])
+
 ## 1.40.0 (2020-06-11)
 
 * Add new `RSpec/VariableName` cop. ([@tejasbubane][])

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -43,7 +43,11 @@ module RuboCop
         def_node_matcher :rails_metadata?, <<-PATTERN
           (pair
             (sym :type)
-            (sym {:request :feature :system :routing :view})
+            (sym {
+                   :channel :controller :helper :job :mailer :model :request
+                   :routing :view :feature :system :mailbox
+                 }
+            )
           )
         PATTERN
 


### PR DESCRIPTION
There are more: https://github.com/rspec/rspec-rails/blob/56aed229410a8e7a30743d82b8770596fd8c125c/lib/rspec/rails/configuration.rb#L28

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).