### PR TITLE
Optimize Base#relevant_file?

### DIFF
--- a/lib/rubocop/cop/rspec/base.rb
+++ b/lib/rubocop/cop/rspec/base.rb
@@ -36,6 +36,10 @@ module RuboCop
           RuboCop::Cop::Base.inherited(subclass)
         end
 
+        class << self
+          attr_accessor :rspec_pattern
+        end
+
         def relevant_file?(file)
           relevant_rubocop_rspec_file?(file) && super
         end
@@ -47,11 +51,14 @@ module RuboCop
         end
 
         def rspec_pattern
-          if rspec_pattern_config?
-            Regexp.union(rspec_pattern_config.map(&Regexp.public_method(:new)))
-          else
-            DEFAULT_PATTERN_RE
-          end
+          self.class.rspec_pattern ||=
+            if rspec_pattern_config?
+              Regexp.union(
+                rspec_pattern_config.map(&Regexp.public_method(:new))
+              )
+            else
+              DEFAULT_PATTERN_RE
+            end
         end
 
         def all_cops_config


### PR DESCRIPTION
I identified the problem, fixed and then discovered https://github.com/rubocop-hq/rubocop-rspec/pull/967. So this is another implementation, with possibly the smallest change possible.
 
So, I profiled `rubocop`s memory usage while running on itself:
```
bundle exec bin/rubocop-profile --memory lib/rubocop/cop
```
And get the following:

### Before
```
Total allocated: 1.14 GB (16969980 objects)
Total retained:  7.35 MB (54861 objects)

allocated memory by gem
-----------------------------------
 408.41 MB  rubocop/lib
 297.48 MB  parser-2.7.2.0
 195.80 MB  rubocop-ast-1.0.1
 112.66 MB  rubocop-rspec-1.43.2
.....
allocated memory by file
-----------------------------------
 125.46 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/parser-2.7.2.0/lib/parser/source/tree_rewriter.rb
 110.64 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rubocop-rspec-1.43.2/lib/rubocop/cop/rspec/base.rb
....
```

### After
```
Total allocated: 1.01 GB (15940558 objects)
Total retained:  6.92 MB (49414 objects)

allocated memory by gem
-----------------------------------
 409.73 MB  rubocop/lib
 300.32 MB  parser-2.7.2.0
 197.03 MB  rubocop-ast-1.0.1
  29.16 MB  other
  23.92 MB  rubocop-performance-1.8.1
  20.42 MB  set
   6.15 MB  ast-2.4.1
   5.84 MB  regexp_parser-1.8.2
   5.22 MB  unicode-display_width-1.7.0
   4.11 MB  psych
   2.24 MB  rubocop-rspec/lib
   2.17 MB  erb
....
allocated memory by file
-----------------------------------
 125.46 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/parser-2.7.2.0/lib/parser/source/tree_rewriter.rb
  60.59 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.0.1/lib/rubocop/ast/node.rb
....
 204.78 kB  /Users/fatkodima/Desktop/oss/rubocop-rspec/lib/rubocop/cop/rspec/base.rb
....
```

And measured the impact of just `rubocop-rspec`.
```
bundle exec bin/rubocop-profile --memory --only RSpec lib/rubocop/cop
```

### Before
```
Total allocated: 354.84 MB (4610105 objects)
Total retained:  5.84 MB (42878 objects)
....
allocated memory by file
-----------------------------------
 101.90 MB  /Users/fatkodima/Desktop/oss/rubocop-rspec/lib/rubocop/cop/rspec/base.rb
  40.35 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/parser-2.7.2.0/lib/parser/lexer.rb
....
```

### After
```
Total allocated: 253.12 MB (3946086 objects)
Total retained:  5.86 MB (43001 objects)
....
allocated memory by file
-----------------------------------
  40.35 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/parser-2.7.2.0/lib/parser/lexer.rb
  29.81 MB  /Users/fatkodima/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rubocop-ast-1.0.1/lib/rubocop/ast/node.rb
....
 43.97 kB  /Users/fatkodima/Desktop/oss/rubocop-rspec/lib/rubocop/cop/rspec/base.rb
....
```

So, `~30%` reducing in memory.