### PR TITLE
Update `RSpec/Focus` to have auto-correction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `RSpec/FilePath` false positive for relative file path runs with long namespaces. ([@ahukkanen][])
+* Update `RSpec/Focus` to have auto-correction. ([@dvandersluis][])
 
 ## 2.0.1 (2020-12-02)
 
@@ -593,3 +594,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@PhilCoggins]: https://github.com/PhilCoggins
 [@sl4vr]: https://github.com/sl4vr
 [@ahukkanen]: https://github.com/ahukkanen
+[@dvandersluis]: https://github.com/dvandersluis

--- a/config/default.yml
+++ b/config/default.yml
@@ -328,6 +328,7 @@ RSpec/Focus:
   Description: Checks if examples are focused.
   Enabled: true
   VersionAdded: '1.5'
+  VersionChanged: '2.1'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 RSpec/HookArgument:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1525,9 +1525,9 @@ my_class_spec.rb         # describe MyClass, '#method'
 
 | Enabled
 | Yes
-| No
+| Yes
 | 1.5
-| -
+| 2.1
 |===
 
 Checks if examples are focused.

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -39,6 +39,26 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       pending 'test', meta: true, focus: true do; end
                                   ^^^^^^^^^^^ Focused spec found.
     RUBY
+
+    expect_correction(<<-RUBY)
+      example 'test', meta: true do; end
+      xit 'test', meta: true do; end
+      describe 'test', meta: true do; end
+      RSpec.describe 'test', meta: true do; end
+      it 'test', meta: true do; end
+      xspecify 'test', meta: true do; end
+      specify 'test', meta: true do; end
+      example_group 'test', meta: true do; end
+      scenario 'test', meta: true do; end
+      xexample 'test', meta: true do; end
+      xdescribe 'test', meta: true do; end
+      context 'test', meta: true do; end
+      xcontext 'test', meta: true do; end
+      feature 'test', meta: true do; end
+      xfeature 'test', meta: true do; end
+      xscenario 'test', meta: true do; end
+      pending 'test', meta: true do; end
+    RUBY
   end
 
   it 'flags all rspec example blocks that include `:focus`' do
@@ -78,6 +98,26 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       pending 'test', :focus do; end
                       ^^^^^^ Focused spec found.
     RUBY
+
+    expect_correction(<<-RUBY)
+      example_group 'test' do; end
+      feature 'test' do; end
+      xexample 'test' do; end
+      xdescribe 'test' do; end
+      xscenario 'test' do; end
+      specify 'test' do; end
+      example 'test' do; end
+      xfeature 'test' do; end
+      xspecify 'test' do; end
+      scenario 'test' do; end
+      describe 'test' do; end
+      RSpec.describe 'test' do; end
+      xit 'test' do; end
+      context 'test' do; end
+      xcontext 'test' do; end
+      it 'test' do; end
+      pending 'test' do; end
+    RUBY
   end
   # rubocop:enable RSpec/ExampleLength
 
@@ -101,10 +141,15 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
-  it 'does not flag a method that is focused twice' do
+  it 'flags a method that is focused twice' do
     expect_offense(<<-RUBY)
       fit "foo", :focus do
       ^^^^^^^^^^^^^^^^^ Focused spec found.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it "foo" do
       end
     RUBY
   end
@@ -116,7 +161,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
-  it 'flags focused block types' do
+  it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
     expect_offense(<<-RUBY)
       fdescribe 'test' do; end
       ^^^^^^^^^^^^^^^^ Focused spec found.
@@ -137,12 +182,28 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       focus 'test' do; end
       ^^^^^^^^^^^^ Focused spec found.
     RUBY
+
+    expect_correction(<<-RUBY)
+      describe 'test' do; end
+      RSpec.describe 'test' do; end
+      feature 'test' do; end
+      context 'test' do; end
+      it 'test' do; end
+      scenario 'test' do; end
+      example 'test' do; end
+      specify 'test' do; end
+      focus 'test' do; end
+    RUBY
   end
 
   it 'flags rspec example blocks that include `:focus` preceding a hash' do
     expect_offense(<<-RUBY)
       describe 'test', :focus, js: true do; end
                        ^^^^^^ Focused spec found.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      describe 'test', js: true do; end
     RUBY
   end
 end


### PR DESCRIPTION
`RSpec/Focus` did not have autocorrection so I've added it now. It will remove `focus: true` and `:focus`, and replace `fdescribe`, `fit`, etc. with the corresponding non-focused method.

Since the methods can be defined by the user, there's a small conceit that it looks for a prefix of `f` and only corrects if there is a parallel "regular" method. This means that `focus 'test' do; end` will not be corrected. However, an offense will still be registered, so I think this is okay. Happy to make changes if anyone has a suggestion.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
