### PR TITLE
Refactor a spec

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,3 +10,7 @@
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 106
+
+RSpec/ExampleLength:
+  Exclude:
+    - spec/rubocop/cop/rspec/factory_bot/attribute_defined_statically_spec.rb


### PR DESCRIPTION
'autocorrect' shared example group does not pass a correct file name to
the cop, and if this cop is tweaked to only inspect factories, this spec
fails because the default file name/path is skipped, since it's not a
factory path.


#1063 depends on this

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).