### PR TITLE
`Language::SelectorSet` tweaks

### DIFF
--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -7,7 +7,8 @@ module RuboCop
       # Set of method selectors
       class SelectorSet
         def initialize(selectors)
-          @selectors = selectors
+          @selectors = selectors.freeze
+          freeze
         end
 
         def ==(other)

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -51,6 +51,10 @@ module RuboCop
           selectors.map(&:inspect).join(' ')
         end
 
+        def to_a
+          selectors
+        end
+
         protected
 
         attr_reader :selectors


### PR DESCRIPTION
I wanted to access `[:subject, :subject!]` and was surprised to realize I couldn't.

This PR addresses that.

Commits are not directly related, but second one assumes first one. Let me know if I need to split them.