### PR TITLE
Make CreateList cop not safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Mark `RSpec/FactoryBot/CreateList` as not safe cop. ([@ngouy][])
+
 ## 2.0.0 (2020-11-06)
 
 * Remove deprecated class `::RuboCop::Cop::RSpec::Cop`. ([@bquorning][])
@@ -586,3 +588,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@Rafix02]: https://github.com/Rafix02
 [@PhilCoggins]: https://github.com/PhilCoggins
 [@sl4vr]: https://github.com/sl4vr
+[@ngouy]: https://github.com/ngouy

--- a/config/default.yml
+++ b/config/default.yml
@@ -735,7 +735,8 @@ RSpec/FactoryBot/CreateList:
     - create_list
     - n_times
   VersionAdded: '1.25'
-  VersionChanged: '2.0'
+  VersionChanged: '2.1'
+  Safe: false
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
 RSpec/FactoryBot/FactoryClassName:

--- a/docs/modules/ROOT/pages/cops_rspec/factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec/factorybot.adoc
@@ -57,10 +57,10 @@ count { 1 }
 | Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.25
-| 2.0
+| 2.1
 |===
 
 Checks for create_list usage.


### PR DESCRIPTION
Fix #1087 
Mark CreateList as not safe cop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).


If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
