### PR TITLE
Ignore trailing punctuation in context prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add a new base cop class `::RuboCop::Cop::RSpec::Base`. The old base class `::RuboCop::Cop::RSpec::Cop` is deprecated, and will be removed in the next major release. ([@bquorning][])
 * Add support for subject detection after includes and example groups in `RSpec/LeadingSubject`. ([@pirj][])
+* Ignore trailing punctuation in context description prefix. ([@elliterate][])
 
 ## 1.42.0 (2020-07-09)
 
@@ -532,3 +533,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rolfschmidt]: https://github.com/rolfschmidt
 [@andrykonchin]: https://github.com/andrykonchin
 [@harrylewis]: https://github.com/harrylewis
+[@elliterate]: https://github.com/elliterate

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -51,7 +51,7 @@ module RuboCop
         private
 
         def bad_prefix?(description)
-          !prefixes.include?(description.split.first)
+          !prefixes.include?(description.split(/\b/).first)
         end
 
         def joined_prefixes

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
     RUBY
   end
 
+  it "skips descriptions beginning with 'when,'" do
+    expect_no_offenses(<<-RUBY)
+      context 'when, for some inexplicable reason, you inject a subordinate clause' do
+      end
+    RUBY
+  end
+
   it 'finds context without separate `when` at the beginning' do
     expect_offense(<<-RUBY)
       context 'whenever you do' do


### PR DESCRIPTION
By splitting on word boundaries rather than whitespace (the default), we can easily ignore trailing punctuation on the first word of the context description.

Note: I didn't update any documentation because this seemed more like a bug fix than a change in behavior.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).