### PR TITLE
Bump version to v1.43.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.43.2 (2020-08-25)
+
 * Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
 * Fix subject nesting detection in `RSpec/LeadingSubject`. ([@pirj][])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
+* Fix subject nesting detection in `RSpec/LeadingSubject`. ([@pirj][])
 
 ## 1.43.1 (2020-08-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
+
 ## 1.43.1 (2020-08-17)
 
 * Fix `RSpec/FilePath` when checking a file defining e.g. an empty class. ([@bquorning][])

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -69,7 +69,7 @@ module RuboCop
 
         def_node_search :routing_metadata?, '(pair (sym :type) (sym :routing))'
 
-        def on_top_level_group(node)
+        def on_top_level_example_group(node)
           return unless top_level_groups.one?
 
           const_described(node) do |send_node, described_class, arguments|

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -54,11 +54,15 @@ module RuboCop
         private
 
         def offending_node(node)
-          node.parent.each_child_node.find do |sibling|
+          parent(node).each_child_node.find do |sibling|
             break if sibling.equal?(node)
 
             yield sibling if offending?(sibling)
           end
+        end
+
+        def parent(node)
+          node.each_ancestor(:block).first.body
         end
 
         def autocorrect(corrector, node, sibling)

--- a/lib/rubocop/rspec/top_level_group.rb
+++ b/lib/rubocop/rspec/top_level_group.rb
@@ -16,7 +16,7 @@ module RuboCop
         return unless root_node
 
         top_level_groups.each do |node|
-          example_group?(node, &method(:on_top_level_example_group))
+          on_top_level_example_group(node) if example_group?(node)
           on_top_level_group(node)
         end
       end
@@ -29,9 +29,9 @@ module RuboCop
       private
 
       # Dummy methods to be overridden in the consumer
-      def on_top_level_example_group; end
+      def on_top_level_example_group(_node); end
 
-      def on_top_level_group; end
+      def on_top_level_group(_node); end
 
       def top_level_group?(node)
         top_level_groups.include?(node)

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.43.1'
+      STRING = '1.43.2'
     end
   end
 end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
     RUBY
   end
 
+  it 'ignores shared examples' do
+    expect_no_offenses(<<-RUBY, 'user.rb')
+      shared_examples_for 'foo' do; end
+    RUBY
+  end
+
   it 'skips specs that do not describe a class / method' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -269,4 +269,16 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  it 'ignores subject nested inside a block' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe User do
+        let(:foo) { 'bar' }
+
+        it_behaves_like 'a good citizen' do
+          subject { described_class.new }
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
As discussed in https://github.com/rubocop-hq/rubocop-rspec/pull/1011#issuecomment-679334188, we have a couple of regression fixes that should be released before the next minor (or major) release goes out.

This branch cherry-picks the merge commits of #1009 and #1011 and changes the version number.

This branch will need to be merged into master afterwards, possibly manually (because of CHANGELOG conflicts), but the tagging and releasing will be done from fd7009b6c1c169f81ec43b9fbff64e6a8398eb03 *before the merge*.

---

Before submitting the PR make sure the following are checked:

* [-] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
