### PR TITLE
Allow us to use `fit`, `fdescribe`, `:focus` etc.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,10 @@ RSpec.configure do |config|
 
   config.order = :random
 
+  # Run focused tests with `fdescribe`, `fit`, `:focus` etc.
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   # Forbid RSpec from monkey patching any of our objects
   config.disable_monkey_patching!
 


### PR DESCRIPTION
I find it useful sometimes to just slap an `f` in front of `it` or `describe` when I want to run just a few specs.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
