### PR TITLE
Allow rubocop 1.0

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.87'
+  spec.add_runtime_dependency 'rubocop', '>= 0.87', '< 1.1'
   spec.add_runtime_dependency 'rubocop-ast', '>= 0.7.1'
 
   spec.add_development_dependency 'rack'


### PR DESCRIPTION
Rubocop 1.0 was released.
https://github.com/rubocop-hq/rubocop/releases/tag/v1.0.0