### PR TITLE
Improve cops by using TopLevelGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Relax `RSpec/VariableDefinition` cop so interpolated and multiline strings are accepted even when configured to enforce the `symbol` style. ([@bquorning][])
 * Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][])
 * Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
+* Improve `RSpec/NestedGroups`, `RSpec/FilePath`, `RSpec/DescribeMethod`, `RSpec/MultipleDescribes`, `RSpec/DescribeClass`'s top-level example group detection. ([@pirj][])
 
 ## 1.42.0 (2020-07-09)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -74,7 +74,7 @@ RSpec/ContextWording:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:
-  Description: Check that the first argument to the top level describe is a constant.
+  Description: Check that the first argument to the top-level describe is a constant.
   Enabled: true
   VersionAdded: '1.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass

--- a/config/default.yml
+++ b/config/default.yml
@@ -381,7 +381,7 @@ RSpec/MissingExampleGroupArgument:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
 
 RSpec/MultipleDescribes:
-  Description: Checks for multiple top level describes.
+  Description: Checks for multiple top-level example groups.
   Enabled: true
   VersionAdded: '1.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks for multiple top level describes.
+      # Checks for multiple top-level example groups.
       #
       # Multiple descriptions for the same class or module should either
       # be nested or separated into different test files.
@@ -23,16 +23,19 @@ module RuboCop
       #     end
       #   end
       class MultipleDescribes < Base
-        include RuboCop::RSpec::TopLevelDescribe
+        include RuboCop::RSpec::TopLevelGroup
 
-        MSG = 'Do not use multiple top level describes - '\
+        MSG = 'Do not use multiple top-level example groups - '\
               'try to nest them.'
 
-        def on_top_level_describe(node, _args)
-          return if single_top_level_describe?
-          return unless top_level_nodes.first.equal?(node)
+        def on_top_level_group(node)
+          top_level_example_groups =
+            top_level_groups.select(&method(:example_group?))
 
-          add_offense(node)
+          return if top_level_example_groups.one?
+          return unless top_level_example_groups.first.equal?(node)
+
+          add_offense(node.send_node)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -87,7 +87,7 @@ module RuboCop
       #
       class NestedGroups < Base
         include ConfigurableMax
-        include RuboCop::RSpec::TopLevelDescribe
+        include RuboCop::RSpec::TopLevelGroup
 
         MSG = 'Maximum example group nesting exceeded [%<total>d/%<max>d].'
 
@@ -97,8 +97,8 @@ module RuboCop
           "Configuration key `#{DEPRECATED_MAX_KEY}` for #{cop_name} is " \
           'deprecated in favor of `Max`. Please use that instead.'
 
-        def on_top_level_describe(node, _args)
-          find_nested_example_groups(node.parent) do |example_group, nesting|
+        def on_top_level_group(node)
+          find_nested_example_groups(node) do |example_group, nesting|
             self.max = nesting
             add_offense(
               example_group.send_node,

--- a/lib/rubocop/rspec/top_level_group.rb
+++ b/lib/rubocop/rspec/top_level_group.rb
@@ -25,14 +25,16 @@ module RuboCop
 
       def top_level_groups
         @top_level_groups ||=
-          top_level_nodes.select { |n| example_or_shared_group?(n) }
+          top_level_nodes(root_node).select { |n| example_or_shared_group?(n) }
       end
 
-      def top_level_nodes
-        if root_node.begin_type?
-          root_node.children
+      def top_level_nodes(node)
+        if node.begin_type?
+          node.children
+        elsif node.module_type? || node.class_type?
+          top_level_nodes(node.body)
         else
-          [root_node]
+          [node]
         end
       end
 

--- a/lib/rubocop/rspec/top_level_group.rb
+++ b/lib/rubocop/rspec/top_level_group.rb
@@ -10,22 +10,31 @@ module RuboCop
       def_node_matcher :example_or_shared_group?,
                        (ExampleGroups::ALL + SharedGroups::ALL).block_pattern
 
-      def on_block(node)
-        return unless respond_to?(:on_top_level_group)
-        return unless top_level_group?(node)
+      def on_new_investigation
+        super
 
-        on_top_level_group(node)
-      end
+        return unless root_node
 
-      private
-
-      def top_level_group?(node)
-        top_level_groups.include?(node)
+        top_level_groups.each do |node|
+          example_group?(node, &method(:on_top_level_example_group))
+          on_top_level_group(node)
+        end
       end
 
       def top_level_groups
         @top_level_groups ||=
           top_level_nodes(root_node).select { |n| example_or_shared_group?(n) }
+      end
+
+      private
+
+      # Dummy methods to be overridden in the consumer
+      def on_top_level_example_group; end
+
+      def on_top_level_group; end
+
+      def top_level_group?(node)
+        top_level_groups.include?(node)
       end
 
       def top_level_nodes(node)

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2033,7 +2033,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 1.0 | -
 
-Checks for multiple top level describes.
+Checks for multiple top-level example groups.
 
 Multiple descriptions for the same class or module should either
 be nested or separated into different test files.

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -322,7 +322,7 @@ Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChan
 --- | --- | --- | --- | ---
 Enabled | Yes | No | 1.0 | -
 
-Check that the first argument to the top level describe is a constant.
+Check that the first argument to the top-level describe is a constant.
 
 ### Examples
 

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   subject(:cop) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'registers an offense for a bad path for all kinds of example groups' do
+    expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
+      example_group MyClass, 'foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+    RUBY
+  end
+
   it 'registers an offense for a wrong class but a correct method' do
     expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -3,26 +3,51 @@
 RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   subject(:cop) { described_class.new }
 
-  it 'finds multiple top level describes with class and method' do
+  it 'flags multiple top-level example groups with class and method' do
     expect_offense(<<-RUBY)
       describe MyClass, '.do_something' do; end
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       describe MyClass, '.do_something_else' do; end
     RUBY
   end
 
-  it 'finds multiple top level describes only with class' do
+  it 'flags multiple top-level example groups only with class' do
     expect_offense(<<-RUBY)
       describe MyClass do; end
-      ^^^^^^^^^^^^^^^^ Do not use multiple top level describes - try to nest them.
+      ^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       describe MyOtherClass do; end
     RUBY
   end
 
-  it 'skips single top level describe' do
-    expect_no_offenses(<<-RUBY)
-      require 'spec_helper'
+  it 'flags multiple top-level example groups with an arbitrary argument' do
+    expect_offense(<<-RUBY)
+      describe 'MyClass' do; end
+      ^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
+      describe 'MyOtherClass' do; end
+    RUBY
+  end
 
+  it 'flags multiple top-level example groups aliases' do
+    expect_offense(<<-RUBY)
+      example_group MyClass do; end
+      ^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
+      feature MyOtherClass do; end
+    RUBY
+  end
+
+  it 'ignores single top-level example group' do
+    expect_no_offenses(<<-RUBY)
+      describe MyClass do
+      end
+    RUBY
+  end
+
+  it 'ignores multiple shared example groups' do
+    expect_no_offenses(<<-RUBY)
+      shared_examples_for 'behaves' do
+      end
+      shared_examples_for 'misbehaves' do
+      end
       describe MyClass do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -35,11 +35,32 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
     expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 4)
   end
 
-  it 'ignores non-spec context methods' do
-    expect_no_offenses(<<-RUBY)
+  it 'flags example groups wrapped in classes' do
+    expect_offense(<<-RUBY)
       class MyThingy
-        context 'this is not rspec' do
-          context 'but it uses contexts' do
+        describe MyClass do
+          context 'when foo' do
+            context 'when bar' do
+              context 'when baz' do
+              ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+              end
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'flags example groups wrapped in modules' do
+    expect_offense(<<-RUBY)
+      module MyNamespace
+        describe MyClass do
+          context 'when foo' do
+            context 'when bar' do
+              context 'when baz' do
+              ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+              end
+            end
           end
         end
       end

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
-  it 'flags nested contexts' do
+  it 'flags nested example groups defined inside `describe`' do
     expect_offense(<<-RUBY)
       describe MyClass do
         context 'when foo' do
@@ -14,6 +14,36 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
 
         context 'when qux' do
           context 'when norf' do
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'flags nested example groups' do
+    expect_offense(<<-RUBY)
+      example_group MyClass do
+        context 'when foo' do
+          context 'when bar' do
+            context 'when baz' do
+            ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'flags nested example groups inside shared examples' do
+    expect_offense(<<-RUBY)
+      shared_examples_for 'nested like express' do
+        context 'when foo' do
+          context 'when bar' do
+            context 'when baz' do
+              context 'when qux' do
+              ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
The previously used `TopLevelDescribe` suffered a few flaws:
 - it was slow: https://github.com/rubocop-hq/rubocop-rspec/pull/925#discussion_r436988718
 - it ignored non-`describe` top-level example groups https://github.com/rubocop-hq/rubocop-rspec/pull/925#issuecomment-641140259

This pull request fixes those problems by using a newly introduced `TopLevelGroup`.
Also fixes a flaw in `TopLevelGroup` when example groups wrapped inside `module` or `class` were missed.

NOT DONE: I'm on the fence if we should deprecate `TopLevelDescribe` before removing it. We most probably don't have much releases left before 2.0, and the majority of people will jump straight to 2.0 skipping that pre-2.0 release. We may add this pull request (and others that replace usages of `TopLevelDescribe` for `TopLevelGroup`) as reference examples for migration.

Fixes #948

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).