### PR TITLE
Performance. RSpec/ReturnFromStub

### DIFF
--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -40,6 +40,7 @@ module RuboCop
         MSG_BLOCK = 'Use block for static values.'
 
         def_node_search :contains_stub?, '(send nil? :receive (...))'
+        def_node_matcher :stub_with_block?, '(block #contains_stub? ...)'
         def_node_search :and_return_value, <<-PATTERN
           $(send _ :and_return $(...))
         PATTERN
@@ -53,7 +54,7 @@ module RuboCop
 
         def on_block(node)
           return unless style == :and_return
-          return unless contains_stub?(node)
+          return unless stub_with_block?(node)
 
           check_block_body(node)
         end

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -45,15 +45,15 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return unless contains_stub?(node)
           return unless style == :block
+          return unless contains_stub?(node)
 
           check_and_return_call(node)
         end
 
         def on_block(node)
-          return unless contains_stub?(node)
           return unless style == :and_return
+          return unless contains_stub?(node)
 
           check_block_body(node)
         end


### PR DESCRIPTION
Optimized performance of RSpec/ReturnFromStub cop.

### Changes

- skip node processing if it's disabled in config
- optimize `#on_block` callback

### Skip processing

The cop forces either code style of method call stubbing _with block_ or _without block_. Here we check configured preferred style before any manipulation with current node.

Performance measurements:

When unnecessary checks are skipped timing of `ReturnFromStub#on_send` changed from 2.3% to 0.3%

<details><summary>Before</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.ReturnFromStub.dump --method 'RuboCop::Cop::RSpec::ReturnFromStub#on_send'
RuboCop::Cop::RSpec::ReturnFromStub#on_send (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/return_from_stub.rb:47)
  samples:     2 self (0.0%)  /    809 total (2.3%)
  callers:
     809  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (807 total):
     805  (   99.8%)  RuboCop::Cop::RSpec::ReturnFromStub#contains_stub?
       2  (    0.2%)  RuboCop::Cop::ConfigurableEnforcedStyle#style
  code:
                                  |    47  |
  807    (2.3%) /     2   (0.0%)  |    48  |         def on_send(node)
    2    (0.0%)                   |    49  |           return unless style == :block
                                  |    50  |           return unless contains_stub?(node)
```

</details>

<details><summary>After</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.ReturnFromStub.2.dump --method 'RuboCop::Cop::RSpec::ReturnFromStub#on_send'
RuboCop::Cop::RSpec::ReturnFromStub#on_send (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/return_from_stub.rb:47)
  samples:     4 self (0.0%)  /    122 total (0.4%)
  callers:
     122  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (118 total):
     118  (  100.0%)  RuboCop::Cop::ConfigurableEnforcedStyle#style
  code:
                                  |    47  |
  122    (0.4%) /     4   (0.0%)  |    48  |         def on_send(node)
                                  |    49  |           return unless style == :block
```

</details>


### on_block callback

The approach is to avoid excessive usage of `def_node_search` and use `def_node_matcher` instead.

Timing of `ReturnFromStub#on_block` callback changed from 5.0% to 0.8%.

<details><summary>Before</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.ReturnFromStub.2.dump --method 'RuboCop::Cop::RSpec::ReturnFromStub#on_block'
RuboCop::Cop::RSpec::ReturnFromStub#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/return_from_stub.rb:54)
  samples:     2 self (0.0%)  /   1737 total (5.0%)
  callers:
    1737  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (1735 total):
    1609  (   92.7%)  RuboCop::Cop::RSpec::ReturnFromStub#contains_stub?
     105  (    6.1%)  RuboCop::Cop::RSpec::ReturnFromStub#check_block_body
      21  (    1.2%)  RuboCop::Cop::ConfigurableEnforcedStyle#style
  code:
                                  |    54  |         def on_block(node)
   22    (0.1%) /     1   (0.0%)  |    55  |           return unless style == :and_return
 1610    (4.7%) /     1   (0.0%)  |    56  |           return unless contains_stub?(node)
                                  |    57  |
  105    (0.3%)                   |    58  |           check_block_body(node)
                                  |    59  |         end
```
</details>

<details><summary>After</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.ReturnFromStub.3.dump --method 'RuboCop::Cop::RSpec::ReturnFromStub#on_block'
RuboCop::Cop::RSpec::ReturnFromStub#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/return_from_stub.rb:56)
  samples:     0 self (0.0%)  /    236 total (0.8%)
  callers:
     236  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (236 total):
     136  (   57.6%)  RuboCop::Cop::RSpec::ReturnFromStub#stub_with_block?
      74  (   31.4%)  RuboCop::Cop::RSpec::ReturnFromStub#check_block_body
      26  (   11.0%)  RuboCop::Cop::ConfigurableEnforcedStyle#style
  code:
                                  |    56  |         def on_block(node)
   26    (0.1%)                   |    59  |           return unless style == :and_return
  136    (0.4%)                   |    62  |           return unless stub_with_block?(node)
                                  |    63  |
   74    (0.2%)                   |    64  |           check_block_body(node)
                                  |    65  |         end
```
</details>

### Measurements approach

Used `stackprof` profiler to measure proportion of the cop timing. Running Rubocop on the GitLab project specs.

Run only one cope without caching and skip config with command

```
bundle exec exe/rubocop --cache false --out gitlab-specs.out --force-default-config  --require rubocop-rspec --only RSpec/ReturnFromStub ../rubocop-profiling-examples/gitlabhq/spec
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
