### PR TITLE
Enable new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.4
+  NewCops: enable
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -39,7 +39,7 @@ module RuboCop
 
           def on_block(node)
             attributes = factory_attributes(node) || []
-            attributes = [attributes] unless attributes.is_a?(Array)
+            attributes = [attributes] unless attributes.is_a?(Array) # rubocop:disable Style/ArrayCoercion, Lint/RedundantCopDisableDirective
 
             attributes.each do |attribute|
               next unless offensive_receiver?(attribute.receiver, node)

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -49,9 +49,10 @@ module RuboCop
 
         def autocorrect(corrector, node)
           replacement = 'expect(subject)'
-          if node.method_name == :should
+          case node.method_name
+          when :should
             replacement += '.to'
-          elsif node.method_name == :should_not
+          when :should_not
             replacement += '.not_to'
           end
 
@@ -66,9 +67,10 @@ module RuboCop
         end
 
         def allowed_by_style?(example)
-          if style == :single_line_only
+          case style
+          when :single_line_only
             example.single_line?
-          elsif style == :single_statement_only
+          when :single_statement_only
             !example.body.begin_type?
           else
             false

--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'CHANGELOG.md' do
     describe 'link to related issue on github' do
       let(:issues) do
         entries.map do |entry|
-          entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^\)]+)\)/)
+          entry.match(/\[(?<number>[#\d]+)\]\((?<url>[^)]+)\)/)
         end.compact
       end
 
@@ -58,7 +58,7 @@ RSpec.describe 'CHANGELOG.md' do
         entries.map do |entry|
           entry
             .sub(/^\*\s*(?:\[.+?\):\s*)?/, '')
-            .sub(/\s*\([^\)]+\)$/, '')
+            .sub(/\s*\([^)]+\)$/, '')
         end
       end
 
@@ -69,7 +69,7 @@ RSpec.describe 'CHANGELOG.md' do
       end
 
       it 'ends with a punctuation' do
-        expect(bodies).to all(match(/[\.\!]$/))
+        expect(bodies).to all(match(/[.!]$/))
       end
     end
   end


### PR DESCRIPTION
After the update, lets enable the new Rubocop cops on our codebase. Almost everything was passing anyway
Note: this will keep all cops added enabled in rubocop edge, so we will get a warning for added cops that would introduce offenses. The alternative would be enabling of cops one by one. But our codebase is already the best, so what's the chance of introducing an offense :smile: 


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Updated documentation.~
* [x] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
