### PR TITLE
Use node pattern generic parameters to simplify a cop

### DIFF
--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -50,17 +50,13 @@ module RuboCop
 
         MSG = 'Example has too many expectations [%<total>d/%<max>d].'
 
+        ANYTHING = ->(_node) { true }
+        TRUE = ->(node) { node.true_type? }
+
         def_node_matcher :aggregate_failures?, <<-PATTERN
           (block {
               (send _ _ <(sym :aggregate_failures) ...>)
-              (send _ _ ... (hash <(pair (sym :aggregate_failures) true) ...>))
-            } ...)
-        PATTERN
-
-        def_node_matcher :aggregate_failures_present?, <<-PATTERN
-          (block {
-              (send _ _ <(sym :aggregate_failures) ...>)
-              (send _ _ ... (hash <(pair (sym :aggregate_failures) _) ...>))
+              (send _ _ ... (hash <(pair (sym :aggregate_failures) %1) ...>))
             } ...)
         PATTERN
 
@@ -89,12 +85,12 @@ module RuboCop
           node_with_aggregate_failures = find_aggregate_failures(example_node)
           return false unless node_with_aggregate_failures
 
-          aggregate_failures?(node_with_aggregate_failures)
+          aggregate_failures?(node_with_aggregate_failures, TRUE)
         end
 
         def find_aggregate_failures(example_node)
           example_node.send_node.each_ancestor(:block)
-            .find { |block_node| aggregate_failures_present?(block_node) }
+            .find { |block_node| aggregate_failures?(block_node, ANYTHING) }
         end
 
         def find_expectation(node, &block)


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop-rspec/pull/804#discussion_r438747249

Support introduced in https://github.com/rubocop-hq/rubocop-ast/pull/31

Presumably generic parameters support will land in RuboCop 1.0 or 1.0.1 worst case.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).