### PR TITLE
Allow dstr even when `symbol` style is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add a new base cop class `::RuboCop::Cop::RSpec::Base`. The old base class `::RuboCop::Cop::RSpec::Cop` is deprecated, and will be removed in the next major release. ([@bquorning][])
 * Add support for subject detection after includes and example groups in `RSpec/LeadingSubject`. ([@pirj][])
 * Ignore trailing punctuation in context description prefix. ([@elliterate][])
-
+* Relax `RSpec/VariableDefinition` cop so interpolated and multiline strings are accepted even when configured to enforce the `symbol` style. ([@bquorning][])
 * Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][])
 * Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
 

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -7,21 +7,21 @@ module RuboCop
       #
       # @example EnforcedStyle: symbols (default)
       #   # bad
-      #   let('user_name') { 'Adam' }
       #   subject('user') { create_user }
+      #   let('user_name') { 'Adam' }
       #
       #   # good
-      #   let(:user_name) { 'Adam' }
       #   subject(:user) { create_user }
+      #   let(:user_name) { 'Adam' }
       #
       # @example EnforcedStyle: strings
       #   # bad
-      #   let(:user_name) { 'Adam' }
       #   subject(:user) { create_user }
+      #   let(:user_name) { 'Adam' }
       #
       #   # good
-      #   let('user_name') { 'Adam' }
       #   subject('user') { create_user }
+      #   let('user_name') { 'Adam' }
       class VariableDefinition < Base
         include ConfigurableEnforcedStyle
         include RuboCop::RSpec::Variable

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -44,7 +44,7 @@ module RuboCop
         end
 
         def string?(node)
-          node.str_type? || node.dstr_type?
+          node.str_type?
         end
 
         def symbol?(node)

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -3042,23 +3042,23 @@ Checks that memoized helpers names are symbols or strings.
 
 ```ruby
 # bad
-let('user_name') { 'Adam' }
 subject('user') { create_user }
+let('user_name') { 'Adam' }
 
 # good
-let(:user_name) { 'Adam' }
 subject(:user) { create_user }
+let(:user_name) { 'Adam' }
 ```
 #### EnforcedStyle: strings
 
 ```ruby
 # bad
-let(:user_name) { 'Adam' }
 subject(:user) { create_user }
+let(:user_name) { 'Adam' }
 
 # good
-let('user_name') { 'Adam' }
 subject('user') { create_user }
+let('user_name') { 'Adam' }
 ```
 
 ### Configurable attributes

--- a/spec/rubocop/cop/rspec/variable_definition_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_definition_spec.rb
@@ -11,17 +11,15 @@ RSpec.describe RuboCop::Cop::RSpec::VariableDefinition, :config do
       RUBY
     end
 
-    it 'registers an offense for interpolated string' do
-      expect_offense(<<~'RUBY')
+    it 'does not register offense for interpolated string' do
+      expect_no_offenses(<<~'RUBY')
         let("user-#{id}") { 'Adam' }
-            ^^^^^^^^^^^^ Use symbols for variable names.
       RUBY
     end
 
-    it 'registers an offense for multiline string' do
-      expect_offense(<<~'RUBY')
-        let("user"\
-            ^^^^^^^ Use symbols for variable names.
+    it 'does not register offense for multiline string' do
+      expect_no_offenses(<<~'RUBY')
+        let("user" \
             "-foo") { 'Adam' }
       RUBY
     end


### PR DESCRIPTION
Relax the `RSpec/VariableDefinition` cop so interpolated and multiline strings are accepted even when configured to enforce the `symbol` style.

It seems weird that we enforce writing e.g. `let(:"foo#{bar}")` instead of `let("foo#{bar}")`. What I think is important to enforce is that people don't mix e.g. `let(:foo)` and `let('bar')`.

See https://github.com/rubocop-hq/rubocop-rspec/pull/910#discussion_r464230835 and #908.

/cc @tejasbubane 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
