### PR TITLE
RuboCop 1.0 is supported

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.87'
+  spec.add_runtime_dependency 'rubocop', '>= 0.87'
   spec.add_runtime_dependency 'rubocop-ast', '>= 0.7.1'
 
   spec.add_development_dependency 'rack'


### PR DESCRIPTION
A quick release would be appreciated, as I believe nobody can use `rubocop-rspec` with 1.0.

At least `rubocop-ast`'s CI [build fails for the `master` branch](https://github.com/rubocop-hq/rubocop-ast/runs/1286473850?check_suite_focus=true) as it can't resolve dependencies.