### PR TITLE
Fix RSpec/FilePath when checking an empty class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/FilePath` when checking a file defining e.g. an empty class. ([@bquorning][])
+
 ## 1.43.0 (2020-08-17)
 
 * Add a new base cop class `::RuboCop::Cop::RSpec::Base`. The old base class `::RuboCop::Cop::RSpec::Cop` is deprecated, and will be removed in the next major release. ([@bquorning][])

--- a/lib/rubocop/rspec/top_level_group.rb
+++ b/lib/rubocop/rspec/top_level_group.rb
@@ -38,7 +38,9 @@ module RuboCop
       end
 
       def top_level_nodes(node)
-        if node.begin_type?
+        if node.nil?
+          []
+        elsif node.begin_type?
           node.children
         elsif node.module_type? || node.class_type?
           top_level_nodes(node.body)

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  # RSpec/FilePath runs on all files - not only **/*_spec.rb
+  it 'works on files defining an empty class' do
+    expect_no_offenses(<<-RUBY)
+      class Foo
+      end
+    RUBY
+  end
+
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 


### PR DESCRIPTION
Remember that `RSpec/FilePath` checks *all* files - not only **/*_spec.rb. And when some class defines e.g. an empty class, the `TopLevelGroup` module would raise an error.

Fixes #999.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).