### PR TITLE
Stop using newly added cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ require:
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: 2.4
-  NewCops: enable
+  NewCops: disable
   Exclude:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'


### PR DESCRIPTION
```
lib/rubocop/cop/rspec/multiple_expectations.rb:73:32: W: Lint/ToEnumArguments: Ensure you correctly provided all the arguments.
              expectations_count = to_enum(:find_expectation, node).count
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
([source](https://app.circleci.com/pipelines/github/rubocop-hq/rubocop-rspec/634/workflows/df5cf9d4-b931-4fd2-af3f-36f4e74276ab/jobs/18146))

We'd still love to use OUR new cops while working on our codebase, let's see how this option works when set under RSpec namespace when we introduce the first pending cop.


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).