### PR TITLE
Fix a false positive for `RSpec/EmptyExampleGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Move our documentation from rubocop-rspec.readthedocs.io to docs.rubocop.org/rubocop-rspec. ([@bquorning][])
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
-* Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Add `RSpec/StubbedMock` cop. ([@bquorning][], [@pirj][])
+* Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
+* Fix a false positive for `RSpec/EmptyExampleGroup` when example is defined in an `if` branch. ([@koic][])
 
 ## 1.43.2 (2020-08-25)
 
@@ -561,3 +562,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jtannas]: https://github.com/jtannas
 [@mockdeep]: https://github.com/mockdeep
 [@biinari]: https://github.com/biinari
+[@koic]: https://github.com/koic


### PR DESCRIPTION
This PR fixes a false positive for `RSpec/EmptyExampleGroup` when example group with examples defined in all `if` branches.

I found it on Capybara's CI.
https://travis-ci.org/github/teamcapybara/capybara/jobs/719967666#L846-L848

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).