### PR TITLE
New RuboCop autocorrect

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,4 +14,4 @@ InternalAffairs/MethodNameEqual:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 104
+  Max: 106

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -44,8 +44,7 @@ module RuboCop
         private
 
         def token_aligner
-          @token_aligner ||=
-            RuboCop::RSpec::AlignLetBrace.new(processed_source.ast, :begin)
+          RuboCop::RSpec::AlignLetBrace.new(processed_source.ast, :begin)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -18,26 +18,24 @@ module RuboCop
       #     let(:a)      { b }
       #
       class AlignLeftLetBrace < Cop
+        extend AutoCorrector
+
         MSG = 'Align left let brace'
 
         def self.autocorrect_incompatible_with
           [Layout::ExtraSpacing]
         end
 
-        def investigate(_processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           token_aligner.offending_tokens.each do |let|
-            add_offense(let, location: :begin)
-          end
-        end
-
-        def autocorrect(let)
-          lambda do |corrector|
-            corrector.insert_before(
-              let.loc.begin,
-              token_aligner.indent_for(let)
-            )
+            add_offense(let.loc.begin) do |corrector|
+              corrector.insert_before(
+                let.loc.begin,
+                token_aligner.indent_for(let)
+              )
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -18,26 +18,24 @@ module RuboCop
       #     let(:a)      { b        }
       #
       class AlignRightLetBrace < Cop
+        extend AutoCorrector
+
         MSG = 'Align right let brace'
 
         def self.autocorrect_incompatible_with
           [Layout::ExtraSpacing]
         end
 
-        def investigate(_processed_source)
+        def on_new_investigation
           return if processed_source.blank?
 
           token_aligner.offending_tokens.each do |let|
-            add_offense(let, location: :end)
-          end
-        end
-
-        def autocorrect(let)
-          lambda do |corrector|
-            corrector.insert_before(
-              let.loc.end,
-              token_aligner.indent_for(let)
-            )
+            add_offense(let.loc.end) do |corrector|
+              corrector.insert_before(
+                let.loc.end,
+                token_aligner.indent_for(let)
+              )
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -44,8 +44,7 @@ module RuboCop
         private
 
         def token_aligner
-          @token_aligner ||=
-            RuboCop::RSpec::AlignLetBrace.new(processed_source.ast, :end)
+          RuboCop::RSpec::AlignLetBrace.new(processed_source.ast, :end)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def on_send(node)
           be_without_args(node) do |matcher|
-            add_offense(matcher, location: :selector)
+            add_offense(matcher.loc.selector)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -36,6 +36,8 @@ module RuboCop
       # coerce objects for comparison.
       #
       class BeEql < Cop
+        extend AutoCorrector
+
         MSG = 'Prefer `be` over `eql`.'
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
@@ -44,12 +46,10 @@ module RuboCop
 
         def on_send(node)
           eql_type_with_identity(node) do |eql|
-            add_offense(eql, location: :selector)
+            add_offense(eql.loc.selector) do |corrector|
+              corrector.replace(eql.loc.selector, 'be')
+            end
           end
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.selector, 'be') }
         end
       end
     end

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -24,6 +24,8 @@ module RuboCop
         #   expect(page).to have_current_path(/widgets/)
         #
         class CurrentPathExpectation < Cop
+          extend AutoCorrector
+
           MSG = 'Do not set an RSpec expectation on `current_path` in ' \
                 'Capybara feature specs - instead, use the ' \
                 '`have_current_path` matcher on `page`'
@@ -47,30 +49,30 @@ module RuboCop
 
           def on_send(node)
             expectation_set_on_current_path(node) do
-              add_offense(node, location: :selector)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              return unless node.chained?
-
-              as_is_matcher(node.parent) do |to_sym, matcher_node|
-                rewrite_expectation(corrector, node, to_sym, matcher_node)
-              end
-
-              regexp_str_matcher(node.parent) do |to_sym, matcher_node, regexp|
-                rewrite_expectation(corrector, node, to_sym, matcher_node)
-                convert_regexp_str_to_literal(corrector, matcher_node, regexp)
+              add_offense(node.loc.selector) do |corrector|
+                autocorrect(corrector, node)
               end
             end
           end
 
           private
 
+          def autocorrect(corrector, node)
+            return unless node.chained?
+
+            as_is_matcher(node.parent) do |to_sym, matcher_node|
+              rewrite_expectation(corrector, node, to_sym, matcher_node)
+            end
+
+            regexp_str_matcher(node.parent) do |to_sym, matcher_node, regexp|
+              rewrite_expectation(corrector, node, to_sym, matcher_node)
+              convert_regexp_str_to_literal(corrector, matcher_node, regexp)
+            end
+          end
+
           def rewrite_expectation(corrector, node, to_symbol, matcher_node)
             current_path_node = node.first_argument
-            corrector.replace(current_path_node.loc.expression, 'page')
+            corrector.replace(current_path_node, 'page')
             corrector.replace(node.parent.loc.selector, 'to')
             matcher_method = if to_symbol == :to
                                'have_current_path'
@@ -84,7 +86,7 @@ module RuboCop
           def convert_regexp_str_to_literal(corrector, matcher_node, regexp_str)
             str_node = matcher_node.first_argument
             regexp_expr = Regexp.new(regexp_str).inspect
-            corrector.replace(str_node.loc.expression, regexp_expr)
+            corrector.replace(str_node, regexp_expr)
           end
 
           # `have_current_path` with no options will include the querystring
@@ -97,7 +99,7 @@ module RuboCop
             return if %i[regexp str].include?(expectation_last_child.type)
 
             corrector.insert_after(
-              expectation_last_child.loc.expression,
+              expectation_last_child,
               ', ignore_query: true'
             )
           end

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -41,6 +41,8 @@ module RuboCop
         #     end
         #   end
         class FeatureMethods < Cop
+          extend AutoCorrector
+
           MSG = 'Use `%<replacement>s` instead of `%<method>s`.'
 
           # https://git.io/v7Kwr
@@ -72,16 +74,11 @@ module RuboCop
               next if enabled?(match)
 
               add_offense(
-                send_node,
-                location: :selector,
+                send_node.loc.selector,
                 message: format(MSG, method: match, replacement: MAP[match])
-              )
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.selector, MAP[node.method_name].to_s)
+              ) do |corrector|
+                corrector.replace(send_node.loc.selector, MAP[match].to_s)
+              end
             end
           end
 

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -24,6 +24,8 @@ module RuboCop
       #     # ...
       #   end
       class ContextMethod < Cop
+        extend AutoCorrector
+
         MSG = 'Use `describe` for testing methods.'
 
         def_node_matcher :context_method, <<-PATTERN
@@ -32,13 +34,9 @@ module RuboCop
 
         def on_block(node)
           context_method(node) do |context|
-            add_offense(context)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.parent.loc.selector, 'describe')
+            add_offense(context) do |corrector|
+              corrector.replace(context.parent.loc.selector, 'describe')
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   #     Patterns:
       #   #     - '_test.rb$'
       #   #     - '(?:^|/)test/'
-      class Cop < ::RuboCop::Cop::Cop
+      class Cop < ::RuboCop::Cop::Base
         include RuboCop::RSpec::Language
         include RuboCop::RSpec::Language::NodePattern
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -55,6 +55,7 @@ module RuboCop
       #   end
       #
       class DescribedClass < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         DESCRIBED_CLASS = 'described_class'
@@ -85,22 +86,24 @@ module RuboCop
           return unless body
 
           find_usage(body) do |match|
-            add_offense(match, message: message(match.const_name))
+            msg = message(match.const_name)
+            add_offense(match, message: msg) do |corrector|
+              autocorrect(corrector, match)
+            end
           end
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, match)
           replacement = if style == :described_class
                           DESCRIBED_CLASS
                         else
                           @described_class.const_name
                         end
-          lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement)
-          end
-        end
 
-        private
+          corrector.replace(match, replacement)
+        end
 
         def find_usage(node, &block)
           yield(node) if offensive?(node)

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -42,6 +42,7 @@ module RuboCop
       #     # ...
       #   end
       class Dialect < Cop
+        extend AutoCorrector
         include MethodPreference
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
@@ -52,23 +53,15 @@ module RuboCop
           return unless rspec_method?(node)
           return unless preferred_methods[node.method_name]
 
-          add_offense(node)
-        end
+          msg = format(MSG, prefer: preferred_method(node.method_name),
+                            current: node.method_name)
 
-        def autocorrect(node)
-          lambda do |corrector|
+          add_offense(node, message: msg) do |corrector|
             current = node.loc.selector
             preferred = preferred_method(current.source)
 
             corrector.replace(current, preferred)
           end
-        end
-
-        private
-
-        def message(node)
-          format(MSG, prefer: preferred_method(node.method_name),
-                      current: node.method_name)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -23,6 +23,7 @@ module RuboCop
       #   end
       #   after(:all) { cleanup_feed }
       class EmptyHook < Cop
+        extend AutoCorrector
         include RuboCop::Cop::RangeHelp
 
         MSG = 'Empty hook detected.'
@@ -33,15 +34,11 @@ module RuboCop
 
         def on_block(node)
           empty_hook?(node) do |hook|
-            add_offense(hook)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            block = node.parent
-            range = range_with_surrounding_space(range: block.loc.expression)
-            corrector.remove(range)
+            add_offense(hook) do |corrector|
+              block = hook.parent
+              range = range_with_surrounding_space(range: block.loc.expression)
+              corrector.remove(range)
+            end
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -42,6 +42,7 @@ module RuboCop
       #   end
       #
       class EmptyLineAfterExample < Cop
+        extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add an empty line after `%<example>s`.'
@@ -52,9 +53,10 @@ module RuboCop
           return if allowed_one_liner?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(node,
-                        location: location,
-                        message: format(MSG, example: node.method_name))
+            msg = format(MSG, example: node.method_name)
+            add_offense(location, message: msg) do |corrector|
+              corrector.insert_after(location.end, "\n")
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -24,6 +24,7 @@ module RuboCop
       #   end
       #
       class EmptyLineAfterExampleGroup < Cop
+        extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add an empty line after `%<example_group>s`.'
@@ -33,11 +34,10 @@ module RuboCop
           return if last_child?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(
-              node,
-              location: location,
-              message: format(MSG, example_group: node.method_name)
-            )
+            msg = format(MSG, example_group: node.method_name)
+            add_offense(location, message: msg) do |corrector|
+              corrector.insert_after(location.end, "\n")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -17,6 +17,7 @@ module RuboCop
       #
       #   it { does_something }
       class EmptyLineAfterFinalLet < Cop
+        extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add an empty line after the last `let` block.'
@@ -30,7 +31,9 @@ module RuboCop
           return if last_child?(latest_let)
 
           missing_separating_line(latest_let) do |location|
-            add_offense(latest_let, location: location)
+            add_offense(location) do |corrector|
+              corrector.insert_after(location.end, "\n")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -34,6 +34,7 @@ module RuboCop
       #   it { does_something }
       #
       class EmptyLineAfterHook < Cop
+        extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add an empty line after `%<hook>s`.'
@@ -43,11 +44,10 @@ module RuboCop
           return if last_child?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(
-              node,
-              location: location,
-              message: format(MSG, hook: node.method_name)
-            )
+            msg = format(MSG, hook: node.method_name)
+            add_offense(location, message: msg) do |corrector|
+              corrector.insert_after(location.end, "\n")
+            end
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -15,6 +15,7 @@ module RuboCop
       #
       #   let(:foo) { bar }
       class EmptyLineAfterSubject < Cop
+        extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
         MSG = 'Add empty line after `subject`.'
@@ -24,7 +25,9 @@ module RuboCop
           return if last_child?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(node, location: location)
+            add_offense(location) do |corrector|
+              corrector.insert_after(location.end, "\n")
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -30,6 +30,8 @@ module RuboCop
       #   it 'does things' do
       #   end
       class ExampleWording < Cop
+        extend AutoCorrector
+
         MSG_SHOULD = 'Do not use should when describing your tests.'
         MSG_IT     = "Do not repeat 'it' when describing your tests."
 
@@ -53,16 +55,12 @@ module RuboCop
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(docstring(node), replacement_text(node))
-          end
-        end
-
         private
 
         def add_wording_offense(node, message)
-          add_offense(node, location: docstring(node), message: message)
+          add_offense(docstring(node), message: message) do |corrector|
+            corrector.replace(docstring(node), replacement_text(node))
+          end
         end
 
         def docstring(node)

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -17,6 +17,8 @@ module RuboCop
       #   expect(name).to eq("John")
       #
       class ExpectActual < Cop
+        extend AutoCorrector
+
         MSG = 'Provide the actual you are testing to `expect(...)`.'
 
         SIMPLE_LITERALS = %i[
@@ -55,17 +57,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          expect_literal(node) do |argument|
-            add_offense(node, location: argument.source_range)
-          end
-        end
+          expect_literal(node) do |actual, matcher, expected|
+            add_offense(actual.source_range) do |corrector|
+              next unless SUPPORTED_MATCHERS.include?(matcher)
 
-        def autocorrect(node)
-          actual, matcher, expected = expect_literal(node)
-          lambda do |corrector|
-            return unless SUPPORTED_MATCHERS.include?(matcher)
-
-            swap(corrector, actual, expected)
+              swap(corrector, actual, expected)
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -30,8 +30,8 @@ module RuboCop
           return if node.body.nil?
 
           expectation(node.body) do |expect|
-            add_offense(expect, location: :selector,
-                                message: message(expect, node))
+            add_offense(expect.loc.selector,
+                        message: message(expect, node))
           end
         end
 

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -27,7 +27,7 @@ module RuboCop
           name = variable_name[1..-1]
           return unless name.eql?('stdout') || name.eql?('stderr')
 
-          add_offense(node, location: :name, message: format(MSG, name: name))
+          add_offense(node.loc.name, message: format(MSG, name: name))
         end
 
         private

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -20,6 +20,8 @@ module RuboCop
         #   factory :foo, class: 'Foo' do
         #   end
         class FactoryClassName < Cop
+          extend AutoCorrector
+
           MSG = "Pass '%<class_name>s' string instead of `%<class_name>s` " \
                 'constant.'
           ALLOWED_CONSTANTS = %w[Hash OpenStruct].freeze
@@ -32,13 +34,10 @@ module RuboCop
             class_name(node) do |cn|
               next if allowed?(cn.const_name)
 
-              add_offense(cn, message: format(MSG, class_name: cn.const_name))
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              corrector.replace(node.loc.expression, "'#{node.source}'")
+              msg = format(MSG, class_name: cn.const_name)
+              add_offense(cn, message: msg) do |corrector|
+                corrector.replace(cn, "'#{cn.source}'")
+              end
             end
           end
 

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -58,6 +58,7 @@ module RuboCop
       #     # ...
       #   end
       class HookArgument < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         IMPLICIT_MSG = 'Omit the default `%<scope>p` ' \
@@ -78,18 +79,11 @@ module RuboCop
             return check_implicit(method_send) unless scope_name
 
             style_detected(scope_name)
-            add_offense(
-              method_send,
-              message: explicit_message(scope_name)
-            )
-          end
-        end
-
-        def autocorrect(node)
-          scope = implicit_style? ? '' : "(#{style.inspect})"
-
-          lambda do |corrector|
-            corrector.replace(argument_range(node), scope)
+            msg = explicit_message(scope_name)
+            add_offense(method_send, message: msg) do |corrector|
+              scope = implicit_style? ? '' : "(#{style.inspect})"
+              corrector.replace(argument_range(method_send), scope)
+            end
           end
         end
 
@@ -100,10 +94,12 @@ module RuboCop
           return if implicit_style?
 
           add_offense(
-            method_send,
-            location: :selector,
+            method_send.loc.selector,
             message: format(EXPLICIT_MSG, scope: style)
-          )
+          ) do |corrector|
+            scope = "(#{style.inspect})"
+            corrector.replace(argument_range(method_send), scope)
+          end
         end
 
         def explicit_message(scope)

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -24,6 +24,8 @@ module RuboCop
       #   end
       #
       class HooksBeforeExamples < Cop
+        extend AutoCorrector
+
         MSG = 'Move `%<hook>s` above the examples in the group.'
 
         def_node_matcher :example_or_group?, <<-PATTERN
@@ -37,15 +39,6 @@ module RuboCop
           return unless example_group_with_body?(node)
 
           check_hooks(node.body) if multiline_block?(node.body)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            first_example = find_first_example(node.parent)
-            RuboCop::RSpec::Corrector::MoveNode.new(
-              node, corrector, processed_source
-            ).move_before(first_example)
-          end
         end
 
         private
@@ -62,15 +55,21 @@ module RuboCop
             next if child.sibling_index < first_example.sibling_index
             next unless hook?(child)
 
-            add_offense(
-              child,
-              message: format(MSG, hook: child.method_name)
-            )
+            msg = format(MSG, hook: child.method_name)
+            add_offense(child, message: msg) do |corrector|
+              autocorrect(corrector, child, first_example)
+            end
           end
         end
 
         def find_first_example(node)
           node.children.find { |sibling| example_or_group?(sibling) }
+        end
+
+        def autocorrect(corrector, node, first_example)
+          RuboCop::RSpec::Corrector::MoveNode.new(
+            node, corrector, processed_source
+          ).move_before(first_example)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -25,6 +25,7 @@ module RuboCop
       #   it { should be_truthy }
       #
       class ImplicitExpect < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<good>s` over `%<bad>s`.'
@@ -55,19 +56,12 @@ module RuboCop
             opposite_style_detected
 
             add_offense(
-              node,
-              location: source_range,
+              source_range,
               message: offense_message(expectation_source)
-            )
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            offense     = offending_expect(node)
-            replacement = replacement_source(offense.source)
-
-            corrector.replace(offense, replacement)
+            ) do |corrector|
+              replacement = replacement_source(expectation_source)
+              corrector.replace(source_range, replacement)
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -27,6 +27,7 @@ module RuboCop
       #   it { expect(subject).to be_truthy }
       #
       class ImplicitSubject < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         MSG = "Don't use implicit subject."
@@ -39,10 +40,14 @@ module RuboCop
           return unless implicit_subject?(node)
           return if valid_usage?(node)
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
-        def autocorrect(node)
+        private
+
+        def autocorrect(corrector, node)
           replacement = 'expect(subject)'
           if node.method_name == :should
             replacement += '.to'
@@ -50,10 +55,8 @@ module RuboCop
             replacement += '.not_to'
           end
 
-          ->(corrector) { corrector.replace(node.loc.selector, replacement) }
+          corrector.replace(node.loc.selector, replacement)
         end
-
-        private
 
         def valid_usage?(node)
           example = node.ancestors.find { |parent| example?(parent) }

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -19,6 +19,8 @@ module RuboCop
       #   end
       #
       class InstanceSpy < Cop
+        extend AutoCorrector
+
         MSG = 'Use `instance_spy` when you check your double '\
               'with `have_received`.'
 
@@ -43,22 +45,26 @@ module RuboCop
 
           null_double(node) do |var, receiver|
             have_received_usage(node) do |expected|
-              add_offense(receiver) if expected == var
+              next if expected != var
+
+              add_offense(receiver) do |corrector|
+                autocorrect(corrector, receiver)
+              end
             end
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            replacement = 'instance_spy'
-            corrector.replace(node.loc.selector, replacement)
+        private
 
-            double_source_map = node.parent.loc
-            as_null_object_range = double_source_map
-              .dot
-              .join(double_source_map.selector)
-            corrector.remove(as_null_object_range)
-          end
+        def autocorrect(corrector, node)
+          replacement = 'instance_spy'
+          corrector.replace(node.loc.selector, replacement)
+
+          double_source_map = node.parent.loc
+          as_null_object_range = double_source_map
+            .dot
+            .join(double_source_map.selector)
+          corrector.remove(as_null_object_range)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/invalid_predicate_matcher.rb
@@ -24,7 +24,8 @@ module RuboCop
 
         def on_send(node)
           invalid_predicate_matcher?(node) do |predicate|
-            add_offense(predicate)
+            add_offense(predicate,
+                        message: format(MSG, matcher: predicate.method_name))
           end
         end
 
@@ -33,10 +34,6 @@ module RuboCop
         def predicate?(name)
           name = name.to_s
           name.start_with?('be_', 'have_') && name.end_with?('?')
-        end
-
-        def message(predicate)
-          format(MSG, matcher: predicate.method_name)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -19,6 +19,7 @@ module RuboCop
       #   # good
       #   it_should_behave_like 'a foo'
       class ItBehavesLike < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<replacement>s` over `%<original>s` when including '\
@@ -28,12 +29,10 @@ module RuboCop
 
         def on_send(node)
           example_inclusion_offense(node, alternative_style) do
-            add_offense(node)
+            add_offense(node) do |corrector|
+              corrector.replace(node.loc.selector, style.to_s)
+            end
           end
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.selector, style.to_s) }
         end
 
         private

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -32,6 +32,8 @@ module RuboCop
       #     it { expect_something_else }
       #
       class LeadingSubject < Cop
+        extend AutoCorrector
+
         MSG = 'Declare `subject` above any other `%<offending>s` declarations.'
 
         def on_block(node)
@@ -43,26 +45,24 @@ module RuboCop
         def check_previous_nodes(node)
           node.parent.each_child_node do |sibling|
             if offending?(sibling)
-              add_offense(
-                node,
-                message: format(MSG, offending: sibling.method_name)
-              )
+              msg = format(MSG, offending: sibling.method_name)
+              add_offense(node, message: msg) do |corrector|
+                autocorrect(corrector, node)
+              end
             end
 
             break if offending?(sibling) || sibling.equal?(node)
           end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            first_node = find_first_offending_node(node)
-            RuboCop::RSpec::Corrector::MoveNode.new(
-              node, corrector, processed_source
-            ).move_before(first_node)
-          end
-        end
-
         private
+
+        def autocorrect(corrector, node)
+          first_node = find_first_offending_node(node)
+          RuboCop::RSpec::Corrector::MoveNode.new(
+            node, corrector, processed_source
+          ).move_before(first_node)
+        end
 
         def offending?(node)
           let?(node) || hook?(node) || example?(node)

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -21,11 +21,12 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          message_chain(node) { add_offense(node, location: :selector) }
-        end
-
-        def message(node)
-          format(MSG, method: node.method_name)
+          message_chain(node) do
+            add_offense(
+              node.loc.selector,
+              message: format(MSG, method: node.method_name)
+            )
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -42,7 +42,7 @@ module RuboCop
             return correct_style_detected if preferred_style?(match)
 
             message = format(MSG, style: style)
-            add_offense(match, location: :selector, message: message) do
+            add_offense(match.loc.selector, message: message) do
               opposite_style_detected
             end
           end

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -48,8 +48,7 @@ module RuboCop
             return correct_style_detected if preferred_style?(message_matcher)
 
             add_offense(
-              message_matcher,
-              location: :selector,
+              message_matcher.loc.selector,
               message: error_message(receiver)
             ) { opposite_style_detected }
           end

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -34,6 +34,7 @@ module RuboCop
       #     This is enough of an edge case that people can just move this to
       #     a `before` hook on their own
       class MultipleSubjects < Cop
+        extend AutoCorrector
         include RangeHelp
 
         MSG = 'Do not set more than one subject per example group'
@@ -44,38 +45,36 @@ module RuboCop
           subjects = RuboCop::RSpec::ExampleGroup.new(node).subjects
 
           subjects[0...-1].each do |subject|
-            add_offense(subject)
-          end
-        end
-
-        def autocorrect(node)
-          return unless node.method_name.equal?(:subject) # Ignore `subject!`
-
-          if named_subject?(node)
-            rename_autocorrect(node)
-          else
-            remove_autocorrect(node)
+            add_offense(subject) do |corrector|
+              autocorrect(corrector, subject)
+            end
           end
         end
 
         private
 
+        def autocorrect(corrector, subject)
+          return unless subject.method_name.equal?(:subject) # Ignore `subject!`
+
+          if named_subject?(subject)
+            rename_autocorrect(corrector, subject)
+          else
+            remove_autocorrect(corrector, subject)
+          end
+        end
+
         def named_subject?(node)
           node.send_node.arguments?
         end
 
-        def rename_autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.send_node.loc.selector, 'let')
-          end
+        def rename_autocorrect(corrector, node)
+          corrector.replace(node.send_node.loc.selector, 'let')
         end
 
-        def remove_autocorrect(node)
-          lambda do |corrector|
-            range = range_by_whole_lines(node.source_range,
-                                         include_final_newline: true)
-            corrector.remove(range)
-          end
+        def remove_autocorrect(corrector, node)
+          range = range_by_whole_lines(node.source_range,
+                                       include_final_newline: true)
+          corrector.remove(range)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -62,7 +62,7 @@ module RuboCop
           return if !rspec_block?(node) || ignored_shared_example?(node)
 
           subject_usage(node) do |subject_node|
-            add_offense(subject_node, location: :selector)
+            add_offense(subject_node.loc.selector)
           end
         end
 

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -16,6 +16,7 @@ module RuboCop
       #     expect(false).not_to be_true
       #   end
       class NotToNot < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<replacement>s` over `%<original>s`.'
@@ -24,12 +25,10 @@ module RuboCop
 
         def on_send(node)
           not_to_not_offense(node, alternative_style) do
-            add_offense(node, location: :selector)
+            add_offense(node.loc.selector) do |corrector|
+              corrector.replace(node.loc.selector, style.to_s)
+            end
           end
-        end
-
-        def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.selector, style.to_s) }
         end
 
         private

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -31,6 +31,7 @@ module RuboCop
         #   it { is_expected.to have_http_status :error }
         #
         class HttpStatus < Cop
+          extend AutoCorrector
           include ConfigurableEnforcedStyle
 
           def_node_matcher :http_status, <<-PATTERN
@@ -42,14 +43,9 @@ module RuboCop
               checker = checker_class.new(ast_node)
               return unless checker.offensive?
 
-              add_offense(checker.node, message: checker.message)
-            end
-          end
-
-          def autocorrect(node)
-            lambda do |corrector|
-              checker = checker_class.new(node)
-              corrector.replace(node.loc.expression, checker.preferred_style)
+              add_offense(checker.node, message: checker.message) do |corrector|
+                corrector.replace(checker.node, checker.preferred_style)
+              end
             end
           end
 

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -14,6 +14,7 @@ module RuboCop
       #     expect(foo).not_to receive(:bar)
       #
       class ReceiveNever < Cop
+        extend AutoCorrector
         MSG = 'Use `not_to receive` instead of `never`.'
 
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
@@ -21,18 +22,17 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :never && method_on_stub?(node)
 
-          add_offense(
-            node,
-            location: :selector
-          )
+          add_offense(node.loc.selector) do |corrector|
+            autocorrect(corrector, node)
+          end
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            corrector.replace(node.parent.loc.selector, 'not_to')
-            range = node.loc.dot.with(end_pos: node.loc.selector.end_pos)
-            corrector.remove(range)
-          end
+        private
+
+        def autocorrect(corrector, node)
+          corrector.replace(node.parent.loc.selector, 'not_to')
+          range = node.loc.dot.with(end_pos: node.loc.selector.end_pos)
+          corrector.remove(range)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -34,6 +34,7 @@ module RuboCop
       #   allow(Foo).to receive(:bar) { bar.baz }
       #
       class ReturnFromStub < Cop
+        extend AutoCorrector
         include ConfigurableEnforcedStyle
 
         MSG_AND_RETURN = 'Use `and_return` for static values.'
@@ -59,24 +60,17 @@ module RuboCop
           check_block_body(node)
         end
 
-        def autocorrect(node)
-          if style == :block
-            AndReturnCallCorrector.new(node)
-          else
-            BlockBodyCorrector.new(node)
-          end
-        end
-
         private
 
         def check_and_return_call(node)
           and_return_value(node) do |and_return, args|
             unless dynamic?(args)
               add_offense(
-                and_return,
-                location: :selector,
+                and_return.loc.selector,
                 message: MSG_BLOCK
-              )
+              ) do |corrector|
+                AndReturnCallCorrector.new(and_return).call(corrector)
+              end
             end
           end
         end
@@ -85,10 +79,11 @@ module RuboCop
           body = block.body
           unless dynamic?(body) # rubocop:disable Style/GuardClause
             add_offense(
-              block,
-              location: :begin,
+              block.loc.begin,
               message: MSG_AND_RETURN
-            )
+            ) do |corrector|
+              BlockBodyCorrector.new(block).call(corrector)
+            end
           end
         end
 
@@ -153,7 +148,7 @@ module RuboCop
             return if heredoc?
 
             corrector.replace(
-              block.loc.expression,
+              block,
               "#{block.send_node.source}.and_return(#{body.source})"
             )
           end

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -27,21 +27,14 @@ module RuboCop
       #   end
       #
       class ScatteredLet < Cop
+        extend AutoCorrector
+
         MSG = 'Group all let/let! blocks in the example group together.'
 
         def on_block(node)
           return unless example_group_with_body?(node)
 
           check_let_declarations(node.body)
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            first_let = find_first_let(node.parent)
-            RuboCop::RSpec::Corrector::MoveNode.new(
-              node, corrector, processed_source
-            ).move_after(first_let)
-          end
         end
 
         private
@@ -53,7 +46,11 @@ module RuboCop
           lets.each_with_index do |node, idx|
             next if node.sibling_index == first_let.sibling_index + idx
 
-            add_offense(node)
+            add_offense(node) do |corrector|
+              RuboCop::RSpec::Corrector::MoveNode.new(
+                node, corrector, processed_source
+              ).move_after(first_let)
+            end
           end
         end
 

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -51,6 +51,8 @@ module RuboCop
       #   end
       #
       class SharedContext < Cop
+        extend AutoCorrector
+
         MSG_EXAMPLES = "Use `shared_examples` when you don't "\
                        'define context.'
 
@@ -68,22 +70,14 @@ module RuboCop
 
         def on_block(node)
           context_with_only_examples(node) do
-            add_shared_item_offense(node.send_node, MSG_EXAMPLES)
+            add_offense(node.send_node, message: MSG_EXAMPLES) do |corrector|
+              corrector.replace(node.send_node.loc.selector, 'shared_examples')
+            end
           end
 
           examples_with_only_context(node) do
-            add_shared_item_offense(node.send_node, MSG_CONTEXT)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            context_with_only_examples(node.parent) do
-              corrector.replace(node.loc.selector, 'shared_examples')
-            end
-
-            examples_with_only_context(node.parent) do
-              corrector.replace(node.loc.selector, 'shared_context')
+            add_offense(node.send_node, message: MSG_CONTEXT) do |corrector|
+              corrector.replace(node.send_node.loc.selector, 'shared_context')
             end
           end
         end
@@ -96,13 +90,6 @@ module RuboCop
 
         def examples_with_only_context(node)
           shared_example(node) { yield if context?(node) && !examples?(node) }
-        end
-
-        def add_shared_item_offense(node, message)
-          add_offense(
-            node,
-            message: message
-          )
         end
       end
     end

--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -21,6 +21,8 @@ module RuboCop
       #   include_examples 'foo bar baz'
       #
       class SharedExamples < Cop
+        extend AutoCorrector
+
         def_node_matcher :shared_examples,
                          (SharedGroups::ALL + Includes::ALL).send_pattern
 
@@ -30,14 +32,9 @@ module RuboCop
             next unless ast_node&.sym_type?
 
             checker = Checker.new(ast_node)
-            add_offense(checker.node, message: checker.message)
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            checker = Checker.new(node)
-            corrector.replace(node.loc.expression, checker.preferred_style)
+            add_offense(checker.node, message: checker.message) do |corrector|
+              corrector.replace(checker.node, checker.preferred_style)
+            end
           end
         end
 

--- a/lib/rubocop/rspec/blank_line_separation.rb
+++ b/lib/rubocop/rspec/blank_line_separation.rb
@@ -32,14 +32,6 @@ module RuboCop
 
         node.equal?(node.parent.children.last)
       end
-
-      def autocorrect(node)
-        lambda do |corrector|
-          missing_separating_line(node) do |location|
-            corrector.insert_after(location.end, "\n")
-          end
-        end
-      end
     end
   end
 end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.68.1'
+  spec.add_runtime_dependency 'rubocop', '>= 0.87.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -308,12 +308,10 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
     let(:cop_config) { {} }
 
     it 'ignores rspec-rails routing specs' do
-      inspect_source(
+      expect_no_offenses(
         'expect(get: "/foo").to be_routeable',
         'spec/routing/foo_spec.rb'
       )
-
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -40,7 +40,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     ]
     config = config.for_cop(cop)
     safe_auto_correct = config.fetch('SafeAutoCorrect', true)
-    autocorrect = if cop.new.support_autocorrect?
+    autocorrect = if cop.support_autocorrect?
                     "Yes #{'(Unsafe)' unless safe_auto_correct}"
                   else
                     'No'


### PR DESCRIPTION
The autocorrection API was changed in Rubocop v0.87.0 (pull request rubocop-hq/rubocop#7868). This PR makes rubocop-rspec compatible with those changes.

The superclass of `RuboCop::Cop::RSpec::Cop` is changed from `::RuboCop::Cop::Cop` to `::RuboCop::Cop::Base`.

This has a few consequences:

- Our `#message` methods get called with a different argument than before. It *can* be customized by defining a `#callback_argument` method, but I think it is clearer to avoid callbacks altogether.
- Our `#autocorrect` methods don't get called anymore. Instead, we extend `Autocorrector`, and the `corrector` is being yielded when calling `#add_offense`, so the code is mostly moved in there. For some cases, this means that some code can be removed, which is nice. For some cases, it means that the methods get too long, or the code complexity gets too high, and in those cases I chose to just call out to an `#autocorrect` method anyway, but of course passing the `corrector` and any usable local variables along.
- Our dependency of RuboCop is bumped from '>= 0.68.1' to '>= 0.87.0'.

See also https://github.com/rubocop-hq/rubocop/blob/master/docs/modules/ROOT/pages/v1_upgrade_notes.adoc for documentation of many of the changes.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).