### PR TITLE
Performance. RSpec/InstanceVariable

### DIFF
--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -47,12 +47,10 @@ module RuboCop
       #   end
       #
       class InstanceVariable < Cop
+        include RuboCop::RSpec::TopLevelGroup
+
         MSG = 'Avoid instance variables – use let, ' \
               'a method call, or a local variable (if possible).'
-
-        EXAMPLE_GROUP_METHODS = ExampleGroups::ALL + SharedGroups::ALL
-
-        def_node_matcher :spec_group?, EXAMPLE_GROUP_METHODS.block_pattern
 
         def_node_matcher :dynamic_class?, <<-PATTERN
           (block (send (const nil? :Class) :new ...) ...)
@@ -69,9 +67,7 @@ module RuboCop
 
         def_node_search :ivar_assigned?, '(ivasgn % ...)'
 
-        def on_block(node)
-          return unless spec_group?(node)
-
+        def on_top_level_group(node)
           ivar_usage(node) do |ivar, name|
             next if valid_usage?(ivar)
             next if assignment_only? && !ivar_assigned?(node, name)

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -152,5 +152,19 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
         end
       RUBY
     end
+
+    it 'flags an instance variable when it is also assigned ' \
+       'in a sibling example group' do
+      expect_offense(<<-RUBY)
+        describe MyClass do
+          context 'foo' do
+            before { @foo = [] }
+          end
+
+          it { expect(@foo).to be_empty }
+                      ^^^^ Avoid instance variables – use let, a method call, or a local variable (if possible).
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Optimized performance of RSpec/InstanceVariable cop.

### Changes

- use `RuboCop::RSpec::TopLevelGroup` to process only top level groups
- added spec to document existing behavior for multiple nested example groups

The cop used `#on_block` callback and processed nested `context`/`describe` blocks multiple times. Now it uses `RuboCop::RSpec::TopLevelGroup` module and declares `#on_top_level_group` callback so nested groups aren't processed

### Performance measurements

Timing is changed from 5.6% (`InstanceVariable#on_block`) to 2.6% (`RuboCop::RSpec::TopLevelGroup#on_block`)

<details><summary>Before</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.InstanceVariable.dump --method 'RuboCop::Cop::RSpec::InstanceVariable#on_block'
RuboCop::Cop::RSpec::InstanceVariable#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/instance_variable.rb:72)
  samples:     0 self (0.0%)  /   1783 total (5.6%)
  callers:
    1783  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
      80  (    4.5%)  RuboCop::Cop::RSpec::InstanceVariable#ivar_usage
  callees (1783 total):
    1695  (   95.1%)  RuboCop::Cop::RSpec::InstanceVariable#ivar_usage
      88  (    4.9%)  RuboCop::Cop::RSpec::InstanceVariable#spec_group?
      62  (    3.5%)  RuboCop::Cop::Cop#add_offense
      17  (    1.0%)  RuboCop::Cop::RSpec::InstanceVariable#valid_usage?
       1  (    0.1%)  RuboCop::Cop::RSpec::InstanceVariable#assignment_only?
  code:
                                  |    72  |         def on_block(node)
   88    (0.3%)                   |    73  |           return unless spec_group?(node)
                                  |    74  |
 1695    (5.4%)                   |    75  |           ivar_usage(node) do |ivar, name|
   17    (0.1%)                   |    76  |             next if valid_usage?(ivar)
    1    (0.0%)                   |    77  |             next if assignment_only? && !ivar_assigned?(node, name)
                                  |    78  |
   62    (0.2%)                   |    79  |             add_offense(ivar)
                                  |    80  |           end
```
</details>

<details><summary>After</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.InstanceVariable.3.dump --method 'RuboCop::RSpec::TopLevelGroup#on_block'
RuboCop::RSpec::TopLevelGroup#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/rspec/top_level_group.rb:13)
  samples:    16 self (0.1%)  /    764 total (2.6%)
  callers:
     764  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (748 total):
     664  (   88.8%)  RuboCop::Cop::RSpec::InstanceVariable#on_top_level_group
      84  (   11.2%)  RuboCop::RSpec::TopLevelGroup#top_level_group?
  code:
                                  |    13  |       def on_block(node)
   16    (0.1%) /    16   (0.1%)  |    14  |         return unless respond_to?(:on_top_level_group)
   84    (0.3%)                   |    15  |         return unless top_level_group?(node)
                                  |    16  |
  664    (2.3%)                   |    17  |         on_top_level_group(node)
                                  |    18  |       end
```
</details>

### Measurements approach

Used `stackprof` profiler to measure proportion of the cop timing. Running Rubocop on the GitLab project specs.

Run only one cope without caching and skip config with command

```
bundle exec exe/rubocop --cache false --out gitlab-specs.out --force-default-config  --require rubocop-rspec --only RSpec/InstanceVariable ../rubocop-profiling-examples/gitlabhq/spec
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).