### PR TITLE
Use `expect_correction` more

### DIFF
--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
         ^^^^^^^^^^ Use `before` instead of `background`.
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe 'some feature' do
+        before do; end
+      end
+    RUBY
   end
 
   it 'flags violations for `scenario`' do
@@ -15,6 +21,12 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
       RSpec.describe 'some feature' do
         scenario 'Foo' do; end
         ^^^^^^^^ Use `it` instead of `scenario`.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe 'some feature' do
+        it 'Foo' do; end
       end
     RUBY
   end
@@ -26,6 +38,12 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
               ^^^^^^^^^ Use `xit` instead of `xscenario`.
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe 'Foo' do
+        RSpec.xit 'Baz' do; end
+      end
+    RUBY
   end
 
   it 'flags violations for `given`' do
@@ -33,6 +51,12 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
       RSpec.describe 'Foo' do
         given(:foo) { :foo }
         ^^^^^ Use `let` instead of `given`.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe 'Foo' do
+        let(:foo) { :foo }
       end
     RUBY
   end
@@ -44,12 +68,22 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
         ^^^^^^ Use `let!` instead of `given!`.
       end
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe 'Foo' do
+        let!(:foo) { :foo }
+      end
+    RUBY
   end
 
   it 'flags violations for `feature`' do
     expect_offense(<<-RUBY)
       RSpec.feature 'Foo' do; end
             ^^^^^^^ Use `describe` instead of `feature`.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe 'Foo' do; end
     RUBY
   end
 
@@ -101,26 +135,4 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
       RUBY
     end
   end
-
-  shared_examples 'autocorrect_spec' do |original, corrected|
-    original = <<-RUBY
-      describe Foo do
-        #{original}
-      end
-    RUBY
-    corrected = <<-RUBY
-      describe Foo do
-        #{corrected}
-      end
-    RUBY
-
-    include_examples 'autocorrect', original, corrected
-  end
-
-  include_examples 'autocorrect_spec', 'background { }',    'before { }'
-  include_examples 'autocorrect_spec', 'scenario { }',      'it { }'
-  include_examples 'autocorrect_spec', 'xscenario { }',     'xit { }'
-  include_examples 'autocorrect_spec', 'given(:foo) { }',   'let(:foo) { }'
-  include_examples 'autocorrect_spec', 'given!(:foo) { }',  'let!(:foo) { }'
-  include_examples 'autocorrect_spec', 'RSpec.feature { }', 'RSpec.describe { }'
 end

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -79,6 +79,29 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
     RUBY
   end
 
+  it 'flags `let` with a heredoc argument' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        include_examples('should be after let')
+
+        let(:foo) { (<<-SOURCE) }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Move `let` before the examples in the group.
+        some long text here
+        SOURCE
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:foo) { (<<-SOURCE) }
+        some long text here
+        SOURCE
+        include_examples('should be after let')
+
+      end
+    RUBY
+  end
+
   it 'does not flag `let` before the examples' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
@@ -129,26 +152,4 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
   end
-
-  bad_code = <<-RUBY
-    RSpec.describe User do
-      include_examples('should be after let')
-
-      let(:foo) { (<<-SOURCE) }
-      some long text here
-      SOURCE
-    end
-  RUBY
-
-  good_code = <<-RUBY
-    RSpec.describe User do
-      let(:foo) { (<<-SOURCE) }
-      some long text here
-      SOURCE
-      include_examples('should be after let')
-
-    end
-  RUBY
-
-  include_examples 'autocorrect', bad_code, good_code
 end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
         it { is_expected.to have_http_status 200 }
                                              ^^^ Prefer `:ok` over `200` to describe HTTP status code.
       RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+      RUBY
     end
 
     it 'does not register an offense when using symbolic value' do
@@ -23,22 +27,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
-    include_examples 'autocorrect',
-                     'it { is_expected.to have_http_status 200 }',
-                     'it { is_expected.to have_http_status :ok }'
-
-    include_examples 'autocorrect',
-                     'it { is_expected.to have_http_status 404 }',
-                     'it { is_expected.to have_http_status :not_found }'
-
     context 'with parenthesis' do
-      include_examples 'autocorrect',
-                       'it { is_expected.to have_http_status(200) }',
-                       'it { is_expected.to have_http_status(:ok) }'
+      it 'registers an offense when using numeric value' do
+        expect_offense(<<-RUBY)
+          it { is_expected.to have_http_status(404) }
+                                               ^^^ Prefer `:not_found` over `404` to describe HTTP status code.
+        RUBY
 
-      include_examples 'autocorrect',
-                       'it { is_expected.to have_http_status(404) }',
-                       'it { is_expected.to have_http_status(:not_found) }'
+        expect_correction(<<-RUBY)
+          it { is_expected.to have_http_status(:not_found) }
+        RUBY
+      end
     end
   end
 
@@ -49,6 +48,10 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       expect_offense(<<-RUBY)
         it { is_expected.to have_http_status :ok }
                                              ^^^ Prefer `200` over `:ok` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status 200 }
       RUBY
     end
 
@@ -67,22 +70,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
-    include_examples 'autocorrect',
-                     'it { is_expected.to have_http_status :ok }',
-                     'it { is_expected.to have_http_status 200 }'
-
-    include_examples 'autocorrect',
-                     'it { is_expected.to have_http_status :not_found }',
-                     'it { is_expected.to have_http_status 404 }'
-
     context 'with parenthesis' do
-      include_examples 'autocorrect',
-                       'it { is_expected.to have_http_status(:ok) }',
-                       'it { is_expected.to have_http_status(200) }'
+      it 'registers an offense when using symbolic value' do
+        expect_offense(<<-RUBY)
+          it { is_expected.to have_http_status(:not_found) }
+                                               ^^^^^^^^^^ Prefer `404` over `:not_found` to describe HTTP status code.
+        RUBY
 
-      include_examples 'autocorrect',
-                       'it { is_expected.to have_http_status(:not_found) }',
-                       'it { is_expected.to have_http_status(404) }'
+        expect_correction(<<-RUBY)
+          it { is_expected.to have_http_status(404) }
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/rspec/receive_counts_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_counts_spec.rb
@@ -128,9 +128,4 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
       expect(action).to have_published_event.exactly(1).times
     RUBY
   end
-
-  # Does not auto-correct if not part of the RSpec API
-  include_examples 'autocorrect',
-                   'expect(foo).to have_published_event(:bar).exactly(2).times',
-                   'expect(foo).to have_published_event(:bar).exactly(2).times'
 end


### PR DESCRIPTION
I think we should use `expect_correction` more and soon completely stop using `include_examples 'autocorrect'`.