### PR TITLE
Limit RuboCop dependency to be < 1.0

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://rubocop-rspec.readthedocs.io/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.87.0'
+  spec.add_runtime_dependency 'rubocop', '~> 0.87'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
RuboCop 1.0 might come with breaking API changes https://github.com/rubocop-hq/rubocop/issues/8278

Limit pre-2.0 RuboCop RSpec versions to RuboCop >= 0.87, < 1.0

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).