### PR TITLE
Performance. RSpec/NestedGroups

### DIFF
--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -76,4 +76,20 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
         ).to_stderr
     end
   end
+
+  it 'counts nesting correctly when non-spec nesting' do
+    expect_offense(<<-RUBY)
+      describe MyClass do
+        context 'when foo' do
+          context 'when bar' do
+            [].each do |i|
+              context 'when baz' do
+              ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+              end
+            end
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Optimized performance of RSpec/NestedGroups and #on_top_level_describe callback.

### Changes

- avoid excessive recursive iteration oven nested example groups
- fixed error with calculating nesting count

### Performance measurements

Timing for RSpec/NestedGroups is changed from 14.3% to 3.3% (for `RuboCop::RSpec::TopLevelDescribe#on_send` callback).

<details><summary>Before</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.NestedGroups.dump --method 'RuboCop::RSpec::TopLevelDescribe#on_send'
RuboCop::RSpec::TopLevelDescribe#on_send (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/rspec/top_level_describe.rb:9)
  samples:   130 self (0.2%)  /   8732 total (16.6%)
  callers:
    8732  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (8602 total):
    8446  (   98.2%)  RuboCop::Cop::RSpec::NestedGroups#on_top_level_describe
     155  (    1.8%)  RuboCop::RSpec::TopLevelDescribe#top_level_describe?
       1  (    0.0%)  RuboCop::AST::MethodDispatchNode#arguments
  code:
                                  |     9  |       def on_send(node)
  127    (0.2%) /   127   (0.2%)  |    10  |         return unless respond_to?(:on_top_level_describe)
  158    (0.3%) /     3   (0.0%)  |    11  |         return unless top_level_describe?(node)
                                  |    12  |
 8447   (16.1%)                   |    13  |         on_top_level_describe(node, node.arguments)
                                  |    14  |       end

```
</details>

<details><summary>After</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.NestedGroups.4.dump --method 'RuboCop::RSpec::TopLevelDescribe#on_send'
RuboCop::RSpec::TopLevelDescribe#on_send (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/rspec/top_level_describe.rb:9)
  samples:    49 self (0.2%)  /    715 total (3.1%)
  callers:
     715  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
  callees (666 total):
     593  (   89.0%)  RuboCop::Cop::RSpec::NestedGroups#on_top_level_describe
      73  (   11.0%)  RuboCop::RSpec::TopLevelDescribe#top_level_describe?
  code:
                                  |     9  |       def on_send(node)
   49    (0.2%) /    49   (0.2%)  |    10  |         return unless respond_to?(:on_top_level_describe)
   73    (0.3%)                   |    11  |         return unless top_level_describe?(node)
                                  |    12  |
  593    (2.6%)                   |    13  |         on_top_level_describe(node, node.arguments)
                                  |    14  |       end

```
</details>

### Measurements approach

Used `stackprof` profiler to measure proportion of the cop timing. Running Rubocop on the GitLab project specs.

Run only one cope without caching and skip config with command

```
bundle exec exe/rubocop --cache false --out gitlab-specs.out --force-default-config  --require rubocop-rspec --only RSpec/NestedGroups ../rubocop-profiling-examples/gitlabhq/spec
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).