### PR TITLE
Fix false positives in RSpec/EmptyExampleGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
 * Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
 * Fix subject nesting detection in `RSpec/LeadingSubject`. ([@pirj][])
+* Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 
 ## 1.43.1 (2020-08-17)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -739,6 +739,11 @@ describe Bacon do
     expect(bacon.chunky?).to be_truthy
   end
 end
+
+# good
+describe Bacon do
+  pending 'will add tests later'
+end
 ----
 
 ==== configuration

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -160,6 +160,8 @@ module RuboCop
         PATTERN
 
         def on_block(node)
+          return if node.each_ancestor(:def, :defs).any?
+
           example_group_body(node) do |body|
             add_offense(node.send_node) unless examples?(body)
           end

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -33,6 +33,11 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good
+      #   describe Bacon do
+      #     pending 'will add tests later'
+      #   end
+      #
       # @example configuration
       #
       #   # .rubocop.yml
@@ -83,11 +88,14 @@ module RuboCop
         #     it_behaves_like 'an animal'
         #     it_behaves_like('a cat') { let(:food) { 'milk' } }
         #     it_has_root_access
+        #     skip
+        #     it 'will be implemented later'
         #
         #   @param node [RuboCop::AST::Node]
         #   @return [Array<RuboCop::AST::Node>] matching nodes
         def_node_matcher :example_or_group_or_include?, <<~PATTERN
           {
+            #{Examples::ALL.send_pattern}
             #{Examples::ALL.block_pattern}
             #{ExampleGroups::ALL.block_pattern}
             #{Includes::ALL.send_pattern}

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -161,6 +161,7 @@ module RuboCop
 
         def on_block(node)
           return if node.each_ancestor(:def, :defs).any?
+          return if node.each_ancestor(:block).any? { |block| example?(block) }
 
           example_group_body(node) do |body|
             add_offense(node.send_node) unless examples?(body)

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -258,4 +258,28 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
       describe Foo
     RUBY
   end
+
+  it 'ignores example groups defined inside methods' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Foo do
+        def self.with_yaml_loaded(&block)
+          context 'with YAML loaded' do
+            module_exec(&block)
+          end
+        end
+
+        class << self
+          def without_yaml_loaded(&block)
+            context 'without YAML loaded' do
+              module_exec(&block)
+            end
+          end
+        end
+
+        with_yaml_loaded do
+          it_behaves_like 'normal YAML serialization'
+        end
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -226,4 +226,36 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
       RUBY
     end
   end
+
+  it 'ignores example groups with pending examples' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        it 'will be implemented later'
+      end
+
+      describe Foo do
+        it 'will be implemented later', year: 2030
+      end
+
+      describe Foo do
+        pending
+      end
+
+      describe Foo do
+        pending 'too hard to specify'
+      end
+
+      describe Foo do
+        skip
+      end
+
+      describe Foo do
+        skip 'undefined behaviour'
+      end
+
+      xdescribe Foo
+
+      describe Foo
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -282,4 +282,15 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
       end
     RUBY
   end
+
+  it 'ignores example groups inside examples' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe 'rspec-core' do
+        it 'runs an example group' do
+          group = RSpec.describe { }
+          group.run
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
After running the cop against real-world-rspec I've found a number of false positives.

To make out users happy, here are three fixes, for:
 - example groups with pending examples
 - example groups defined inside methods
 - example groups defined inside examples

Before: 529 offenses
After: 291 offences (real ones mostly, and some due to custom example group definitions like in Pundit specs)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).