### PR TITLE
Release v2.0.0-pre, compatible with RuboCop v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.0.0-pre (2020-10-22)
+
 * Update RuboCop dependency to v1.0.0. ([@bquorning][])
 * **(Potentially breaking)** Change namespace of several cops (`Capybara/*` -> `RSpec/Capybara/*`, `FactoryBot/*` -> `RSpec/FactoryBot/*`, `Rails/*` -> `RSpec/Rails/*`). ([@pirj][], [@bquorning][])
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '1.44.1'
+      STRING = '2.0.0-pre'
     end
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/rubocop-hq/rubocop-rspec/issues/1051#issuecomment-714407197, let’s make a 2.0 pre-release so our users can try out the new RuboCop v1.0.

I will hold off on pushing our documentation until we release the _real_ v2.0. Does that sound ok?

---

Before submitting the PR make sure the following are checked:

* [-] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
