### PR TITLE
Drop RSpec/EmptyExampleGroup customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Retire `RSpec/InvalidPredicateMatcher` cop. ([@pirj][])
 * Remove the code responsible for filtering files to inspect. ([@pirj][])
 * Make RSpec language elements configurable. ([@sl4vr][])
+* Remove `CustomIncludeMethods` `RSpec/EmptyExampleGroup` option in favour of the new RSpec DSL configuration. ([@pirj][])
 
 ## 2.0.0.pre (2020-10-22)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -207,8 +207,8 @@ RSpec/Dialect:
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
-  CustomIncludeMethods: []
   VersionAdded: '1.7'
+  VersionChanged: '2.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
 RSpec/EmptyHook:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -729,12 +729,10 @@ end
 | Yes
 | No
 | 1.7
-| -
+| 2.0
 |===
 
 Checks if an example group does not include any tests.
-
-This cop is configurable using the `CustomIncludeMethods` option
 
 === Examples
 
@@ -771,43 +769,6 @@ describe Bacon do
   pending 'will add tests later'
 end
 ----
-
-==== configuration
-
-[source,ruby]
-----
-# .rubocop.yml
-# RSpec/EmptyExampleGroup:
-#   CustomIncludeMethods:
-#   - include_tests
-
-# spec_helper.rb
-RSpec.configure do |config|
-  config.alias_it_behaves_like_to(:include_tests)
-end
-
-# bacon_spec.rb
-describe Bacon do
-  let(:bacon)      { Bacon.new(chunkiness) }
-  let(:chunkiness) { false                 }
-
-  context 'extra chunky' do   # not flagged by rubocop
-    let(:chunkiness) { true }
-
-    include_tests 'shared tests'
-  end
-end
-----
-
-=== Configurable attributes
-
-|===
-| Name | Default value | Configurable values
-
-| CustomIncludeMethods
-| `[]`
-| Array
-|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -5,8 +5,6 @@ module RuboCop
     module RSpec
       # Checks if an example group does not include any tests.
       #
-      # This cop is configurable using the `CustomIncludeMethods` option
-      #
       # @example usage
       #
       #   # bad
@@ -37,31 +35,6 @@ module RuboCop
       #   describe Bacon do
       #     pending 'will add tests later'
       #   end
-      #
-      # @example configuration
-      #
-      #   # .rubocop.yml
-      #   # RSpec/EmptyExampleGroup:
-      #   #   CustomIncludeMethods:
-      #   #   - include_tests
-      #
-      #   # spec_helper.rb
-      #   RSpec.configure do |config|
-      #     config.alias_it_behaves_like_to(:include_tests)
-      #   end
-      #
-      #   # bacon_spec.rb
-      #   describe Bacon do
-      #     let(:bacon)      { Bacon.new(chunkiness) }
-      #     let(:chunkiness) { false                 }
-      #
-      #     context 'extra chunky' do   # not flagged by rubocop
-      #       let(:chunkiness) { true }
-      #
-      #       include_tests 'shared tests'
-      #     end
-      #   end
-      #
       class EmptyExampleGroup < Base
         MSG = 'Empty example group detected.'
 
@@ -99,7 +72,6 @@ module RuboCop
               '{#Examples.all #ExampleGroups.all #Includes.all}'
             )}
             #{send_pattern('{#Examples.all #Includes.all}')}
-            (send nil? #custom_include? ...)
           }
         PATTERN
 
@@ -190,16 +162,6 @@ module RuboCop
 
         def examples_in_branches?(if_node)
           if_node.branches.any? { |branch| examples?(branch) }
-        end
-
-        def custom_include?(method_name)
-          custom_include_methods.include?(method_name)
-        end
-
-        def custom_include_methods
-          cop_config
-            .fetch('CustomIncludeMethods', [])
-            .map(&:to_sym)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/base_spec.rb
+++ b/spec/rubocop/cop/rspec/base_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
 
     context 'when `epic` is set as an alias to example group' do
       before do
-        other_cops['RSpec']['Language']['ExampleGroups']['Regular']
+        other_cops.dig('RSpec', 'Language', 'ExampleGroups', 'Regular')
           .push('epic')
       end
 

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -268,8 +268,9 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
   end
 
   context 'when a custom include method is specified' do
-    let(:cop_config) do
-      { 'CustomIncludeMethods' => %w[it_has_special_behavior] }
+    before do
+      other_cops.dig('RSpec', 'Language', 'Includes', 'Examples')
+        .push('it_has_special_behavior')
     end
 
     it 'ignores an empty example group with a custom include' do


### PR DESCRIPTION
We're providing a flexible way of customizing RSpec syntax thanks to #956

This is not based on #956, but rather includes it (can't specify a base branch from another fork).
Those are the changes https://github.com/rubocop-hq/rubocop-rspec/pull/1007/commits/42f77084fe01f5abe333bbbe1a8ba7b402c25e2c
This is the change needed to avoid mutating the default config between the examples https://github.com/rubocop-hq/rubocop-rspec/pull/1007/commits/718b398dcdfc794017d93bb8578466b7e65f22a3

This way it's possible to drop customization of this cop instead customize via .rubocop.yml configuration, i.e.:

```yaml
AllCops:
  RSpec:
    Language:
      Includes:
        Example:
        - it_has_special_behavior
```

There's a problem with specs, though, specifically with this:
```ruby
RuboCop::ConfigLoader.default_configuration.for_all_cops.dig('RSpec', 'Language')
```

`for_all_cops` is memoized in `Config`:
```ruby
# rubocop-0.89.1/lib/rubocop/config.rb:132:

def for_all_cops
  @for_all_cops ||= self['AllCops'] || {}
end
```

It's not so obvious to notice, since in this cop the example that is modifying the language is in its own context, and it runs last.
Even if you add an example after it, due to how RSpec orders examples, it will still be executed last.
However, if you add a `context` with an example, you'll see that the language changes leaked.

~We need to figure out a way to reset the config between examples, and do it in a performant way.~
~Thoughts? `dup` in `before` and assign back in `after`?~


Fixes #969 

---

Before submitting the PR make sure the following are checked:

* [no] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `default/config.yml` to the next major version.