### PR TITLE
Allow context with no args followed by include context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
 * Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Add `RSpec/StubbedMock` cop. ([@bquorning][], [@pirj][])
+* Relax `RSpec/MissingExampleGroupArgument` cop so `context` with no arguments can be used if `include_context` is followed on next line. ([@mpospelov][])
 
 ## 1.43.2 (2020-08-25)
 
@@ -561,3 +562,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jtannas]: https://github.com/jtannas
 [@mockdeep]: https://github.com/mockdeep
 [@biinari]: https://github.com/biinari
+[@mpospelov]: https://github.com/mpospelov

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2499,6 +2499,10 @@ end
 
 describe "A feature example" do
 end
+
+context do
+  include_context 'when something is different'
+end
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/missing_example_group_argument.rb
+++ b/lib/rubocop/cop/rspec/missing_example_group_argument.rb
@@ -19,12 +19,25 @@ module RuboCop
       #
       #   describe "A feature example" do
       #   end
+      #
+      #   context do
+      #     include_context 'when something is different'
+      #   end
       class MissingExampleGroupArgument < Base
         MSG = 'The first argument to `%<method>s` should not be empty.'
+        INCLUDE_CONTEXT = '(send nil? :include_context str)'
+
+        def_node_matcher :context_with_shared_context?, <<~PATTERN
+          (block (send nil? :context) _ {
+            (begin #{INCLUDE_CONTEXT} ...)
+            #{INCLUDE_CONTEXT}
+          })
+        PATTERN
 
         def on_block(node)
           return unless example_group?(node)
           return if node.send_node.arguments?
+          return if context_with_shared_context?(node)
 
           add_offense(node, message: format(MSG, method: node.method_name))
         end

--- a/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
       end
     RUBY
   end
+
+  it 'accepts context without name with included context on next line' do
+    expect_no_offenses(<<-RUBY)
+      context do
+        include_context 'when something is different'
+      end
+    RUBY
+  end
+
+  it 'accepts context without name with included context and tests' do
+    expect_no_offenses(<<-RUBY)
+      context do
+        include_context 'when something is different'
+
+        specify { expect(1 + 2).to eq(3) }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Relax `RSpec/MissingExampleGroupArgument` to allow `context` with no arguments in case of `include_context`
 
```ruby
context do
  include_context 'when something is different'

  specify { expect(1 + 2).to eq(3) }
end
```
---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
