### PR TITLE
Bump version to v1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (Unreleased)
 
+## 1.42.0 (2020-07-09)
+
+* Update RuboCop dependency to 0.87.0 because of changes to internal APIs. ([@bquorning][], [@Darhazer][])
+
 ## 1.41.0 (2020-07-03)
 
 * Extend the list of Rails spec types for `RSpec/DescribeClass`. ([@pirj][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.41.0'
+      STRING = '1.42.0'
     end
   end
 end


### PR DESCRIPTION
As mentioned in #955, the internal API for autocorrections changed in RuboCop v0.87.0 (rubocop-hq/rubocop#7868), and we already have bug reports because of this incompatibility. Fixes #957.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
