### PR TITLE
Relaxes rubocop-ast dependency locking

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 0.87'
-  spec.add_runtime_dependency 'rubocop-ast', '~> 0.7.1'
+  spec.add_runtime_dependency 'rubocop-ast', '>= 0.7.1'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Relaxes rubocop-ast dependency lock from `~> 0.7.1` to `~> 0.7`, fixes https://github.com/rubocop-hq/rubocop-rspec/issues/1046

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
