### PR TITLE
Use rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 inherit_from: .rubocop_todo.yml
+
 require:
+ - rubocop-performance
  - rubocop-rspec
  - rubocop/cop/internal_affairs
 

--- a/lib/rubocop/cop/rspec/cop.rb
+++ b/lib/rubocop/cop/rspec/cop.rb
@@ -41,7 +41,7 @@ module RuboCop
         private
 
         def relevant_rubocop_rspec_file?(file)
-          rspec_pattern =~ file
+          rspec_pattern.match?(file)
         end
 
         def rspec_pattern

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -64,7 +64,7 @@ module RuboCop
 
         def string_constant_describe?(described_value)
           described_value.str_type? &&
-            described_value.value =~ /^((::)?[A-Z]\w*)+$/
+            described_value.value.match?(/^(?:(?:::)?[A-Z]\w*)+$/)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -25,11 +25,11 @@ module RuboCop
         def on_block(node)
           return unless example_group_with_body?(node)
 
-          latest_let = node.body.child_nodes.select { |child| let?(child) }.last
+          final_let = node.body.child_nodes.reverse.find { |child| let?(child) }
 
-          return if latest_let.nil?
+          return if final_let.nil?
 
-          missing_separating_line_offense(latest_let) do |method|
+          missing_separating_line_offense(final_let) do |method|
             format(MSG, let: method)
           end
         end

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -47,9 +47,9 @@ module RuboCop
 
         def on_block(node)
           it_description(node) do |description_node, message|
-            if message =~ SHOULD_PREFIX
+            if message.match?(SHOULD_PREFIX)
               add_wording_offense(description_node, MSG_SHOULD)
-            elsif message =~ IT_PREFIX
+            elsif message.match?(IT_PREFIX)
               add_wording_offense(description_node, MSG_IT)
             end
           end
@@ -77,7 +77,7 @@ module RuboCop
         def replacement_text(node)
           text = text(node)
 
-          if text =~ SHOULD_PREFIX
+          if text.match?(SHOULD_PREFIX)
             RuboCop::RSpec::Wording.new(
               text,
               ignore:  ignored_words,

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.7'
   # Workaround for cc-test-reporter with SimpleCov 0.18.
   # Stop upgrading SimpleCov until the following issue will be resolved.
   # https://github.com/codeclimate/test-reporter/issues/418


### PR DESCRIPTION
[Rubocop-performance](https://github.com/rubocop-hq/rubocop-performance/) recommended using `reverse.find` over `select.last`, and `match?` over `=~`. The last one led to me finding two unused regex captures, which I prefixed with `?:` to not generate captures at all.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).