### PR TITLE
Support expect_offense template arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,7 @@ RSpec/ExampleLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb
+
+Style/FormatStringToken:
+  Exclude:
+    - spec/rubocop/**/*.rb

--- a/spec/support/expect_offense.rb
+++ b/spec/support/expect_offense.rb
@@ -9,7 +9,7 @@ module ExpectOffense
 
   DEFAULT_FILENAME = 'example_spec.rb'
 
-  def expect_offense(source, filename = DEFAULT_FILENAME)
+  def expect_offense(source, filename = DEFAULT_FILENAME, *args, **kwargs)
     super
   end
 


### PR DESCRIPTION
Pass keyword arguments through to `RuboCop::RSpec::ExpectOffense#expect_offense`. These are used to set template replacements like `%{name}` added in [rubocop #8069](https://github.com/rubocop-hq/rubocop/issues/8069).

Allow code offense templates in specs to use `%{name}`. [`Style/FormatStringToken`](https://docs.rubocop.org/rubocop/cops_style.html#styleformatstringtoken) prefers `%<name>s` to `%{name}` but `expect_offense` does not use `Kernel#format` or `String#%`.

Example usage (from work in progress for #992):

```ruby
[include_examples it_behaves_like it_should_behave_like].each do |include_method|
  it "registers an offense with #{include_method}" do
    expect_offense(<<~RUBY, include_method: include_method)
      describe 'foo' do
        %{include_method} 'an x'
        ^{include_method}^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [3]
        %{include_method} 'an x'
        ^{include_method}^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2]
      end
    RUBY
  end
end
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).