### PR TITLE
Allow rubocop-rspec to install with rubocop 1.0.0

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.87'
+  spec.add_runtime_dependency 'rubocop', '> 0.87'
   spec.add_runtime_dependency 'rubocop-ast', '>= 0.7.1'
 
   spec.add_development_dependency 'rack'


### PR DESCRIPTION
Fix for
```
      rubocop-rspec (= 1.44.1) was resolved to 1.44.1, which depends on
        rubocop (~> 0.87)
```
when trying to use it with rubocop 1.0.0
