### PR TITLE
Fix false positive for relative file path runs with long namespaces (fixes #1091)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/FilePath` false positive for relative file path runs with long namespaces. ([@ahukkanen][])
+
 ## 2.0.1 (2020-12-02)
 
 * Fixed infinite loop in `RSpec/ExpectActual` autocorrection when both expected and actual values are literals. ([@Darhazer][])
@@ -590,3 +592,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@Rafix02]: https://github.com/Rafix02
 [@PhilCoggins]: https://github.com/PhilCoggins
 [@sl4vr]: https://github.com/sl4vr
+[@ahukkanen]: https://github.com/ahukkanen


### PR DESCRIPTION
This is a PR that fixes the issue that is further explained at #1091. 

This was broken by this commit included in the PR #869:
https://github.com/rubocop-hq/rubocop-rspec/commit/811ae08ea3a60453e18a8bcb9dfaefafd848f779#diff-5b709885b35566a0c699ad4a3200b9b7acbc28ef640fa56a8e66f6c732420a34

It turned out to be extremely difficult (at least I don't know how after multiple tries and experiments) to fix the issue described at #1091 using the file name globs. Therefore I switched to regular expression based matching which allows a more specific targeting for the case in question.

The removed specs originate from this commit in the PR #917:
https://github.com/rubocop-hq/rubocop-rspec/commit/23ad402fb3bd5149adc456ca3c54204c38fc271f#diff-5bc1941f9b92914876efec6f7fcc70b153e82194d960213a280078c6cb4b0c3a

The removed specs are no longer needed because it now uses absolute paths as it did prior to merging #869. I believe these were also issues introduced by #869.

Fixes #1091

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
