### PR TITLE
Support rspec aruba integration in RSpec/DescribeClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
 * Fix subject nesting detection in `RSpec/LeadingSubject`. ([@pirj][])
+* Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 
 ## 1.43.1 (2020-08-17)
 
@@ -563,3 +564,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mockdeep]: https://github.com/mockdeep
 [@biinari]: https://github.com/biinari
 [@koic]: https://github.com/koic
+[@Rafix02]: https://github.com/Rafix02

--- a/config/default.yml
+++ b/config/default.yml
@@ -90,6 +90,7 @@ RSpec/DescribeClass:
     - feature
     - system
     - mailbox
+    - aruba
   VersionAdded: '1.0'
   VersionChanged: '1.44'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass

--- a/config/default.yml
+++ b/config/default.yml
@@ -76,7 +76,22 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Description: Check that the first argument to the top-level describe is a constant.
   Enabled: true
+  IgnoredMetadata:
+    type:
+    - channel
+    - controller
+    - helper
+    - job
+    - mailer
+    - model
+    - request
+    - routing
+    - view
+    - feature
+    - system
+    - mailbox
   VersionAdded: '1.0'
+  VersionChanged: '1.44'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -398,12 +398,28 @@ end
 | Yes
 | No
 | 1.0
-| -
+| 1.44
 |===
 
 Check that the first argument to the top-level describe is a constant.
 
+It can be configured to ignore strings when certain metadata is passed.
+
+Ignores Rails `type` metadata by default.
+
 === Examples
+
+==== `IgnoredMetadata` configuration
+
+[source,ruby]
+----
+# .rubocop.yml
+# RSpec/DescribeClass:
+#   IgnoredMetadata:
+#     type:
+#       - request
+#       - controller
+----
 
 [source,ruby]
 ----
@@ -423,6 +439,16 @@ end
 describe "A feature example", type: :feature do
 end
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| IgnoredMetadata
+| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox"]}`
+| 
+|===
 
 === References
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -405,7 +405,7 @@ Check that the first argument to the top-level describe is a constant.
 
 It can be configured to ignore strings when certain metadata is passed.
 
-Ignores Rails `type` metadata by default.
+Ignores Rails and Aruba `type` metadata by default.
 
 === Examples
 
@@ -446,7 +446,7 @@ end
 | Name | Default value | Configurable values
 
 | IgnoredMetadata
-| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox"]}`
+| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba"]}`
 | 
 |===
 

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # It can be configured to ignore strings when certain metadata is passed.
       #
-      # Ignores Rails `type` metadata by default.
+      # Ignores Rails and Aruba `type` metadata by default.
       #
       # @example `IgnoredMetadata` configuration
       #

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -5,6 +5,19 @@ module RuboCop
     module RSpec
       # Check that the first argument to the top-level describe is a constant.
       #
+      # It can be configured to ignore strings when certain metadata is passed.
+      #
+      # Ignores Rails `type` metadata by default.
+      #
+      # @example `IgnoredMetadata` configuration
+      #
+      #   # .rubocop.yml
+      #   # RSpec/DescribeClass:
+      #   #   IgnoredMetadata:
+      #   #     type:
+      #   #       - request
+      #   #       - controller
+      #
       # @example
       #   # bad
       #   describe 'Do something' do
@@ -27,35 +40,41 @@ module RuboCop
         MSG = 'The first argument to describe should be '\
               'the class or module being tested.'
 
-        def_node_matcher :rails_metadata?, <<-PATTERN
-          (pair
-            (sym :type)
-            (sym { :channel :controller :helper :job :mailer :model :request
-                   :routing :view :feature :system :mailbox })
-          )
-        PATTERN
-
-        def_node_matcher :example_group_with_rails_metadata?, <<~PATTERN
-          (send #rspec? :describe ... (hash <#rails_metadata? ...>))
+        def_node_matcher :example_group_with_ignored_metadata?, <<~PATTERN
+          (send #rspec? :describe ... (hash <#ignored_metadata? ...>))
         PATTERN
 
         def_node_matcher :not_a_const_described, <<~PATTERN
           (send #rspec? :describe $[!const !#string_constant?] ...)
         PATTERN
 
-        def on_top_level_group(top_level_node)
-          return if example_group_with_rails_metadata?(top_level_node.send_node)
+        def_node_matcher :sym_pair?, <<~PATTERN
+          (pair $sym $sym)
+        PATTERN
 
-          not_a_const_described(top_level_node.send_node) do |described|
+        def on_top_level_group(node)
+          return if example_group_with_ignored_metadata?(node.send_node)
+
+          not_a_const_described(node.send_node) do |described|
             add_offense(described)
           end
         end
 
         private
 
+        def ignored_metadata?(node)
+          sym_pair?(node) do |key, value|
+            ignored_metadata[key.value.to_s].to_a.include?(value.value.to_s)
+          end
+        end
+
         def string_constant?(described)
           described.str_type? &&
             described.value.match?(/^(?:(?:::)?[A-Z]\w*)+$/)
+        end
+
+        def ignored_metadata
+          cop_config['IgnoredMetadata'] || {}
         end
       end
     end

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -48,7 +48,7 @@ module RuboCop
           (send #rspec? :describe $[!const !#string_constant?] ...)
         PATTERN
 
-        def_node_matcher :sym_pair?, <<~PATTERN
+        def_node_matcher :sym_pair, <<~PATTERN
           (pair $sym $sym)
         PATTERN
 
@@ -63,7 +63,7 @@ module RuboCop
         private
 
         def ignored_metadata?(node)
-          sym_pair?(node) do |key, value|
+          sym_pair(node) do |key, value|
             ignored_metadata[key.value.to_s].to_a.include?(value.value.to_s)
           end
         end

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RuboCop::Cop::RSpec::DescribeClass, :config do
   it 'checks first-line describe statements' do
     expect_offense(<<-RUBY)
       describe "bad describe" do
@@ -120,57 +118,6 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
   end
 
-  it 'ignores request specs' do
-    expect_no_offenses(<<-RUBY)
-      describe 'my new feature', type: :request do
-      end
-    RUBY
-  end
-
-  it 'ignores feature specs' do
-    expect_no_offenses(<<-RUBY)
-      describe 'my new feature', type: :feature do
-      end
-    RUBY
-  end
-
-  it 'ignores system specs' do
-    expect_no_offenses(<<-RUBY)
-      describe 'my new system test', type: :system do
-      end
-    RUBY
-  end
-
-  it 'ignores feature specs when RSpec.describe is used' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe 'my new feature', type: :feature do
-      end
-    RUBY
-  end
-
-  it 'flags specs with non :type metadata' do
-    expect_offense(<<-RUBY)
-      describe 'my new feature', foo: :feature do
-               ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
-      end
-    RUBY
-  end
-
-  it 'flags normal metadata in describe' do
-    expect_offense(<<-RUBY)
-      describe 'my new feature', blah, type: :wow do
-               ^^^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
-      end
-    RUBY
-  end
-
-  it 'ignores feature specs - also with complex options' do
-    expect_no_offenses(<<-RUBY)
-      describe 'my new feature', :test, :type => :feature, :foo => :bar do
-      end
-    RUBY
-  end
-
   it 'ignores an empty describe' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe do
@@ -179,24 +126,6 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
       describe do
       end
     RUBY
-  end
-
-  it 'ignores routing specs' do
-    expect_no_offenses(<<-RUBY)
-      describe 'my new route', type: :routing do
-      end
-    RUBY
-  end
-
-  it 'ignores view specs' do
-    expect_no_offenses(<<-RUBY)
-      describe 'widgets/index', type: :view do
-      end
-    RUBY
-  end
-
-  it "doesn't blow up on single-line describes" do
-    expect_no_offenses('describe Some::Class')
   end
 
   it "doesn't flag top level describe in a shared example" do
@@ -233,5 +162,57 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
         end
       end
     RUBY
+  end
+
+  it 'ignores `type` metadata ignored by default' do
+    expect_no_offenses(<<-RUBY)
+      describe 'widgets/index', type: :view do
+      end
+    RUBY
+  end
+
+  it 'flags specs with non `type` metadata' do
+    expect_offense(<<-RUBY)
+      describe 'foo bar', foo: :bar do
+               ^^^^^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
+  end
+
+  it 'ignores feature specs - also with complex options' do
+    expect_no_offenses(<<-RUBY)
+      describe 'my new feature', :test, foo: :bar, type: :feature do
+      end
+    RUBY
+  end
+
+  it 'flags non-ignored `type` metadata' do
+    expect_offense(<<-RUBY)
+      describe 'wow', blah, type: :wow do
+               ^^^^^ The first argument to describe should be the class or module being tested.
+      end
+    RUBY
+  end
+
+  context 'when IgnoredMetadata is configured' do
+    let(:cop_config) do
+      { 'IgnoredMetadata' =>
+        { 'foo' => ['bar'],
+          'type' => ['wow'] } }
+    end
+
+    it 'ignores configured metadata' do
+      expect_no_offenses(<<-RUBY)
+        describe 'foo bar', foo: :bar do
+        end
+      RUBY
+    end
+
+    it 'ignores configured `type` metadata' do
+      expect_no_offenses(<<-RUBY)
+        describe 'my new system test', type: :wow do
+        end
+      RUBY
+    end
   end
 end

--- a/spec/smoke_tests/weird_rspec_spec.rb
+++ b/spec/smoke_tests/weird_rspec_spec.rb
@@ -201,6 +201,8 @@ RSpec.shared_context('even pointless-er') {}
 RSpec.describe do end
 RSpec.shared_examples('pointless2') do end
 RSpec.shared_context('even pointless-er2') do end
+RSpec.describe
+RSpec.describe 'empty'
 
 class Broken
 end


### PR DESCRIPTION
As discussed in #1017, @pirj suggested first extracting the Rails-related metadata already being ignored to an `IgnoredMetadata` config option, and then adding `aruba` to the default list.

My implementation treats the config as symbols, i.e. `type: :request` will be ignored, but `'type' => 'request'` won't. I tried making it so the configuration would mandate the typing, but Psych tells me symbols are not allowed, so that's the second best thing I could think of.

`reek` says my method smells, but since I'm unfamiliar with the codebase I couldn't think of anything better... the cops with similar behaviour I could find did more or less the same thing. If anyone can think of a better way, I'm all ears!

Please do also tell me whether you think the updated documentation is lacking in some sense. Should I add more info to the commit messages?

Fixes #1017.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `default/config.yml` to the next major version.
