### PR TITLE
Add detection of `let!` with a block-pass or a string literal to `RSpec/LetSetup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix `RSpec/EmptyExampleGroup` to flag example groups with examples in invalid scopes. ([@mlarraz][])
 * Fix `RSpec/EmptyExampleGroup` to ignore examples groups with examples defined inside iterators. ([@pirj][])
 * Improve `RSpec/NestedGroups`, `RSpec/FilePath`, `RSpec/DescribeMethod`, `RSpec/MultipleDescribes`, `RSpec/DescribeClass`'s top-level example group detection. ([@pirj][])
+* Add detection of `let!` with a block-pass or a string literal to `RSpec/LetSetup`. ([@pirj][])
 
 ## 1.42.0 (2020-07-09)
 

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -35,7 +35,10 @@ module RuboCop
                          ).block_pattern
 
         def_node_matcher :let_bang, <<-PATTERN
-          (block $(send nil? :let! {(sym $_) (str $_)}) ...)
+          {
+            (block $(send nil? :let! {(sym $_) (str $_)}) ...)
+            $(send nil? :let! {(sym $_) (str $_)} block_pass)
+          }
         PATTERN
 
         def_node_search :method_called?, '(send nil? %)'

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -35,7 +35,7 @@ module RuboCop
                          ).block_pattern
 
         def_node_matcher :let_bang, <<-PATTERN
-          (block $(send nil? :let! (sym $_)) args ...)
+          (block $(send nil? :let! {(sym $_) (str $_)}) ...)
         PATTERN
 
         def_node_search :method_called?, '(send nil? %)'
@@ -52,7 +52,7 @@ module RuboCop
 
         def unused_let_bang(node)
           child_let_bang(node) do |method_send, method_name|
-            yield(method_send) unless method_called?(node, method_name)
+            yield(method_send) unless method_called?(node, method_name.to_sym)
           end
         end
 

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -98,6 +98,24 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
     RUBY
   end
 
+  it 'flags unused helpers defined as strings' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        let!('bar') { baz }
+        ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+      end
+    RUBY
+  end
+
+  it 'ignores used helpers defined as strings' do
+    expect_no_offenses(<<-RUBY)
+      describe Foo do
+        let!('bar') { baz }
+        it { expect(bar).to be_near }
+      end
+    RUBY
+  end
+
   it 'complains when there is a custom nesting level' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -116,6 +116,15 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
     RUBY
   end
 
+  it 'flags blockpass' do
+    expect_offense(<<-RUBY)
+      shared_context Foo do |&block|
+        let!(:bar, &block)
+        ^^^^^^^^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+      end
+    RUBY
+  end
+
   it 'complains when there is a custom nesting level' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/variable_definition_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_definition_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::VariableDefinition, :config do
 
     it 'registers an offense for string name' do
       expect_offense(<<~RUBY)
-        let("user_name") { 'Adam' }
+        let('user_name') { 'Adam' }
             ^^^^^^^^^^^ Use symbols for variable names.
       RUBY
     end
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::VariableDefinition, :config do
 
     it 'does not register offense for string names' do
       expect_no_offenses(<<~RUBY)
-        let("user_name") { 'Adam' }
+        let('user_name') { 'Adam' }
       RUBY
     end
   end

--- a/spec/smoke_tests/weird_rspec_spec.rb
+++ b/spec/smoke_tests/weird_rspec_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe 'Weirdness' do
 
   let(:doop) { foo; 1 }
 
+  let('foo') { 1 }
+  let('foo' \
+      'bar') { 1 }
+
+  let!('foo') { 1 }
+  let!('foo' \
+      'bar') { 1 }
+
+  let("foo#{1}") { 1 }
+  let!("foo#{1}") { 1 }
+
   it {}
   specify {}
 


### PR DESCRIPTION
Found when addressing [this comment](https://github.com/rubocop-hq/rubocop-rspec/pull/863#discussion_r466290915).

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).