### PR TITLE
Use the new Node Pattern multiple term union syntax

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -31,7 +31,7 @@ module RuboCop
                          'or `%<arg>s.run`.'
 
         def_node_matcher :hook, <<-PATTERN
-          (block {(send nil? :around) (send nil? :around sym)} (args $...) ...)
+          (block (send nil? :around sym ?) (args $...) ...)
         PATTERN
 
         def_node_search :find_arg_usage, <<-PATTERN

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -22,8 +22,7 @@ module RuboCop
         def_node_matcher :lambda?, <<-PATTERN
           {
             (send (const nil? :Proc) :new)
-            (send nil? :proc)
-            (send nil? :lambda)
+            (send nil? {:proc :lambda})
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -43,10 +43,10 @@ module RuboCop
         #
         #   @yield [Symbol] subject name
         def_node_matcher :subject, <<-PATTERN
-          {
-            (block (send nil? :subject (sym $_)) args ...)
-            (block (send nil? $:subject) args ...)
-          }
+            (block
+              (send nil?
+                {:subject (sym $_) | $:subject}
+              ) args ...)
         PATTERN
 
         # @!method message_expectation?(node, method_name)

--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -6,11 +6,7 @@ module RuboCop
     class Hook < Concept
       def_node_matcher :extract_metadata, <<~PATTERN
         (block
-          {
-            (send _ _ #valid_scope? $...)
-            (send _ _ $...)
-          }
-          ...
+          (send _ _ #valid_scope? ? $...) ...
         )
       PATTERN
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 0.87'
+  spec.add_runtime_dependency 'rubocop-ast', '~> 0.7.1'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
`rubocop-ast` has recently introduced syntax that allows for matching multiple subsequent terms in a union.

https://github.com/rubocop-hq/rubocop-ast/commit/e28920a56c894bdf5b482d274cbc88e91f54e5a3#diff-9a2615ac7e37917e7fb9e29d3cb4beb0

https://github.com/rubocop-hq/rubocop-ast/issues/79

This change is to demonstrate this syntax in action, and to (subjectively and arguably) simplify the node pattern used.

~I'm targeting this for 2.0 to avoid bumping our dependencies for `rubocop-ast` to 0.7.1.~

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).