### PR TITLE
Pull example group node matchers up

### DIFF
--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -51,8 +51,6 @@ module RuboCop
           )
         PATTERN
 
-        def_node_matcher :shared_group?, SharedGroups::ALL.block_pattern
-
         def on_top_level_describe(node, (described_value, _))
           return if shared_group?(root_node)
           return if valid_describe?(node)

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -50,10 +50,6 @@ module RuboCop
         MSG = 'Avoid instance variables – use let, ' \
               'a method call, or a local variable (if possible).'
 
-        EXAMPLE_GROUP_METHODS = ExampleGroups::ALL + SharedGroups::ALL
-
-        def_node_matcher :spec_group?, EXAMPLE_GROUP_METHODS.block_pattern
-
         def_node_matcher :dynamic_class?, <<-PATTERN
           (block (send (const nil? :Class) :new ...) ...)
         PATTERN

--- a/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
+++ b/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
@@ -119,11 +119,8 @@ module RuboCop
         private
 
         def inside_describe_block?(node)
-          node.each_ancestor(:block).any?(&method(:in_example_or_shared_group?))
+          node.each_ancestor(:block).any?(&method(:spec_group?))
         end
-
-        def_node_matcher :in_example_or_shared_group?,
-                         (ExampleGroups::ALL + SharedGroups::ALL).block_pattern
       end
     end
   end

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -8,6 +8,10 @@ module RuboCop
         extend RuboCop::NodePattern::Macros
 
         def_node_matcher :example_group?, ExampleGroups::ALL.block_pattern
+        def_node_matcher :shared_group?, SharedGroups::ALL.block_pattern
+
+        spec_groups = ExampleGroups::ALL + SharedGroups::ALL
+        def_node_matcher :spec_group?, spec_groups.block_pattern
 
         def_node_matcher :example_group_with_body?, <<-PATTERN
           (block #{ExampleGroups::ALL.send_pattern} args [!nil?])


### PR DESCRIPTION
This refactors to add `shared_group?` and `spec_group?` node matchers in
`NodePattern` for use across cops. I wanted to check shared contexts in
the [rule that I'm working on][1] and noticed that there were similar
implementations in a handful of other places. I thought it was probably
worth abstracting upwards.

[1]: https://github.com/rubocop-hq/rubocop-rspec/pull/863

---

* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [n/a] Added tests.
* [n/a] Updated documentation.
* [n/a] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).