### PR TITLE
Improve performance by limiting on_send calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Master (Unreleased)
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])
-* Improve rubocop-rspec performance. ([@Darhazer][])
+* Improve rubocop-rspec performance. ([@Darhazer][], [@bquorning][])
 * Include `Enabled: true` to prevent a mismatched configuration parameter warning when `RSpec` cops are explicitly enabled in the user configuration. ([@pirj][])
 
 ## 2.1.0 (2020-12-17)

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -35,6 +35,7 @@ module RuboCop
 
         MSG_BLOCK = 'Prefer `change(%<obj>s, :%<attr>s)`.'
         MSG_CALL = 'Prefer `change { %<obj>s.%<attr>s }`.'
+        RESTRICT_ON_SEND = %i[change].freeze
 
         def_node_matcher :expect_change_with_arguments, <<-PATTERN
           (send nil? :change ({const send} nil? $_) (sym $_))

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -30,6 +30,7 @@ module RuboCop
 
           MSG_CREATE_LIST = 'Prefer create_list.'
           MSG_N_TIMES = 'Prefer %<number>s.times.'
+          RESTRICT_ON_SEND = %i[create_list].freeze
 
           def_node_matcher :n_times_block_without_arg?, <<-PATTERN
             (block

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -30,6 +30,7 @@ module RuboCop
         MSG = 'Prefer `%<style>s` for setting message expectations.'
 
         SUPPORTED_STYLES = %w[allow expect].freeze
+        RESTRICT_ON_SEND = %i[to].freeze
 
         def_node_matcher :message_expectation, <<-PATTERN
           (send $(send nil? {:expect :allow} ...) :to #receive_message?)

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -28,6 +28,8 @@ module RuboCop
 
         MSG = 'Use `%<alternative>s` instead of `%<original>s`.'
 
+        RESTRICT_ON_SEND = %i[times].freeze
+
         def_node_matcher :receive_counts, <<-PATTERN
           (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)
         PATTERN


### PR DESCRIPTION
Inspired by @Darhazer's PR #1117 I added a few more `RESTRICT_ON_SEND` constants.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
