### PR TITLE
Imrpove performance by limitting on_send calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])
+* Improve rubocop-rspec performance. ([@Darhazer][])
 
 ## 2.1.0 (2020-12-17)
 

--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -24,18 +24,14 @@ module RuboCop
       #   end
       class AnyInstance < Base
         MSG = 'Avoid stubbing using `%<method>s`.'
-
-        def_node_matcher :disallowed_stub, <<-PATTERN
-          (send _ ${:any_instance :allow_any_instance_of :expect_any_instance_of} ...)
-        PATTERN
+        RESTRICT_ON_SEND = %i[
+          any_instance
+          allow_any_instance_of
+          expect_any_instance_of
+        ].freeze
 
         def on_send(node)
-          disallowed_stub(node) do |method|
-            add_offense(
-              node,
-              message: format(MSG, method: method)
-            )
-          end
+          add_offense(node, message: format(MSG, method: node.method_name))
         end
       end
     end

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -39,6 +39,7 @@ module RuboCop
         extend AutoCorrector
 
         MSG = 'Prefer `be` over `eql`.'
+        RESTRICT_ON_SEND = %i[to].freeze
 
         def_node_matcher :eql_type_with_identity, <<-PATTERN
           (send _ :to $(send nil? :eql {true false int float sym nil_type?}))

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -29,6 +29,8 @@ module RuboCop
               '`use_transactional_fixtures` is enabled, then records created ' \
               'in `%<hook>s` are not automatically rolled back.'
 
+        RESTRICT_ON_SEND = %i[before after].freeze
+
         def_node_matcher :before_or_after_all, <<-PATTERN
           $(send _ {:before :after} (sym {:all :context}))
         PATTERN

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -30,6 +30,8 @@ module RuboCop
                 'Capybara feature specs - instead, use the ' \
                 '`have_current_path` matcher on `page`'
 
+          RESTRICT_ON_SEND = %i[expect].freeze
+
           def_node_matcher :expectation_set_on_current_path, <<-PATTERN
             (send nil? :expect (send {(send nil? :page) nil?} :current_path))
           PATTERN

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -44,6 +44,8 @@ module RuboCop
             have_content
           ].freeze
 
+          RESTRICT_ON_SEND = CAPYBARA_MATCHER_METHODS
+
           def_node_matcher :visible_true?, <<~PATTERN
             (send nil? #capybara_matcher? ... (hash <$(pair (sym :visible) true) ...>))
           PATTERN

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -19,6 +19,7 @@ module RuboCop
       # @see https://github.com/rspec/rspec-core/issues/1610
       class DescribeSymbol < Base
         MSG = 'Avoid describing symbols.'
+        RESTRICT_ON_SEND = %i[describe].freeze
 
         def_node_matcher :describe_symbol?, <<-PATTERN
           (send #rspec? :describe $sym ...)

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -25,6 +25,7 @@ module RuboCop
           MSG = "Pass '%<class_name>s' string instead of `%<class_name>s` " \
                 'constant.'
           ALLOWED_CONSTANTS = %w[Hash OpenStruct].freeze
+          RESTRICT_ON_SEND = %i[factory].freeze
 
           def_node_matcher :class_name, <<~PATTERN
             (send _ :factory _ (hash <(pair (sym :class) $(const ...)) ...>))

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   end
       class ImplicitBlockExpectation < Base
         MSG = 'Avoid implicit block expectations.'
+        RESTRICT_ON_SEND = %i[is_expected should should_not].freeze
 
         def_node_matcher :lambda?, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -31,6 +31,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG = "Don't use implicit subject."
+        RESTRICT_ON_SEND = %i[is_expected should should_not].freeze
 
         def_node_matcher :implicit_subject?, <<-PATTERN
           (send nil? {:should :should_not :is_expected} ...)

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -24,6 +24,7 @@ module RuboCop
 
         MSG = 'Prefer `%<replacement>s` over `%<original>s` when including ' \
               'examples in a nested context.'
+        RESTRICT_ON_SEND = %i[it_behaves_like it_should_behave_like].freeze
 
         def_node_matcher :example_inclusion_offense, '(send _ % ...)'
 

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -15,18 +15,12 @@ module RuboCop
       #
       class MessageChain < Base
         MSG = 'Avoid stubbing using `%<method>s`.'
-
-        def_node_matcher :message_chain, <<-PATTERN
-          (send _ {:receive_message_chain :stub_chain} ...)
-        PATTERN
+        RESTRICT_ON_SEND = %i[receive_message_chain stub_chain].freeze
 
         def on_send(node)
-          message_chain(node) do
-            add_offense(
-              node.loc.selector,
-              message: format(MSG, method: node.method_name)
-            )
-          end
+          add_offense(
+            node.loc.selector, message: format(MSG, method: node.method_name)
+          )
         end
       end
     end

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -20,6 +20,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG = 'Prefer `%<replacement>s` over `%<original>s`.'
+        RESTRICT_ON_SEND = %i[not_to to_not].freeze
 
         def_node_matcher :not_to_not_offense, '(send _ % ...)'
 

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -33,6 +33,7 @@ module RuboCop
         class HttpStatus < Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
+          RESTRICT_ON_SEND = %i[have_http_status].freeze
 
           def_node_matcher :http_status, <<-PATTERN
             (send nil? :have_http_status ${int sym})

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -16,6 +16,7 @@ module RuboCop
       class ReceiveNever < Base
         extend AutoCorrector
         MSG = 'Use `not_to receive` instead of `never`.'
+        RESTRICT_ON_SEND = %i[never].freeze
 
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
 

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -39,6 +39,7 @@ module RuboCop
 
         MSG_AND_RETURN = 'Use `and_return` for static values.'
         MSG_BLOCK = 'Use block for static values.'
+        RESTRICT_ON_SEND = %i[and_return].freeze
 
         def_node_search :contains_stub?, '(send nil? :receive (...))'
         def_node_matcher :stub_with_block?, '(block #contains_stub? ...)'

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -21,6 +21,7 @@ module RuboCop
 
         MSG = 'Use `%<recommended>s` instead of calling ' \
               '`%<called>s` with a single argument.'
+        RESTRICT_ON_SEND = %i[receive_message_chain stub_chain].freeze
 
         def_node_matcher :message_chain, <<-PATTERN
           (send _ {:receive_message_chain :stub_chain} $_)

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -32,6 +32,7 @@ module RuboCop
       #     expect { do_something }.not_to raise_error
       class UnspecifiedException < Base
         MSG = 'Specify the exception being captured'
+        RESTRICT_ON_SEND = %i[to].freeze
 
         def_node_matcher :empty_raise_error_or_exception, <<-PATTERN
           (send

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -24,6 +24,7 @@ module RuboCop
       #   end
       class VerifiedDoubles < Base
         MSG = 'Prefer using verifying doubles over normal doubles.'
+        RESTRICT_ON_SEND = %i[double spy].freeze
 
         def_node_matcher :unverified_double, <<-PATTERN
           {(send nil? {:double :spy} $...)}

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -14,6 +14,7 @@ module RuboCop
       class VoidExpect < Base
         MSG = 'Do not use `expect()` without `.to` or `.not_to`. ' \
               'Chain the methods or remove it.'
+        RESTRICT_ON_SEND = %i[expect].freeze
 
         def_node_matcher :expect?, <<-PATTERN
           (send nil? :expect ...)


### PR DESCRIPTION
I noticed that Rubocop, since v0.90, has an [optimization for not calling on_send](https://github.com/rubocop-hq/rubocop/pull/8365) based on the expected method_name for the cop.

I applied that to the cops for it was easy (which is about 50% of the cops). Due to the configurable language, it might be hard to do for some cops, and for others, it just requires more refactoring, as the cops check for a method somewhere down the chain. 

I haven't really measured the performance improvement, but a naive test (running it with `time` over our own specs) shows a significant difference.

cc: @fatkodima

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Updated documentation.~
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
