### PR TITLE
Performance. RSpec/LetSetup 

### DIFF
--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -28,14 +28,20 @@ module RuboCop
       class LetSetup < Cop
         MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
-        def_node_search :let_bang, <<-PATTERN
+        def_node_matcher :example_or_shared_group_or_including?,
+                         (
+                           ExampleGroups::ALL + SharedGroups::ALL +
+                           Includes::ALL
+                         ).block_pattern
+
+        def_node_matcher :let_bang, <<-PATTERN
           (block $(send nil? :let! (sym $_)) args ...)
         PATTERN
 
         def_node_search :method_called?, '(send nil? %)'
 
         def on_block(node)
-          return unless example_group?(node)
+          return unless example_or_shared_group_or_including?(node)
 
           unused_let_bang(node) do |let|
             add_offense(let)
@@ -45,8 +51,14 @@ module RuboCop
         private
 
         def unused_let_bang(node)
-          let_bang(node) do |method_send, method_name|
+          child_let_bang(node) do |method_send, method_name|
             yield(method_send) unless method_called?(node, method_name)
+          end
+        end
+
+        def child_let_bang(node, &block)
+          RuboCop::RSpec::ExampleGroup.new(node).lets.each do |let|
+            let_bang(let, &block)
           end
         end
       end

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -63,4 +63,53 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
       end
     RUBY
   end
+
+  it 'complains when let! is used and not referenced in shared example group' do
+    expect_offense(<<-RUBY)
+      shared_context 'foo' do
+        let!(:bar) { baz }
+        ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+        it 'does not use bar' do
+          expect(baz).to eq(qux)
+        end
+      end
+    RUBY
+  end
+
+  it 'complains when let! used in shared example including' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        it_behaves_like 'bar' do
+          let!(:baz) { foobar }
+          ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+          let(:a) { b }
+        end
+      end
+    RUBY
+  end
+
+  it 'complains when there is only one nested node into example group' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        let!(:bar) { baz }
+        ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+      end
+    RUBY
+  end
+
+  it 'complains when there is a custom nesting level' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        [].each do |i|
+          let!(:bar) { i }
+          ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+          it 'does not use bar' do
+            expect(baz).to eq(qux)
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Optimize RSpec/LetSetup cop and #on_block callback.

### Changes

- avoid excessive iteration over **all** the `let!` nodes nested into current example group
- fixed handling shared example groups

The approach is to iterate over only **direct** child `let!` nodes of a current example group.

### Performance measurements

Timing for RuboCop::Cop::RSpec::LetSetup#on_block is changed from 10.2% to 1.3%.

<details><summary>Before</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.LetSetup.dump --method 'RuboCop::Cop::RSpec::LetSetup#on_block'
RuboCop::Cop::RSpec::LetSetup#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/let_setup.rb:37)
  samples:     1 self (0.0%)  /   4003 total (10.2%)
  callers:
    4003  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
     144  (    3.6%)  RuboCop::Cop::RSpec::LetSetup#unused_let_bang
  callees (4002 total):
    3895  (   97.3%)  RuboCop::Cop::RSpec::LetSetup#unused_let_bang
     144  (    3.6%)  RuboCop::Cop::Cop#add_offense
     107  (    2.7%)  RuboCop::RSpec::Language::NodePattern#example_group?
  code:
                                  |    37  |           (block $(send nil? :let! (sym $_)) args ...)
  108    (0.3%) /     1   (0.0%)  |    38  |         PATTERN
                                  |    39  |
                                  |    40  |         def_node_search :method_called?, '(send nil? %)'
 3895    (9.9%)                   |    41  |
  144    (0.4%)                   |    42  |         def on_block(node)
                                  |    43  |           return unless example_group?(node)
```
</details>

<details><summary>After</summary>

```
stackprof tmp/stackprof-cpu-gitlab.master.with-rubocop-rspec.LetSetup.2.dump --method 'RuboCop::Cop::RSpec::LetSetup#on_block'
RuboCop::Cop::RSpec::LetSetup#on_block (/Users/andrykonchin/projects/rubocop-rspec/lib/rubocop/cop/rspec/let_setup.rb:42)
  samples:     1 self (0.0%)  /    440 total (1.3%)
  callers:
     440  (  100.0%)  RuboCop::Cop::Commissioner#trigger_responding_cops
     113  (   25.7%)  RuboCop::Cop::RSpec::LetSetup#unused_let_bang
  callees (439 total):
     361  (   82.2%)  RuboCop::Cop::RSpec::LetSetup#unused_let_bang
     113  (   25.7%)  RuboCop::Cop::Cop#add_offense
      78  (   17.8%)  RuboCop::RSpec::Language::NodePattern#example_group?
  code:
                                  |    42  |         def on_block(node)
   79    (0.2%) /     1   (0.0%)  |    43  |           return unless example_group?(node)
                                  |    44  |
                                  |    45  |           #puts node
  361    (1.1%)                   |    46  |           unused_let_bang(node) do |let|
  113    (0.3%)                   |    47  |             add_offense(let)
                                  |    48  |           end
```
</details>

### Measurements approach

Used `stackprof` profiler to measure proportion of the cop timing. Running Rubocop on the GitLab project specs.

Run only one cope without caching and skip config with command

```
bundle exec exe/rubocop --cache false --out gitlab-specs.out --force-default-config  --require rubocop-rspec --only RSpec/LetSetup ../rubocop-profiling-examples/gitlabhq/spec
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).