### PR TITLE
Allow `#traits_for_enum` to be used in a `FactoryBot` factory without a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Extend the list of Rails spec types for `RSpec/DescribeClass`. ([@pirj][])
+* Fix `FactoryBot/AttributeDefinedStatically` to allow `#traits_for_enum` without a block. ([@harrylewis][])
 
 ## 1.40.0 (2020-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,3 +521,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@robotdana]: https://github.com/robotdana
 [@rolfschmidt]: https://github.com/rolfschmidt
 [@andrykonchin]: https://github.com/andrykonchin
+[@harrylewis]: https://github.com/harrylewis

--- a/lib/rubocop/rspec/factory_bot.rb
+++ b/lib/rubocop/rspec/factory_bot.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # RuboCop FactoryBot project namespace
     module FactoryBot
-      ATTRIBUTE_DEFINING_METHODS = %i[factory trait transient ignore].freeze
+      ATTRIBUTE_DEFINING_METHODS = %i[factory trait traits_for_enum transient ignore].freeze
 
       UNPROXIED_METHODS = %i[
         __send__

--- a/lib/rubocop/rspec/factory_bot.rb
+++ b/lib/rubocop/rspec/factory_bot.rb
@@ -4,7 +4,13 @@ module RuboCop
   module RSpec
     # RuboCop FactoryBot project namespace
     module FactoryBot
-      ATTRIBUTE_DEFINING_METHODS = %i[factory trait traits_for_enum transient ignore].freeze
+      ATTRIBUTE_DEFINING_METHODS = %i[
+        factory
+        ignore
+        trait
+        traits_for_enum
+        transient
+      ].freeze
 
       UNPROXIED_METHODS = %i[
         __send__

--- a/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
@@ -154,6 +154,16 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do
     RUBY
   end
 
+  it 'accepts valid traits_for_enum definition' do
+    expect_no_offenses(<<-RUBY)
+      FactoryBot.define do
+        factory :post do
+          traits_for_enum :status, [:draft, :published]
+        end
+      end
+    RUBY
+  end
+
   bad = <<-RUBY
     FactoryBot.define do
       factory :post do


### PR DESCRIPTION
This PR fixes a bug that arose in relation to FactoryBot's recent [`6.0.0` version release](https://github.com/thoughtbot/factory_bot/blob/master/NEWS.md#600-june-18-2020). This release introduced a new method, `#traits_for_enum`, which can be used to dynamically define factory traits for an enumerated attribute.

The behaviour expected is that usage of this method (which does not take a block argument) does not produce a `FactoryBot/AttributeDefinedStatically` offense.

The actual behaviour is that it does produce this offense because it is assumed to be an attribute, which should be defined with a block. The fix is simply to add it to the list of pre-qualified methods.

The documentation surrounding this cop does not make any mention around what methods are allowed to be used without a block, so I didn't feel it was necessary to update the documentation.

I _believe_ this constitutes a "user-observable" change, but am not sure. If you feel it does, I will add a commit to add an entry to the `CHANGELOG.md`.

This fixes #943.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).