### PR TITLE
Fix backtick with a following quote

### DIFF
--- a/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
+++ b/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
@@ -91,7 +91,7 @@ RSpec/FactoryBot:
     - property/factories/**/*.rb
 ----
 
-NOTE: Please keep in mind that `Include`'s merge mode is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.
+NOTE: Please keep in mind that `Include`’s merge mode is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.
 
 https://github.com/rubocop-hq/rubocop-rspec/pull/1063[Learn more about this change].
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -114,4 +114,4 @@ RSpec:
     - '**/*_test.rb'
 ----
 
-NOTE: Please keep in mind that `Include`'s merge mode is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.
+NOTE: Please keep in mind that `Include`’s merge mode is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.


### PR DESCRIPTION
It seems that a quote follwoing the backtick doesn't work well:

![image](https://user-images.githubusercontent.com/6916/98392864-8f22a780-2069-11eb-8425-b7dcf469e24f.png)

Looks better now, at least according to [GH's render](https://github.com/rubocop-hq/rubocop-rspec/blob/c04a22d56c998109ee6d1be6b7c16150c2fd52b1/docs/modules/ROOT/pages/upgrade_to_version_2.adoc#use-the-rubocop-standard-include-option-to-filter-inspected-files):
![image](https://user-images.githubusercontent.com/6916/98392983-ba0cfb80-2069-11eb-8d0e-61f3cfd193d8.png)

[Old one](https://github.com/rubocop-hq/rubocop-rspec/blob/master/docs/modules/ROOT/pages/upgrade_to_version_2.adoc#use-the-rubocop-standard-include-option-to-filter-inspected-files) for comparison:

![image](https://user-images.githubusercontent.com/6916/98393085-dc9f1480-2069-11eb-84b1-1c5ef9ceb4b1.png)


Before submitting the PR make sure the following are checked:

* [x] Updated documentation.