### PR TITLE
Use config context for all cop specs

### DIFF
--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
-  subject(:cop) { described_class.new }
-
   # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
-  subject(:cop) { described_class.new }
-
   # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
-  subject(:cop) { described_class.new }
-
   it 'finds `allow_any_instance_of` instead of an instance double' do
     expect_offense(<<-RUBY)
       before do

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
-  subject(:cop) { described_class.new }
-
   context 'when no value is yielded' do
     it 'registers an offense' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::BeEql do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for `eql` when argument is a boolean' do
     expect_offense(<<-RUBY)
       it { expect(foo).to eql(true) }

--- a/spec/rubocop/cop/rspec/be_spec.rb
+++ b/spec/rubocop/cop/rspec/be_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Be do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for `be` without an argument' do
     expect_offense(<<-RUBY)
       it { expect(foo).to be }

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
-  subject(:cop) { described_class.new }
-
   def message(hook)
     "Beware of using `#{hook}` as it may cause state to leak between tests. "\
     'If you are using `rspec-rails`, and `use_transactional_fixtures` is '\

--- a/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation do
-  subject(:cop) { described_class.new }
-
   it 'flags violations for `expect(current_path)`' do
     expect_offense(<<-RUBY)
       expect(current_path).to eq("/callback")

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods, :config do
+RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   it 'flags violations for `background`' do
     expect_offense(<<-RUBY)
       describe 'some feature' do

--- a/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::VisibilityMatcher do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense when using `visible: true`' do
     expect_offense(<<-RUBY)
       expect(page).to have_selector('.my_element', visible: true)

--- a/spec/rubocop/cop/rspec/context_method_spec.rb
+++ b/spec/rubocop/cop/rspec/context_method_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
-  subject(:cop) { described_class.new }
-
   it 'ignores describe blocks' do
     expect_no_offenses(<<-RUBY)
       describe '.foo_bar' do

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ContextWording, :config do
+RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   let(:cop_config) { { 'Prefixes' => %w[when with] } }
 
   it 'skips describe blocks' do

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::DescribeClass, :config do
+RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   it 'checks first-line describe statements' do
     expect_offense(<<-RUBY)
       describe "bad describe" do

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
-  subject(:cop) { described_class.new }
-
   it 'ignores describes with only a class' do
     expect_no_offenses('describe Some::Class do; end')
   end

--- a/spec/rubocop/cop/rspec/describe_symbol_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_symbol_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
-  subject(:cop) { described_class.new }
-
   it 'flags violations for `describe :symbol`' do
     expect_offense(<<-RUBY)
       describe(:some_method) { }

--- a/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping do
-  subject(:cop) { described_class.new }
-
   it 'allows a describe block in the outermost scope' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe MyClass do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::DescribedClass, :config do
+RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
   let(:cop_config) { {} }
 
   context 'when SkipBlocks is `true`' do

--- a/spec/rubocop/cop/rspec/dialect_spec.rb
+++ b/spec/rubocop/cop/rspec/dialect_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::Dialect, :config do
+RSpec.describe RuboCop::Cop::RSpec::Dialect do
   let(:cop_config) do
     {
       'PreferredMethods' => {

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
+RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
   it 'flags an empty example group' do
     expect_offense(<<~RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/empty_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_hook_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyHook do
-  subject(:cop) { described_class.new }
-
   context 'with `before` hook' do
     it 'detects offense for empty `before`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
-  subject(:cop) { described_class.new }
-
   it 'checks for empty line after describe' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample, :config do
+RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   it 'flags a missing empty line after `it`' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
-  subject(:cop) { described_class.new }
-
   it 'checks for empty line after last let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
-  subject(:cop) { described_class.new }
-
   it 'checks for empty line after `before` hook' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
-  subject(:cop) { described_class.new }
-
   it 'checks for empty line after subject' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExampleLength, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
   let(:cop_config) { { 'Max' => 3 } }
 
   it 'ignores non-spec blocks' do

--- a/spec/rubocop/cop/rspec/example_without_description_spec.rb
+++ b/spec/rubocop/cop/rspec/example_without_description_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExampleWording, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   it 'ignores non-example blocks' do
     expect_no_offenses('foo "should do something" do; end')
   end

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExpectActual, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   it 'flags numeric literal values within expect(...)' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExpectChange, :config do
+RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
-  subject(:cop) { described_class.new }
-
   it 'adds an offense for `expect` in `before` hook' do
     expect_offense(<<-RUBY)
       before do

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for overwriting $stdout within an example' do
     expect_offense(<<-RUBY)
       specify do

--- a/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::FactoryBot::AttributeDefinedStatically do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for offending code' do
     expect_offense(<<-RUBY)
       FactoryBot.define do

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList, :config do
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_class_name_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryClassName do
-  subject(:cop) { described_class.new }
-
   context 'when passing block' do
     it 'flags passing a class' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::FilePath, :config do
+RSpec.describe RuboCop::Cop::RSpec::FilePath do
   it 'registers an offense for a bad path' do
     expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
       describe MyClass, 'foo' do; end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Focus do
-  subject(:cop) { described_class.new }
-
   # rubocop:disable RSpec/ExampleLength
   it 'flags all rspec example blocks with that include `focus: true`' do
     expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::HookArgument, :config do
+RSpec.describe RuboCop::Cop::RSpec::HookArgument do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
-  subject(:cop) { described_class.new }
-
   it 'flags `before` after `it`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
-  subject(:cop) { described_class.new }
-
   it 'flags lambda in subject' do
     expect_offense(<<-RUBY)
       describe do

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect, :config do
+RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect do
   context 'when EnforcedStyle is is_expected' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'is_expected' }

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject, :config do
+RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
-  subject(:cop) { described_class.new }
-
   context 'when used with `have_received`' do
     it 'adds an offense for an instance_double with single argument' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
-  subject(:cop) { described_class.new }
-
   it 'flags an instance variable inside a describe' do
     expect_offense(<<-RUBY)
       describe MyClass do
@@ -130,7 +128,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     end
   end
 
-  context 'when configured with AssignmentOnly', :config do
+  context 'when configured with AssignmentOnly' do
     let(:cop_config) do
       { 'AssignmentOnly' => true }
     end

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike, :config do
+RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
-  subject(:cop) { described_class.new }
-
   it 'flags `each` with an expectation' do
     expect_offense(<<-RUBY)
       it 'validates users' do

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
-  subject(:cop) { described_class.new }
-
   it 'checks subject below let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
+++ b/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
-  subject(:cop) { described_class.new }
-
   describe 'constant assignment' do
     it 'flags inside an example group' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
-  subject(:cop) { described_class.new }
-
   it 'flags `let` after `it`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::LetSetup do
-  subject(:cop) { described_class.new }
-
   it 'complains when let! is used and not referenced' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MessageChain do
-  subject(:cop) { described_class.new }
-
   it 'finds `receive_message_chain`' do
     expect_offense(<<-RUBY)
       before do

--- a/spec/rubocop/cop/rspec/message_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/message_expectation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::MessageExpectation, :config do
+RSpec.describe RuboCop::Cop::RSpec::MessageExpectation do
   context 'when EnforcedStyle is allow' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'allow' }

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::MessageSpies, :config do
+RSpec.describe RuboCop::Cop::RSpec::MessageSpies do
   context 'when EnforcedStyle is have_received' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'have_received' }

--- a/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
-  subject(:cop) { described_class.new }
-
   it 'accepts describe with an argument' do
     expect_no_offenses(<<-RUBY)
       describe FooClass do

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
-  subject(:cop) { described_class.new }
-
   it 'flags multiple top-level example groups with class and method' do
     expect_offense(<<-RUBY)
       describe MyClass, '.do_something' do; end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations, :config do
+RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
   context 'without configuration' do
     let(:cop_config) { {} }
 

--- a/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers, :config do
+RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers do
   let(:cop_config) { { 'Max' => 1 } }
 
   it 'flags excessive `#let`' do
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers, :config do
     RUBY
   end
 
-  context 'when using AllowSubject configuration', :config do
+  context 'when using AllowSubject configuration' do
     let(:cop_config) { { 'Max' => 1, 'AllowSubject' => false } }
 
     it 'flags `#subject` without name' do

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::NamedSubject, :config do
+RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   shared_examples_for 'checking subject outside of shared examples' do
     it 'checks `it` and `specify` for explicit subject usage' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::NestedGroups, :config do
+RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   it 'flags nested example groups defined inside `describe`' do
     expect_offense(<<-RUBY)
       describe MyClass do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::NotToNot, :config do
+RSpec.describe RuboCop::Cop::RSpec::NotToNot do
   context 'when EnforcedStyle is `not_to`' do
     let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
-  subject(:cop) { described_class.new }
-
   it 'finds overwriten `let`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Pending do
-  subject(:cop) { described_class.new }
-
   it 'flags xcontext' do
     expect_offense(<<-RUBY)
       xcontext 'test' do

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher, :config do
+RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style,
       'Strict' => strict,

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus, :config do
+RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
   context 'when EnforcedStyle is `symbolic`' do
     let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 

--- a/spec/rubocop/cop/rspec/receive_counts_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_counts_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
-  subject(:cop) { described_class.new }
-
   it 'flags usage of `exactly(1).times`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).exactly(1).times

--- a/spec/rubocop/cop/rspec/receive_never_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_never_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
-  subject(:cop) { described_class.new }
-
   it 'flags usage of `never`' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).never

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for repeated descriptions' do
     expect_offense(<<-RUBY)
       describe 'doing x' do

--- a/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for repeated describe body' do
     expect_offense(<<-RUBY)
       describe 'doing x' do

--- a/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for repeated describe descriptions' do
     expect_offense(<<-RUBY)
       describe 'doing x' do

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense for repeated example' do
     expect_offense(<<-RUBY)
       describe 'doing x' do

--- a/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
-  subject(:cop) { described_class.new }
-
   shared_examples 'detect repeated include examples' do |include_method|
     context "with include method: #{include_method}" do
       context 'without parameters' do

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub, :config do
+RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
-  subject(:cop) { described_class.new }
-
   it 'flags `let` after the first different node ' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
-  subject(:cop) { described_class.new }
-
   it 'flags multiple hooks in the same example group' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::SharedContext do
-  subject(:cop) { described_class.new }
-
   describe 'shared_context' do
     it 'does not register an offense for empty contexts' do
       expect_no_offenses(<<-RUBY)

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
-  subject(:cop) { described_class.new }
-
   it 'registers an offense when using symbolic title' do
     expect_offense(<<-RUBY)
       it_behaves_like :foo_bar_baz

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
-  subject(:cop) { described_class.new }
-
   describe 'receive_message_chain' do
     it 'reports single-argument calls' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
+++ b/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
-  subject(:cop) { described_class.new }
-
   it 'flags stubbed message expectation' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).and_return('hello world')

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
-  subject(:cop) { described_class.new }
-
   it 'flags when subject is stubbed' do
     expect_offense(<<-RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
-  subject(:cop) { described_class.new }
-
   context 'with raise_error matcher' do
     it 'detects the `unspecified_exception` offense' do
       expect_offense(<<-RUBY)

--- a/spec/rubocop/cop/rspec/variable_definition_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_definition_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::VariableDefinition, :config do
+RSpec.describe RuboCop::Cop::RSpec::VariableDefinition do
   context 'when EnforcedStyle is `symbols`' do
     let(:cop_config) { { 'EnforcedStyle' => 'symbols' } }
 

--- a/spec/rubocop/cop/rspec/variable_name_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_name_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::VariableName, :config do
+RSpec.describe RuboCop::Cop::RSpec::VariableName do
   context 'when configured for `snake_case`' do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles, :config do
+RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
   it 'finds a `double` instead of an `instance_double`' do
     expect_offense(<<-RUBY)
       it do

--- a/spec/rubocop/cop/rspec/void_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/void_expect_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
-  subject(:cop) { described_class.new }
-
   it 'registers offenses to void `expect`' do
     expect_offense(<<-RUBY)
       it 'something' do

--- a/spec/rubocop/cop/rspec/yield_spec.rb
+++ b/spec/rubocop/cop/rspec/yield_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Yield do
-  subject(:cop) { described_class.new }
-
   it 'flags `block.call`' do
     expect_offense(<<-RUBY)
       allow(foo).to receive(:bar) { |&block| block.call }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,11 @@ RSpec.configure do |config|
     meta[:type] = :cop_spec
   end
 
+  # Include config shared context for all cop specs
+  config.define_derived_metadata(type: :cop_spec) do |metadata|
+    metadata[:config] = true
+  end
+
   config.order = :random
 
   # Forbid RSpec from monkey patching any of our objects


### PR DESCRIPTION
* Add shared context for all cop specs.
* Remove redundant `config` metadata for cop specs.
* Remove redundant `cop` subjects from cop specs.

Extracted from #956.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
