### PR TITLE
Add detection of custom include blocks for `EmptyExampleGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
+* Add detection of custom include blocks for `EmptyExampleGroup`. ([@sl4vr][])
 
 ## 1.43.1 (2020-08-17)
 
@@ -553,3 +554,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jtannas]: https://github.com/jtannas
 [@mockdeep]: https://github.com/mockdeep
 [@biinari]: https://github.com/biinari
+[@sl4vr]: https://github.com/sl4vr

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -92,7 +92,8 @@ module RuboCop
             #{ExampleGroups::ALL.block_pattern}
             #{Includes::ALL.send_pattern}
             #{Includes::ALL.block_pattern}
-            (send nil? #custom_include? ...)
+            (send #rspec? #custom_include? ...)
+            (block (send #rspec? #custom_include? ...) ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -225,5 +225,17 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
         end
       RUBY
     end
+
+    it 'ignores an empty example group with a custom include and a block' do
+      expect_no_offenses(<<~RUBY)
+        describe Foo do
+          context "when I do something clever" do
+            it_has_special_behavior do
+              expect(foo).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Custom includes should be able to take blocks as well.
While https://github.com/rubocop-hq/rubocop-rspec/pull/956 is probably going to be released in in 2.0, here's small fix.
Fixes https://github.com/rubocop-hq/rubocop-rspec/issues/1006

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
