### PR TITLE
Bump version to v1.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.43.0 (2020-08-17)
+
 * Add a new base cop class `::RuboCop::Cop::RSpec::Base`. The old base class `::RuboCop::Cop::RSpec::Cop` is deprecated, and will be removed in the next major release. ([@bquorning][])
 * Add support for subject detection after includes and example groups in `RSpec/LeadingSubject`. ([@pirj][])
 * Ignore trailing punctuation in context description prefix. ([@elliterate][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -399,6 +399,7 @@ RSpec/MultipleMemoizedHelpers:
   Enabled: true
   AllowSubject: true
   Max: 5
+  VersionAdded: '1.43'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
 
 RSpec/MultipleSubjects:

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.42.0'
+      STRING = '1.43.0'
     end
   end
 end

--- a/manual/cops_rspec.md
+++ b/manual/cops_rspec.md
@@ -2123,7 +2123,7 @@ Max | `1` | Integer
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Enabled | Yes | No | 1.43 | -
 
 Checks if example groups contain too many `let` and `subject` calls.
 


### PR DESCRIPTION
We have a lot of great changes just sitting on the master branch waiting for a release. And 4 new contributors!

Not to diminish any of the contributions, but the reason I want to create a release _now_ (and I should have done it weeks ago) is that it will be explicitly incompatible with RuboCop 1.0. I hope that as many as possible of our users will upgrade to 1.43.0, so that the will be (temporarily) blocked from upgrading when RuboCop 1.0 is released.

Please note that I am adding `VersionAdded: '1.43'` for `RSpec/MultipleMemoizedHelpers` which seemed to be missing.

Also I think our documentation isn’t being updated correctly at the moment, and we should fix that ASAP. But again, I wanted to get this release out ASAP too :-)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
