### PR TITLE
Bump version to 1.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -513,8 +513,8 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rspeicher]: https://github.com/rspeicher
 [@jonatas]: https://github.com/jonatas
 [@pocke]: https://github.com/pocke
-[@bmorrall]: https:/github.com/bmorrall
-[@zverok]: https:/github.com/zverok
+[@bmorrall]: https://github.com/bmorrall
+[@zverok]: https://github.com/zverok
 [@timrogers]: https://github.com/timrogers
 [@yevhene]: https://github.com/yevhene
 [@walf443]: https://github.com/walf443
@@ -559,7 +559,6 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@andrykonchin]: https://github.com/andrykonchin
 [@harrylewis]: https://github.com/harrylewis
 [@elliterate]: https://github.com/elliterate
-[@mlarraz]: https://github.com/mlarraz
 [@jtannas]: https://github.com/jtannas
 [@mockdeep]: https://github.com/mockdeep
 [@biinari]: https://github.com/biinari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 1.44.0 (2020-10-20)
+
 * Move our documentation from rubocop-rspec.readthedocs.io to docs.rubocop.org/rubocop-rspec. ([@bquorning][])
 * Add `RSpec/RepeatedIncludeExample` cop. ([@biinari][])
 * Add `RSpec/StubbedMock` cop. ([@bquorning][], [@pirj][])

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.43.2'
+      STRING = '1.44.0'
     end
   end
 end

--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe 'CHANGELOG.md' do
     end
   end
 
+  describe 'contributors' do
+    let(:contributors) do
+      changelog.partition("<!-- Contributors -->\n\n").last.lines
+    end
+
+    it 'does not contain duplicates' do
+      expect(contributors.uniq).to eq(contributors)
+    end
+
+    it 'links to github profiles' do
+      expect(contributors).to all(
+        match(%r{\A\[@([^\]]+)\]: https://github.com/\1\n\z})
+      )
+    end
+  end
+
   describe 'entry' do
     subject(:entries) { lines.grep(/^\*/).map(&:chomp) }
 


### PR DESCRIPTION
@pirj mentioned in https://github.com/rubocop-hq/rubocop-rspec/pull/1018#issuecomment-709905986 that maybe it was time for a new release.

I am still unsure of the new release process for our documentation, so please don’t merge before we’ve figured that out 😄 

By the way, sorry for doing two things in one pull request, but I added a spec to check the looks of the contributors list in the changelog file.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
