### PR TITLE
Enable Enabled parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])
 * Improve rubocop-rspec performance. ([@Darhazer][])
+* Include `Enabled: true` to prevent a mismatched configuration parameter warning when `RSpec` cops are explicitly enabled in the user configuration. ([@pirj][])
 
 ## 2.1.0 (2020-12-17)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,6 @@
 ---
 RSpec:
+  Enabled: true
   Include:
     - "**/*_spec.rb"
     - "**/spec/**/*"


### PR DESCRIPTION
When the project configured as:
```yaml
# .rubocop.yml

require:
  - rubocop-rspec

AllCops:
  DisabledByDefault: true

RSpec:
  Enabled: true
```

an annoying warning pops up:
```
Warning: RSpec does not support Enabled parameter.

Supported parameters are:

  - Include
  - Language
```

`Enabled: true` does, however, what it is supposed to do, and RSpec cops are inspecting the source.

This is not the case with e.g. `rubocop-rails`. Apparently, this is due to our RSpec DSL configuration, as `rubocop-rails` doesn't have any `Rails:` YAML configuration in their `config/default.yml`.

Enabling `Enabled: true` in our `config/default.yml` removes the warning.

Wondering if it makes sense to skip this warning for `Enabled`/`Include`/`Exclude` and other universal extension parameters in RuboCop itself? WDYT?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).