### PR TITLE
Add clearer examples for SubjectStub cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3822,11 +3822,21 @@ Checks for stubbed test subjects.
 [source,ruby]
 ----
 # bad
-describe Foo do
-  subject(:bar) { baz }
+describe Article do
+  subject(:article) { Article.new }
 
-  before do
-    allow(bar).to receive(:qux?).and_return(true)
+  it 'indicates that the author is unknown' do
+    allow(article).to receive(:author).and_return(nil)
+    expect(article.description).to include('by an unknown author')
+  end
+end
+
+# good
+describe Article do
+  subject(:article) { Article.new(author: nil) }
+
+  it 'indicates that the author is unknown' do
+    expect(article.description).to include('by an unknown author')
   end
 end
 ----

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -13,11 +13,21 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   describe Foo do
-      #     subject(:bar) { baz }
+      #   describe Article do
+      #     subject(:article) { Article.new }
       #
-      #     before do
-      #       allow(bar).to receive(:qux?).and_return(true)
+      #     it 'indicates that the author is unknown' do
+      #       allow(article).to receive(:author).and_return(nil)
+      #       expect(article.description).to include('by an unknown author')
+      #     end
+      #   end
+      #
+      #   # good
+      #   describe Article do
+      #     subject(:article) { Article.new(author: nil) }
+      #
+      #     it 'indicates that the author is unknown' do
+      #       expect(article.description).to include('by an unknown author')
       #     end
       #   end
       #


### PR DESCRIPTION
This PR updates the examples present in the [SubjectStub documentation](https://docs.rubocop.org/rubocop-rspec/2.0/cops_rspec.html#rspecsubjectstub). Previous one was a good indication of when the cop would fire but didn't suggested a way to handle it.

The code examples were taken from [the RSpec Style Guide](https://github.com/rubocop-hq/rspec-style-guide#dont-stub-subject). This gave me reasons to open the PR as they're already accepted ones.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
