### PR TITLE
Extract some shared logic to BlankLineSeparation

### DIFF
--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -23,7 +23,7 @@ require_relative 'rubocop/cop/rspec/cop'
 require_relative 'rubocop/rspec/align_let_brace'
 require_relative 'rubocop/rspec/factory_bot'
 require_relative 'rubocop/rspec/final_end_location'
-require_relative 'rubocop/rspec/blank_line_separation'
+require_relative 'rubocop/rspec/empty_line_separation'
 require_relative 'rubocop/rspec/corrector/move_node'
 
 RuboCop::RSpec::Inject.defaults!

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -43,7 +43,7 @@ module RuboCop
       #
       class EmptyLineAfterExample < Cop
         extend AutoCorrector
-        include RuboCop::RSpec::BlankLineSeparation
+        include RuboCop::RSpec::EmptyLineSeparation
 
         MSG = 'Add an empty line after `%<example>s`.'
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -49,14 +49,10 @@ module RuboCop
 
         def on_block(node)
           return unless example?(node)
-          return if last_child?(node)
           return if allowed_one_liner?(node)
 
-          missing_separating_line(node) do |location|
-            msg = format(MSG, example: node.method_name)
-            add_offense(location, message: msg) do |corrector|
-              corrector.insert_after(location.end, "\n")
-            end
+          missing_separating_line_offense(node) do |method|
+            format(MSG, example: method)
           end
         end
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -31,13 +31,9 @@ module RuboCop
 
         def on_block(node)
           return unless example_group?(node)
-          return if last_child?(node)
 
-          missing_separating_line(node) do |location|
-            msg = format(MSG, example_group: node.method_name)
-            add_offense(location, message: msg) do |corrector|
-              corrector.insert_after(location.end, "\n")
-            end
+          missing_separating_line_offense(node) do |method|
+            format(MSG, example_group: method)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -25,7 +25,7 @@ module RuboCop
       #
       class EmptyLineAfterExampleGroup < Cop
         extend AutoCorrector
-        include RuboCop::RSpec::BlankLineSeparation
+        include RuboCop::RSpec::EmptyLineSeparation
 
         MSG = 'Add an empty line after `%<example_group>s`.'
 

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   it { does_something }
       class EmptyLineAfterFinalLet < Cop
         extend AutoCorrector
-        include RuboCop::RSpec::BlankLineSeparation
+        include RuboCop::RSpec::EmptyLineSeparation
 
         MSG = 'Add an empty line after the last `%<let>s`.'
 

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -20,7 +20,7 @@ module RuboCop
         extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add an empty line after the last `let` block.'
+        MSG = 'Add an empty line after the last `%<let>s`.'
 
         def on_block(node)
           return unless example_group_with_body?(node)
@@ -31,7 +31,8 @@ module RuboCop
           return if last_child?(latest_let)
 
           missing_separating_line(latest_let) do |location|
-            add_offense(location) do |corrector|
+            msg = format(MSG, let: latest_let.method_name)
+            add_offense(location, message: msg) do |corrector|
               corrector.insert_after(location.end, "\n")
             end
           end

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -28,13 +28,9 @@ module RuboCop
           latest_let = node.body.child_nodes.select { |child| let?(child) }.last
 
           return if latest_let.nil?
-          return if last_child?(latest_let)
 
-          missing_separating_line(latest_let) do |location|
-            msg = format(MSG, let: latest_let.method_name)
-            add_offense(location, message: msg) do |corrector|
-              corrector.insert_after(location.end, "\n")
-            end
+          missing_separating_line_offense(latest_let) do |method|
+            format(MSG, let: method)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -41,13 +41,9 @@ module RuboCop
 
         def on_block(node)
           return unless hook?(node)
-          return if last_child?(node)
 
-          missing_separating_line(node) do |location|
-            msg = format(MSG, hook: node.method_name)
-            add_offense(location, message: msg) do |corrector|
-              corrector.insert_after(location.end, "\n")
-            end
+          missing_separating_line_offense(node) do |method|
+            format(MSG, hook: method)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -35,7 +35,7 @@ module RuboCop
       #
       class EmptyLineAfterHook < Cop
         extend AutoCorrector
-        include RuboCop::RSpec::BlankLineSeparation
+        include RuboCop::RSpec::EmptyLineSeparation
 
         MSG = 'Add an empty line after `%<hook>s`.'
 

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -18,14 +18,15 @@ module RuboCop
         extend AutoCorrector
         include RuboCop::RSpec::BlankLineSeparation
 
-        MSG = 'Add empty line after `subject`.'
+        MSG = 'Add an empty line after `%<subject>s`.'
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)
           return if last_child?(node)
 
           missing_separating_line(node) do |location|
-            add_offense(location) do |corrector|
+            msg = format(MSG, subject: node.method_name)
+            add_offense(location, message: msg) do |corrector|
               corrector.insert_after(location.end, "\n")
             end
           end

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   let(:foo) { bar }
       class EmptyLineAfterSubject < Cop
         extend AutoCorrector
-        include RuboCop::RSpec::BlankLineSeparation
+        include RuboCop::RSpec::EmptyLineSeparation
 
         MSG = 'Add an empty line after `%<subject>s`.'
 

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -22,13 +22,9 @@ module RuboCop
 
         def on_block(node)
           return unless subject?(node) && !in_spec_block?(node)
-          return if last_child?(node)
 
-          missing_separating_line(node) do |location|
-            msg = format(MSG, subject: node.method_name)
-            add_offense(location, message: msg) do |corrector|
-              corrector.insert_after(location.end, "\n")
-            end
+          missing_separating_line_offense(node) do |method|
+            format(MSG, subject: method)
           end
         end
 

--- a/lib/rubocop/rspec/empty_line_separation.rb
+++ b/lib/rubocop/rspec/empty_line_separation.rb
@@ -2,9 +2,9 @@
 
 module RuboCop
   module RSpec
-    # Helps determine the offending location if there is not a blank line
+    # Helps determine the offending location if there is not an empty line
     # following the node. Allows comments to follow directly after.
-    module BlankLineSeparation
+    module EmptyLineSeparation
       include FinalEndLocation
       include RuboCop::Cop::RangeHelp
 

--- a/lib/rubocop/rspec/empty_line_separation.rb
+++ b/lib/rubocop/rspec/empty_line_separation.rb
@@ -8,6 +8,17 @@ module RuboCop
       include FinalEndLocation
       include RuboCop::Cop::RangeHelp
 
+      def missing_separating_line_offense(node)
+        return if last_child?(node)
+
+        missing_separating_line(node) do |location|
+          msg = yield(node.method_name)
+          add_offense(location, message: msg) do |corrector|
+            corrector.insert_after(location.end, "\n")
+          end
+        end
+      end
+
       def missing_separating_line(node)
         line = final_end_location(node).line
 

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
-        ^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        ^^^^^^^^^^^^^ Add an empty line after the last `let`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         let!(:b) do
           b
         end
-        ^^^ Add an empty line after the last `let` block.
+        ^^^ Add an empty line after the last `let!`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       RSpec.describe User do
         let(:a) { a }
         let(:user, &args[:build_user])
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         let(:a) { a }
         let(:b) { b }
         # end of setup
-        ^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        ^^^^^^^^^^^^^^ Add an empty line after the last `let`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         let(:b) { b }
         # a multiline comment marking
         # the end of setup
-        ^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        ^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         subject { described_class }
 
         let!(:b) { b }
-        ^^^^^^^^^^^^^^ Add an empty line after the last `let` block.
+        ^^^^^^^^^^^^^^ Add an empty line after the last `let!`.
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
         hello
         world
         BAR
-        ^^^ Add an empty line after the last `let` block.
+        ^^^ Add an empty line after the last `let`.
         it 'has tricky syntax' do
           expect(foo).to eql("  hello\n  world\n")
         end

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after `subject`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
         let(:params) { foo }
       end
     RUBY
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject! { described_class.new }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add empty line after `subject`.
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject!`.
         let(:params) { foo }
       end
     RUBY


### PR DESCRIPTION
In 0289cd892ba5e34b67140a98a985db476e3f10f1, a bunch of logic was extracted into `BlankLineSeparation` module. In this PR I extract another bit.

Please help me with the naming of the method. I am not sure if `check_missing_separating_lines` is the best name.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
