### PR TITLE
Quotes

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -27,7 +27,7 @@ module RuboCop
       #   end
       class AroundBlock < Base
         MSG_NO_ARG     = 'Test object should be passed to around block.'
-        MSG_UNUSED_ARG = 'You should call `%<arg>s.call` '\
+        MSG_UNUSED_ARG = 'You should call `%<arg>s.call` ' \
                          'or `%<arg>s.run`.'
 
         def_node_matcher :hook, <<-PATTERN

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -20,7 +20,7 @@ module RuboCop
       #   expect(foo).to be(true)
       #
       class Be < Base
-        MSG = 'Don\'t use `be` without an argument.'
+        MSG = "Don't use `be` without an argument."
 
         def_node_matcher :be_without_args, <<-PATTERN
           (send _ #Runners.all $(send nil? :be))

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -24,9 +24,9 @@ module RuboCop
       #     after(:each) { Widget.delete_all }
       #   end
       class BeforeAfterAll < Base
-        MSG = 'Beware of using `%<hook>s` as it may cause state to leak '\
-              'between tests. If you are using `rspec-rails`, and '\
-              '`use_transactional_fixtures` is enabled, then records created '\
+        MSG = 'Beware of using `%<hook>s` as it may cause state to leak ' \
+              'between tests. If you are using `rspec-rails`, and ' \
+              '`use_transactional_fixtures` is enabled, then records created ' \
               'in `%<hook>s` are not automatically rolled back.'
 
         def_node_matcher :before_or_after_all, <<-PATTERN

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -37,7 +37,7 @@ module RuboCop
       class DescribeClass < Base
         include TopLevelGroup
 
-        MSG = 'The first argument to describe should be '\
+        MSG = 'The first argument to describe should be ' \
               'the class or module being tested.'
 
         def_node_matcher :example_group_with_ignored_metadata?, <<~PATTERN

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -19,7 +19,7 @@ module RuboCop
       class DescribeMethod < Base
         include TopLevelGroup
 
-        MSG = 'The second argument to describe should be the method '\
+        MSG = 'The second argument to describe should be the method ' \
               "being tested. '#instance' or '.class'."
 
         def_node_matcher :second_argument, <<~PATTERN

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   # good
       #   expect { my_app.print_report }.to output('Hello World').to_stdout
       class ExpectOutput < Base
-        MSG = 'Use `expect { ... }.to output(...).to_%<name>s` '\
+        MSG = 'Use `expect { ... }.to output(...).to_%<name>s` ' \
               'instead of mutating $%<name>s.'
 
         def on_gvasgn(node)

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -21,7 +21,7 @@ module RuboCop
       class InstanceSpy < Base
         extend AutoCorrector
 
-        MSG = 'Use `instance_spy` when you check your double '\
+        MSG = 'Use `instance_spy` when you check your double ' \
               'with `have_received`.'
 
         def_node_search :null_double, <<-PATTERN

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -22,7 +22,7 @@ module RuboCop
         extend AutoCorrector
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%<replacement>s` over `%<original>s` when including '\
+        MSG = 'Prefer `%<replacement>s` over `%<original>s` when including ' \
               'examples in a nested context.'
 
         def_node_matcher :example_inclusion_offense, '(send _ % ...)'

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   end
       class IteratedExpectation < Base
         MSG = 'Prefer using the `all` matcher instead ' \
-                  'of iterating over an array.'
+              'of iterating over an array.'
 
         def_node_matcher :each?, <<-PATTERN
           (block

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -29,8 +29,8 @@ module RuboCop
 
         MSG_RECEIVE = 'Prefer `receive` for setting message expectations.'
 
-        MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message '\
-                            'expectations. Setup `%<source>s` as a spy using '\
+        MSG_HAVE_RECEIVED = 'Prefer `have_received` for setting message ' \
+                            'expectations. Setup `%<source>s` as a spy using ' \
                             '`allow` or `instance_spy`.'
 
         SUPPORTED_STYLES = %w[have_received receive].freeze

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -25,8 +25,7 @@ module RuboCop
       class MultipleDescribes < Base
         include TopLevelGroup
 
-        MSG = 'Do not use multiple top-level example groups - '\
-              'try to nest them.'
+        MSG = 'Do not use multiple top-level example groups - try to nest them.'
 
         def on_top_level_group(node)
           top_level_example_groups =

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   end
       #
       class ScatteredSetup < Base
-        MSG = 'Do not define multiple `%<hook_name>s` hooks in the same '\
+        MSG = 'Do not define multiple `%<hook_name>s` hooks in the same ' \
               'example group (also defined on %<lines>s).'
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -53,11 +53,8 @@ module RuboCop
       class SharedContext < Base
         extend AutoCorrector
 
-        MSG_EXAMPLES = "Use `shared_examples` when you don't "\
-                       'define context.'
-
-        MSG_CONTEXT  = "Use `shared_context` when you don't "\
-                       'define examples.'
+        MSG_EXAMPLES = "Use `shared_examples` when you don't define context."
+        MSG_CONTEXT  = "Use `shared_context` when you don't define examples."
 
         def_node_search :examples?,
                         send_pattern('{#Includes.examples #Examples.all}')

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -19,7 +19,7 @@ module RuboCop
       class SingleArgumentMessageChain < Base
         extend AutoCorrector
 
-        MSG = 'Use `%<recommended>s` instead of calling '\
+        MSG = 'Use `%<recommended>s` instead of calling ' \
               '`%<called>s` with a single argument.'
 
         def_node_matcher :message_chain, <<-PATTERN

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
   def message(hook)
-    "Beware of using `#{hook}` as it may cause state to leak between tests. "\
-    'If you are using `rspec-rails`, and `use_transactional_fixtures` is '\
-    "enabled, then records created in `#{hook}` are not automatically rolled "\
+    "Beware of using `#{hook}` as it may cause state to leak between tests. " \
+    'If you are using `rspec-rails`, and `use_transactional_fixtures` is ' \
+    "enabled, then records created in `#{hook}` are not automatically rolled " \
     'back.'
   end
 

--- a/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/current_path_expectation_spec.rb
@@ -29,37 +29,37 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation do
 
   include_examples 'autocorrect',
                    'expect(current_path).to eq expected_path',
-                   'expect(page).to have_current_path expected_path, '\
+                   'expect(page).to have_current_path expected_path, ' \
                    'ignore_query: true'
 
   include_examples 'autocorrect',
                    'expect(current_path).to eq(expected_path)',
-                   'expect(page).to have_current_path(expected_path, '\
+                   'expect(page).to have_current_path(expected_path, ' \
                    'ignore_query: true)'
 
   include_examples 'autocorrect',
                    'expect(current_path).to(eq(expected_path))',
-                   'expect(page).to(have_current_path(expected_path, '\
+                   'expect(page).to(have_current_path(expected_path, ' \
                    'ignore_query: true))'
 
   include_examples 'autocorrect',
                    'expect(current_path).to eq(expected_path(f: :b))',
-                   'expect(page).to have_current_path(expected_path(f: :b), '\
+                   'expect(page).to have_current_path(expected_path(f: :b), ' \
                    'ignore_query: true)'
 
   include_examples 'autocorrect',
                    'expect(page.current_path).to eq(foo(bar).path)',
-                   'expect(page).to have_current_path(foo(bar).path, '\
+                   'expect(page).to have_current_path(foo(bar).path, ' \
                    'ignore_query: true)'
 
   include_examples 'autocorrect',
                    'expect(current_path).not_to eq expected_path',
-                   'expect(page).to have_no_current_path expected_path, '\
+                   'expect(page).to have_no_current_path expected_path, ' \
                    'ignore_query: true'
 
   include_examples 'autocorrect',
                    'expect(current_path).to_not eq expected_path',
-                   'expect(page).to have_no_current_path expected_path, '\
+                   'expect(page).to have_no_current_path expected_path, ' \
                    'ignore_query: true'
 
   include_examples 'autocorrect',

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -152,8 +152,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
 
   it 'flags \-separated multiline strings' do
     expect_offense(<<-RUBY)
-      it 'should do something '\\
-          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      it 'should do something ' \\
+          ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
           'and correctly fix' do
       end
     RUBY
@@ -166,8 +166,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
 
   it 'flags \-separated multiline interpolated strings' do
     expect_offense(<<-'RUBY')
-      it "should do something "\
-          ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      it "should do something " \
+          ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
           "with #{object}" do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     RUBY
   end
 
-  it 'finds description with `shouldn\'t` at the beginning' do
+  it "finds description with `shouldn't` at the beginning" do
     expect_offense(<<-RUBY)
       it "shouldn't do something" do
           ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     RUBY
   end
 
-  it 'finds description with `SHOULDN\'T` at the beginning' do
+  it "finds description with `SHOULDN'T` at the beginning" do
     expect_offense(<<-RUBY)
       it "SHOULDN'T do something" do
           ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::RSpec::Example, :config do
   end
 
   it 'extracts interpolated doc string' do
-    expect(example("it(\"does \#{x}\")").doc_string)
+    expect(example('it("does #{x}")').doc_string)
       .to eq(s(:dstr, s(:str, 'does '), s(:begin, s(:send, nil, :x))))
   end
 


### PR DESCRIPTION
Add a bit of consistency re. backslashes in and around quotes. I have suggested some rules for consistent formatting of these strings in rubocop-hq/rubocop#6420, but it seems to be too complicated to have RuboCop enforce them.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
