### PR TITLE
New cops should be added as "pending"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Before submitting the PR make sure the following are checked:
 If you have created a new cop:
 
 * [ ] Added the new cop to `config/default.yml`.
+* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
 * [ ] The cop documents examples of good and bad code.
 * [ ] The tests assert both that bad code is reported and that good code is not reported.
 * [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.


### PR DESCRIPTION
New cops should be pending, until the next major release. So we avoid situations like this: https://github.com/rubocop-hq/rubocop-rspec/pull/863#discussion_r471603667
