### PR TITLE
[UPDATE] gems' version dependency

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -36,13 +36,13 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.0'
   spec.add_runtime_dependency 'rubocop-ast', '>= 1.1.0'
 
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.7'
+  spec.add_development_dependency 'rubocop-performance', '>= 1.7'
   # Workaround for cc-test-reporter with SimpleCov 0.18.
   # Stop upgrading SimpleCov until the following issue will be resolved.
   # https://github.com/codeclimate/test-reporter/issues/418


### PR DESCRIPTION
In a `Gemfile` if you use Rubocop 1.2, you face an issue to install this gem:
```
rubocop-rspec (~> 2.0) was resolved to 2.0.0, which depends on
      rubocop (~> 1.0)
```

According to [the gem documentation](https://guides.rubygems.org/specification-reference/#required_ruby_version=) I propose to update the version of rubocop in the `rubocop-rspec.gemspec` file.

Tested on `Fedora 32` with `ruby --version ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. __(No new test needed)__
* [x] Updated documentation. __(No documentation update needed)__
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
