### PR TITLE
[Fix #1127] Allow `RSpec/EmptyExampleGroup` to have example group types that should be allowed specified in its configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Allow `RSpec/EmptyExampleGroup` to have example group types that should be allowed specified in its configuration. ([@dvandersluis][])
+
 ## 2.2.0 (2021-02-02)
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -209,8 +209,9 @@ RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
   VersionAdded: '1.7'
-  VersionChanged: '2.0'
+  VersionChanged: '2.3'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
+  AllowedTypes: []
 
 RSpec/EmptyHook:
   Description: Checks for empty before and after hooks.

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -729,7 +729,7 @@ end
 | Yes
 | No
 | 1.7
-| 2.0
+| 2.3
 |===
 
 Checks if an example group does not include any tests.
@@ -769,6 +769,25 @@ describe Bacon do
   pending 'will add tests later'
 end
 ----
+
+==== AllowedTypes: [describe]
+
+[source,ruby]
+----
+# good
+describe Bacon do
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedTypes
+| `[]`
+| Array
+|===
 
 === References
 

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
+RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup, :config do
   it 'flags an empty example group' do
     expect_offense(<<~RUBY)
       describe Foo do
@@ -349,5 +349,38 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         end
       end
     RUBY
+  end
+
+  context 'with AllowedTypes: [describe]' do
+    let(:cop_config) { { 'AllowedTypes' => %w[describe] } }
+
+    it 'allows an empty `describe` without a block' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe 'rspec-core'
+      RUBY
+    end
+
+    it 'allows a `describe` example group to be empty' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe 'rspec-core' do
+        end
+      RUBY
+    end
+
+    it 'allows a nested `describe` example group to be empty' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.context 'rspec-core' do
+          describe 'foo'
+        end
+      RUBY
+    end
+
+    it 'registers an offense for an non-allowed empty example group' do
+      expect_offense(<<~RUBY)
+        RSpec.context 'rspec-core' do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Empty example group detected.
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Allows certain example group methods to be excluded from `RSpec/EmptyExampleGroup`. Fixes #1127.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
