### PR TITLE
Less autocorrect

### DIFF
--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       expect_offense(<<-RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
-        after(:each)  { true }
+        after(:each) { true }
         ^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
         around(:each) { true }
         ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
-        config.after(:each)  { true }
+        config.after(:each) { true }
         ^^^^^^^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
       RUBY
     end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       expect_offense(<<-RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
-        after(:example)  { true }
+        after(:example) { true }
         ^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
         around(:example) { true }
         ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     it 'does not flag :each for hooks' do
       expect_no_offenses(<<-RUBY)
         before(:each) { true }
-        after(:each)  { true }
+        after(:each) { true }
         around(:each) { true }
         config.before(:each) { true }
       RUBY
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       expect_offense(<<-RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
-        after(:example)  { true }
+        after(:example) { true }
         ^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
         around(:example) { true }
         ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     it 'does not flag :example for hooks' do
       expect_no_offenses(<<-RUBY)
         before(:example) { true }
-        after(:example)  { true }
+        after(:example) { true }
         around(:example) { true }
         config.before(:example) { true }
       RUBY
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       expect_offense(<<-RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
-        after(:each)  { true }
+        after(:each) { true }
         ^^^^^^^^^^^^ Use `:example` for RSpec hooks.
         around(:each) { true }
         ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -28,19 +28,6 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
   end
 
-  shared_examples 'hook autocorrect' do |output|
-    include_examples 'autocorrect', 'before(:each) { }', output
-    include_examples 'autocorrect', 'before(:example) { }', output
-    include_examples 'autocorrect', 'before { }', output
-
-    include_examples 'autocorrect', 'config.before(:each) { }',
-                     "config.#{output}"
-    include_examples 'autocorrect', 'config.before(:example) { }',
-                     "config.#{output}"
-    include_examples 'autocorrect', 'config.before { }',
-                     "config.#{output}"
-  end
-
   shared_examples 'an example hook' do
     include_examples 'ignored hooks'
     include_examples 'detects style', 'before(:each) { foo }', 'each'
@@ -62,6 +49,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.after(:each) { true }
         ^^^^^^^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before { true }
+        after { true }
+        around { true }
+        config.after { true }
+      RUBY
     end
 
     it 'detects :example for hooks' do
@@ -75,6 +69,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.before(:example) { true }
         ^^^^^^^^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before { true }
+        after { true }
+        around { true }
+        config.before { true }
+      RUBY
     end
 
     it 'does not flag hooks without default scopes' do
@@ -87,7 +88,6 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     include_examples 'an example hook'
-    include_examples 'hook autocorrect', 'before { }'
   end
 
   context 'when EnforcedStyle is :each' do
@@ -113,6 +113,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.before(:example) { true }
         ^^^^^^^^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before(:each) { true }
+        after(:each) { true }
+        around(:each) { true }
+        config.before(:each) { true }
+      RUBY
     end
 
     it 'detects hooks without default scopes' do
@@ -126,10 +133,16 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.before { true }
                ^^^^^^ Use `:each` for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before(:each) { true }
+        after(:each) { true }
+        around(:each) { true }
+        config.before(:each) { true }
+      RUBY
     end
 
     include_examples 'an example hook'
-    include_examples 'hook autocorrect', 'before(:each) { }'
   end
 
   context 'when EnforcedStyle is :example' do
@@ -155,6 +168,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.before(:each) { true }
         ^^^^^^^^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before(:example) { true }
+        after(:example) { true }
+        around(:example) { true }
+        config.before(:example) { true }
+      RUBY
     end
 
     it 'detects hooks without default scopes' do
@@ -168,9 +188,15 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         config.before { true }
                ^^^^^^ Use `:example` for RSpec hooks.
       RUBY
+
+      expect_correction(<<-RUBY)
+        before(:example) { true }
+        after(:example) { true }
+        around(:example) { true }
+        config.before(:example) { true }
+      RUBY
     end
 
     include_examples 'an example hook'
-    include_examples 'hook autocorrect', 'before(:example) { }'
   end
 end

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       expect_no_offenses(<<-RUBY)
         before { true }
         after { true }
+        around { true }
         config.before { true }
       RUBY
     end
@@ -120,6 +121,8 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^ Use `:each` for RSpec hooks.
         after { true }
         ^^^^^ Use `:each` for RSpec hooks.
+        around { true }
+        ^^^^^^ Use `:each` for RSpec hooks.
         config.before { true }
                ^^^^^^ Use `:each` for RSpec hooks.
       RUBY
@@ -160,6 +163,8 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^ Use `:example` for RSpec hooks.
         after { true }
         ^^^^^ Use `:example` for RSpec hooks.
+        around { true }
+        ^^^^^^ Use `:example` for RSpec hooks.
         config.before { true }
                ^^^^^^ Use `:example` for RSpec hooks.
       RUBY

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
   context 'when EnforcedStyle is :each' do
     let(:enforced_style) { :each }
 
-    it 'detects :each for hooks' do
+    it 'does not flag :each for hooks' do
       expect_no_offenses(<<-RUBY)
         before(:each) { true }
         after(:each)  { true }
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
   context 'when EnforcedStyle is :example' do
     let(:enforced_style) { :example }
 
-    it 'detects :example for hooks' do
+    it 'does not flag :example for hooks' do
       expect_no_offenses(<<-RUBY)
         before(:example) { true }
         after(:example)  { true }
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
       RUBY
     end
 
-    it 'does not flag hooks without default scopes' do
+    it 'detects hooks without default scopes' do
       expect_offense(<<-RUBY)
         before { true }
         ^^^^^^ Use `:example` for RSpec hooks.


### PR DESCRIPTION
Follow-up to #1081. Use `expect_correction` more, and use `include_examples 'autocorrect'` less.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).