### PR TITLE
Fix edge RuboCop offences

### DIFF
--- a/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
     RUBY
 
     expect_offense(source)
+
     expect_no_corrections
   end
 
@@ -72,6 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
         subject { 3 }
       end
     RUBY
+
     expect_correction(<<-RUBY)
       describe 'hello there' do
         subject { 3 }

--- a/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
               ^{include_method}^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2]
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -27,6 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
               ^{include_method}^^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2]
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -63,6 +65,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
               ^{include_method}^^^^^^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2]
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -76,6 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
               ^{include_method}^^^^^^^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2]
             end
           RUBY
+
           expect_no_corrections
         end
 
@@ -191,6 +195,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2, 3]
         end
       RUBY
+
       expect_no_corrections
     end
 
@@ -215,6 +220,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated include of shared_examples 'an x' on line(s) [2, 3]
         end
       RUBY
+
       expect_no_corrections
     end
 


### PR DESCRIPTION
spec/rubocop/cop/rspec/repeated_include_example_spec.rb:217:1: C: [Corrected] InternalAffairs/EmptyLineBetweenExpectOffenseAndCorrection: Add empty line between expect_offense and expect_no_corrections.
          RUBY
    ^^^^^^^^^^


**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).