### PR TITLE
Fix RuboCop 0.89 offences

### DIFF
--- a/lib/rubocop/cop/rspec/base.rb
+++ b/lib/rubocop/cop/rspec/base.rb
@@ -30,7 +30,7 @@ module RuboCop
         )
 
         # Invoke the original inherited hook so our cops are recognized
-        def self.inherited(subclass)
+        def self.inherited(subclass) # rubocop:disable Lint/MissingSuper
           RuboCop::Cop::Base.inherited(subclass)
         end
 

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -84,7 +84,7 @@ module RuboCop
           def autocorrect_replacing_parens(corrector, node)
             left_braces, right_braces = braces(node)
 
-            corrector.replace(node.location.begin, ' ' + left_braces)
+            corrector.replace(node.location.begin, " #{left_braces}")
             corrector.replace(node.location.end, right_braces)
           end
 

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -79,7 +79,7 @@ module RuboCop
           end
 
           # :nodoc
-          class Corrector
+          module Corrector
             private
 
             def build_options_string(options)
@@ -102,7 +102,9 @@ module RuboCop
           end
 
           # :nodoc
-          class TimesCorrector < Corrector
+          class TimesCorrector
+            include Corrector
+
             def initialize(node)
               @node = node
             end
@@ -130,7 +132,9 @@ module RuboCop
           end
 
           # :nodoc:
-          class CreateListCorrector < Corrector
+          class CreateListCorrector
+            include Corrector
+
             def initialize(node)
               @node = node.parent
             end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -208,12 +208,14 @@ module RuboCop
             'is_a?'
           when 'be_an_instance_of', 'be_instance_of', 'an_instance_of'
             'instance_of?'
-          when 'include', 'respond_to'
-            matcher + '?'
+          when 'include'
+            'include?'
+          when 'respond_to'
+            'respond_to?'
           when /^have_(.+)/
             "has_#{Regexp.last_match(1)}?"
           else
-            matcher[/^be_(.+)/, 1] + '?'
+            "#{matcher[/^be_(.+)/, 1]}?"
           end
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/rubocop/rspec/corrector/move_node.rb
+++ b/lib/rubocop/rspec/corrector/move_node.rb
@@ -16,19 +16,21 @@ module RuboCop
           @processed_source = processed_source # used by RangeHelp
         end
 
-        def move_before(other) # rubocop:disable Metrics/AbcSize
+        def move_before(other)
           position = other.loc.expression
-          indent = "\n" + ' ' * other.loc.column
+          indent = ' ' * other.loc.column
+          newline_indent = "\n#{indent}"
 
-          corrector.insert_before(position, source(original) + indent)
+          corrector.insert_before(position, source(original) + newline_indent)
           corrector.remove(node_range_with_surrounding_space(original))
         end
 
         def move_after(other)
           position = final_end_location(other)
-          indent = "\n" + ' ' * other.loc.column
+          indent = ' ' * other.loc.column
+          newline_indent = "\n#{indent}"
 
-          corrector.insert_after(position, indent + source(original))
+          corrector.insert_after(position, newline_indent + source(original))
           corrector.remove(node_range_with_surrounding_space(original))
         end
 

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
     include_examples 'autocorrect', 'before { }', output
 
     include_examples 'autocorrect', 'config.before(:each) { }',
-                     'config.' + output
+                     "config.#{output}"
     include_examples 'autocorrect', 'config.before(:example) { }',
-                     'config.' + output
+                     "config.#{output}"
     include_examples 'autocorrect', 'config.before { }',
-                     'config.' + output
+                     "config.#{output}"
   end
 
   shared_examples 'an example hook' do

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
     temp.class_exec do
       class << self
         undef inherited
-        def inherited(*) end
+        def inherited(*) end # rubocop:disable Lint/MissingSuper
       end
     end
     temp

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -17,7 +17,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
 
   def cops_body(config, cop, description, examples_objects, pars)
     content = h2(cop.cop_name)
-    content << properties(config, cop)
+    content << "#{properties(config, cop)}\n"
     content << "#{description}\n"
     content << examples(examples_objects) if examples_objects.count.positive?
     content << configurations(pars)
@@ -52,7 +52,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       config.fetch('VersionAdded', '-'),
       config.fetch('VersionChanged', '-')
     ]]
-    to_table(header, content) + "\n"
+    to_table(header, content)
   end
   # rubocop:enable Metrics/MethodLength
 
@@ -125,12 +125,11 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   end
 
   def to_table(header, content)
-    table = [
-      header.join(' | '),
-      Array.new(header.size, '---').join(' | ')
-    ]
-    table.concat(content.map { |c| c.join(' | ') })
-    table.join("\n") + "\n"
+    <<~TABLE
+      #{header.join(' | ')}
+      #{Array.new(header.size, '---').join(' | ')}
+      #{content.map { |c| c.join(' | ') }.join("\n")}
+    TABLE
   end
 
   def format_table_value(val) # rubocop:disable Metrics/MethodLength
@@ -204,7 +203,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     end
   end
 
-  def print_cop_with_doc(cop, config) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def print_cop_with_doc(cop, config) # rubocop:disable Metrics/MethodLength
     t = config.for_cop(cop)
     non_display_keys = %w[
       Description Enabled StyleGuide Reference Safe SafeAutoCorrect VersionAdded


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/rubocop-hq/rubocop-rspec/316/workflows/222eb8e0-b0ff-47ee-be23-02c87a989517/jobs/14689

**Please hold off merging this before RuboCop 0.89 is released.**
This PR fixes `rubocop-edge`, but with the current 0.88:
```
lib/rubocop/cop/rspec/base.rb:33:38: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/MissingSuper (did you mean Lint/MissingCopEnableDirective?).
        def self.inherited(subclass) # rubocop:disable Lint/MissingSuper
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/rspec/description_extractor_spec.rb:50:30: W: Lint/RedundantCopDisableDirective: Unnecessary disabling of Lint/MissingSuper (did you mean Lint/MissingCopEnableDirective?).
        def inherited(*) end # rubocop:disable Lint/MissingSuper
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).