### PR TITLE
Skip files with shared groups in RSpec/FilePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
+* Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
 
 ## 1.43.1 (2020-08-17)
 

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         def_node_search :routing_metadata?, '(pair (sym :type) (sym :routing))'
 
-        def on_top_level_group(node)
+        def on_top_level_example_group(node)
           return unless top_level_groups.one?
 
           const_described(node) do |send_node, described_class, arguments|

--- a/lib/rubocop/rspec/top_level_group.rb
+++ b/lib/rubocop/rspec/top_level_group.rb
@@ -16,7 +16,7 @@ module RuboCop
         return unless root_node
 
         top_level_groups.each do |node|
-          example_group?(node, &method(:on_top_level_example_group))
+          on_top_level_example_group(node) if example_group?(node)
           on_top_level_group(node)
         end
       end
@@ -29,9 +29,9 @@ module RuboCop
       private
 
       # Dummy methods to be overridden in the consumer
-      def on_top_level_example_group; end
+      def on_top_level_example_group(_node); end
 
-      def on_top_level_group; end
+      def on_top_level_group(_node); end
 
       def top_level_group?(node)
         top_level_groups.include?(node)

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'ignores shared examples' do
+    expect_no_offenses(<<-RUBY, 'user.rb')
+      shared_examples_for 'foo' do; end
+    RUBY
+  end
+
   it 'skips specs that do not describe a class / method' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end


### PR DESCRIPTION
https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples states that shared groups don't have to have the _spec.rb suffix, and even preferably omit _spec.


Fixes #1008

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).