### PR TITLE
Shut up UselessMethodDefinition cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,14 @@ Lint/InterpolationCheck:
   Exclude:
     - spec/**/*.rb
 
+# When the `edge-rubocop` build is red, and we decide to disable the cop,
+# the rest of the builds become red if the cop has not yet been released.
+# Instead of waiting for RuboCop releases to make `edge-rubocop` green,
+# we prefer keeping disable directives here and there and check if they
+# are still needed once in a while.
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - rubocop-rspec.gemspec

--- a/spec/support/expect_offense.rb
+++ b/spec/support/expect_offense.rb
@@ -9,11 +9,11 @@ module ExpectOffense
 
   DEFAULT_FILENAME = 'example_spec.rb'
 
-  def expect_offense(source, filename = DEFAULT_FILENAME, *args, **kwargs)
+  def expect_offense(source, filename = DEFAULT_FILENAME, *args, **kwargs) # rubocop:disable Lint/UselessMethodDefinition
     super
   end
 
-  def expect_no_offenses(source, filename = DEFAULT_FILENAME)
+  def expect_no_offenses(source, filename = DEFAULT_FILENAME) # rubocop:disable Lint/UselessMethodDefinition
     super
   end
 end


### PR DESCRIPTION
This fixes `edge-rubocop` CI job

Caused by this bug https://github.com/rubocop-hq/rubocop/issues/8561

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).