### PR TITLE
Remove unnecessary captures in CreateList

### DIFF
--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -44,7 +44,7 @@ module RuboCop
           PATTERN
 
           def_node_matcher :factory_list_call, <<-PATTERN
-            (send ${(const nil? {:FactoryGirl :FactoryBot}) nil?} :create_list (sym $_) (int $_) $...)
+            (send {(const nil? {:FactoryGirl :FactoryBot}) nil?} :create_list (sym _) (int $_) ...)
           PATTERN
 
           def on_block(node)
@@ -60,7 +60,7 @@ module RuboCop
           def on_send(node)
             return unless style == :n_times
 
-            factory_list_call(node) do |_receiver, _factory, count, _|
+            factory_list_call(node) do |count|
               message = format(MSG_N_TIMES, number: count)
               add_offense(node.loc.selector, message: message) do |corrector|
                 TimesCorrector.new(node).call(corrector)


### PR DESCRIPTION
As requested in https://github.com/rubocop-hq/rubocop-rspec/pull/955#discussion_r451807603, let’s remove unnecessary captures from FactoryBot/CreatList.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
