### PR TITLE
Add a Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# The RuboCop Community Code of Conduct
+
+**Note:** We have picked the following code of conduct based on [Ruby's own
+code of conduct](https://www.ruby-lang.org/en/conduct/).
+
+This document provides a few simple community guidelines for a safe, respectful,
+productive, and collaborative place for any person who is willing to contribute
+to the RuboCop community. It applies to all "collaborative spaces", which are
+defined as community communications channels (such as mailing lists, submitted
+patches, commit comments, etc.).
+
+* Participants will be tolerant of opposing views.
+* Participants must ensure that their language and actions are free of personal
+  attacks and disparaging personal remarks.
+* When interpreting the words and actions of others, participants should always
+  assume good intentions.
+* Behaviour which can be reasonably considered harassment will not be tolerated.


### PR DESCRIPTION
This is a copy of RuboCop's Code of conduct, copied from https://github.com/rubocop-hq/rubocop/blob/37c34a42f0/CODE_OF_CONDUCT.md

That itself is derived based on https://www.ruby-lang.org/en/conduct/
