### PR TITLE
Add Example Request to Examples Module

### DIFF
--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -93,8 +93,9 @@ module RuboCop
         FOCUSED  = SelectorSet.new(%i[fit fspecify fexample fscenario focus])
         SKIPPED  = SelectorSet.new(%i[xit xspecify xexample xscenario skip])
         PENDING  = SelectorSet.new(%i[pending])
+        API_DOC  = SelectorSet.new(%i[example_request])
 
-        ALL = EXAMPLES + FOCUSED + SKIPPED + PENDING
+        ALL = EXAMPLES + FOCUSED + SKIPPED + PENDING + API_DOC
       end
 
       module Hooks


### PR DESCRIPTION
I started using https://github.com/zipmark/rspec_api_documentation . I understand since this is not part of any core rspec gems, it is entirely debatable whether this should be added or not. The easy option is to exclude the cop. However, I still find it to be a valid cop in keeping spec files clean.

As explained [here](https://github.com/zipmark/rspec_api_documentation), `example` is used as `it`. When using `example`, `do_request` needs to be added within the block. However, there is a more concise method of using [example_request](https://github.com/zipmark/rspec_api_documentation). Unfortunately, this upsets rubo 😞 

Thoughts from anyone would be great. The trend of auto generating docs is certainly a thing, I would be curious on the best way to solve for this.

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
