### PR TITLE
Fix links

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -3,9 +3,9 @@
 * xref:usage.adoc[Usage]
 * xref:cops.adoc[Cops]
 * xref:upgrade_to_version_2.adoc[Upgrade to 2.x]
-* xref:third_party_rspec_extensions.adoc[RSpec syntax extensions in third-party gems]
+* xref:third_party_rspec_syntax_extensions.adoc[RSpec syntax extensions in third-party gems]
 * Cops Documentation
-** xref:cops_capybara.adoc[Capybara]
-** xref:cops_factorybot.adoc[FactoryBot]
-** xref:cops_rails.adoc[Rails]
+** xref:cops_rspec/capybara.adoc[Capybara]
+** xref:cops_rspec/factorybot.adoc[FactoryBot]
+** xref:cops_rspec/rails.adoc[Rails]
 ** xref:cops_rspec.adoc[RSpec]


### PR DESCRIPTION
Due to a mistake and file renames, links were referring to anchors on index instead of different pages, e.g.:
 - https://docs.rubocop.org/rubocop-rspec/index.html#third_party_rspec_extensions.adoc
 - https://docs.rubocop.org/rubocop-rspec/index.html#cops_capybara.adoc


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).