### PR TITLE
Use `case` instead of `if`

### DIFF
--- a/lib/rubocop/cop/rspec/mixin/top_level_group.rb
+++ b/lib/rubocop/cop/rspec/mixin/top_level_group.rb
@@ -9,7 +9,6 @@ module RuboCop
 
         def on_new_investigation
           super
-          return unless root_node
 
           top_level_groups.each do |node|
             on_top_level_example_group(node) if example_group?(node)
@@ -34,11 +33,12 @@ module RuboCop
         end
 
         def top_level_nodes(node)
-          if node.nil?
-            []
-          elsif node.begin_type?
+          return [] if node.nil?
+
+          case node.type
+          when :begin
             node.children
-          elsif node.module_type? || node.class_type?
+          when :module, :class
             top_level_nodes(node.body)
           else
             [node]


### PR DESCRIPTION
Code Climate has been complaining about `RuboCop::Cop::RSpec::TopLevelGroup#top_level_nodes`. I ran [Flog](https://ruby.sadi.st/Flog.html) on it and tried to reduce the complexity.

I think this new version using `case` reads nicer, and Flog agrees. Before:
```
❯ flog lib/rubocop/cop/rspec/mixin/top_level_group.rb
    29.7: flog total
     5.0: flog/method average

     9.8: RuboCop::Cop::RSpec::TopLevelGroup#top_level_nodes lib/rubocop/cop/rspec/mixin/top_level_group.rb:36-44
     7.6: RuboCop::Cop::RSpec::TopLevelGroup#on_new_investigation lib/rubocop/cop/rspec/mixin/top_level_group.rb:10-16
     4.9: RuboCop::Cop::RSpec::TopLevelGroup#top_level_groups lib/rubocop/cop/rspec/mixin/top_level_group.rb:20-22
```
After:
```
❯ flog lib/rubocop/cop/rspec/mixin/top_level_group.rb
    25.8: flog total
     4.3: flog/method average

     7.2: RuboCop::Cop::RSpec::TopLevelGroup#top_level_nodes lib/rubocop/cop/rspec/mixin/top_level_group.rb:35-44
     6.3: RuboCop::Cop::RSpec::TopLevelGroup#on_new_investigation lib/rubocop/cop/rspec/mixin/top_level_group.rb:10-15
     4.9: RuboCop::Cop::RSpec::TopLevelGroup#top_level_groups lib/rubocop/cop/rspec/mixin/top_level_group.rb:19-21
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with ~`master`~ `release-2.0` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
