### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Move our documentation from rubocop-rspec.readthedocs.io to docs.rubocop.org/rubocop-rspec. ([@bquorning][])
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
 * Add `RSpec/StubbedMock` cop. ([@bquorning][], [@pirj][])
+* Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 * Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Fix a false positive for `RSpec/EmptyExampleGroup` when example is defined in an `if` branch. ([@koic][])
 
@@ -12,7 +13,6 @@
 
 * Fix `RSpec/FilePath` when checking a file with a shared example. ([@pirj][])
 * Fix subject nesting detection in `RSpec/LeadingSubject`. ([@pirj][])
-* Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 
 ## 1.43.1 (2020-08-17)
 


### PR DESCRIPTION
Mistakenly added a changelog entry to a released version in https://github.com/rubocop-hq/rubocop-rspec/pull/1021

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).