### PR TITLE
[Fix #941] Add support for ignoring certain variables in RSpec/VariableName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
 * Improve `RSpec/NestedGroups`, `RSpec/FilePath`, `RSpec/DescribeMethod`, `RSpec/MultipleDescribes`, `RSpec/DescribeClass`'s top-level example group detection. ([@pirj][])
 * Add detection of `let!` with a block-pass or a string literal to `RSpec/LetSetup`. ([@pirj][])
+* Add `IgnoredPatterns` configuration option to `RSpec/VariableName`. ([@jtannas][])
 
 ## 1.42.0 (2020-07-09)
 
@@ -540,3 +541,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@harrylewis]: https://github.com/harrylewis
 [@elliterate]: https://github.com/elliterate
 [@mlarraz]: https://github.com/mlarraz
+[@jtannas]: https://github.com/jtannas

--- a/config/default.yml
+++ b/config/default.yml
@@ -558,7 +558,9 @@ RSpec/VariableName:
   SupportedStyles:
   - snake_case
   - camelCase
+  IgnoredPatterns: []
   VersionAdded: '1.40'
+  VersionChanged: '1.43'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
 
 RSpec/VerifiedDoubles:

--- a/lib/rubocop/cop/rspec/variable_name.rb
+++ b/lib/rubocop/cop/rspec/variable_name.rb
@@ -5,25 +5,43 @@ module RuboCop
     module RSpec
       # Checks that memoized helper names use the configured style.
       #
+      # Variables can be excluded from checking using the `IgnoredPatterns`
+      # option.
+      #
       # @example EnforcedStyle: snake_case (default)
       #   # bad
-      #   let(:userName) { 'Adam' }
-      #   subject(:userName) { 'Adam' }
+      #   subject(:userName1) { 'Adam' }
+      #   let(:userName2) { 'Adam' }
       #
       #   # good
-      #   let(:user_name) { 'Adam' }
-      #   subject(:user_name) { 'Adam' }
+      #   subject(:user_name_1) { 'Adam' }
+      #   let(:user_name_2) { 'Adam' }
       #
       # @example EnforcedStyle: camelCase
       #   # bad
-      #   let(:user_name) { 'Adam' }
-      #   subject(:user_name) { 'Adam' }
+      #   subject(:user_name_1) { 'Adam' }
+      #   let(:user_name_2) { 'Adam' }
       #
       #   # good
-      #   let(:userName) { 'Adam' }
-      #   subject(:userName) { 'Adam' }
+      #   subject(:userName1) { 'Adam' }
+      #   let(:userName2) { 'Adam' }
+      #
+      # @example IgnoredPatterns configuration
+      #
+      #   # rubocop.yml
+      #   # RSpec/VariableName:
+      #   #   EnforcedStyle: snake_case
+      #   #   IgnoredPatterns:
+      #   #     - ^userFood
+      #
+      # @example
+      #   # okay because it matches the `^userFood` regex in `IgnoredPatterns`
+      #   subject(:userFood_1) { 'spaghetti' }
+      #   let(:userFood_2) { 'fettuccine' }
+      #
       class VariableName < Base
         include ConfigurableNaming
+        include IgnoredPattern
         include RuboCop::RSpec::Variable
 
         MSG = 'Use %<style>s for variable names.'
@@ -31,6 +49,7 @@ module RuboCop
         def on_send(node)
           variable_definition?(node) do |variable|
             return if variable.dstr_type? || variable.dsym_type?
+            return if matches_ignored_pattern?(variable.value)
 
             check_name(node, variable.value, variable.loc.expression)
           end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -3075,9 +3075,12 @@ EnforcedStyle | `symbols` | `symbols`, `strings`
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | 1.40 | -
+Enabled | Yes | No | 1.40 | 1.43
 
 Checks that memoized helper names use the configured style.
+
+Variables can be excluded from checking using the `IgnoredPatterns`
+option.
 
 ### Examples
 
@@ -3085,23 +3088,37 @@ Checks that memoized helper names use the configured style.
 
 ```ruby
 # bad
-let(:userName) { 'Adam' }
-subject(:userName) { 'Adam' }
+subject(:userName1) { 'Adam' }
+let(:userName2) { 'Adam' }
 
 # good
-let(:user_name) { 'Adam' }
-subject(:user_name) { 'Adam' }
+subject(:user_name_1) { 'Adam' }
+let(:user_name_2) { 'Adam' }
 ```
 #### EnforcedStyle: camelCase
 
 ```ruby
 # bad
-let(:user_name) { 'Adam' }
-subject(:user_name) { 'Adam' }
+subject(:user_name_1) { 'Adam' }
+let(:user_name_2) { 'Adam' }
 
 # good
-let(:userName) { 'Adam' }
-subject(:userName) { 'Adam' }
+subject(:userName1) { 'Adam' }
+let(:userName2) { 'Adam' }
+```
+#### IgnoredPatterns configuration
+
+```ruby
+# rubocop.yml
+# RSpec/VariableName:
+#   EnforcedStyle: snake_case
+#   IgnoredPatterns:
+#     - ^userFood
+```
+```ruby
+# okay because it matches the `^userFood` regex in `IgnoredPatterns`
+subject(:userFood_1) { 'spaghetti' }
+let(:userFood_2) { 'fettuccine' }
 ```
 
 ### Configurable attributes
@@ -3109,6 +3126,7 @@ subject(:userName) { 'Adam' }
 Name | Default value | Configurable values
 --- | --- | ---
 EnforcedStyle | `snake_case` | `snake_case`, `camelCase`
+IgnoredPatterns | `[]` | Array
 
 ### References
 

--- a/spec/rubocop/cop/rspec/variable_name_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_name_spec.rb
@@ -188,4 +188,24 @@ RSpec.describe RuboCop::Cop::RSpec::VariableName, :config do
       end
     end
   end
+
+  context 'when configured to ignore certain patterns' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'snake_case',
+        'IgnoredPatterns' => ['^userFood$', '^userPet$'] }
+    end
+
+    it 'registers an offense when not matching any ignored patterns' do
+      expect_offense(<<~RUBY)
+        let(:userName) { 'Adam' }
+            ^^^^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
+    it 'does not register an offense when matching any ignored pattern' do
+      expect_no_offenses(<<~RUBY)
+        let(:userFood) { 'Adam' }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #941

This PR adds support for ignoring naming conventions on certain RSpec variables via configuration options. Options for `IgnoredVariables` and `IgnoredPatterns` are provided, and are empty by default. This will be helpful for strange cases and for codebases that are iteratively refactoring to apply the rule.

My original thought was to have them combined in a single `Ignore` option which would accept both static values and regex patterns, but the extra complexity of parsing the configuration led me to split it in two.

Edit: `IgnoredVariables` has been removed - see comments below

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `default/config.yml` to the next major version.
