### PR TITLE
Fix a false negative for `RSpec/FilePath` when spec file has multiple `describe`.

### DIFF
--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -70,8 +70,6 @@ module RuboCop
         def_node_search :routing_metadata?, '(pair (sym :type) (sym :routing))'
 
         def on_top_level_example_group(node)
-          return unless top_level_groups.one?
-
           const_described(node) do |send_node, described_class, arguments|
             next if routing_spec?(arguments)
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'registers an offense for a bad path with multiple describe for instance methods' do
+  it 'registers an offense for a bad path' \
+        'with multiple describe for instance methods' do
     expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
@@ -80,7 +81,8 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'registers an offense for a bad path with multiple describe for class methods' do
+  it 'registers an offense for a bad path' \
+        'with multiple describe for class methods' do
     expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '.foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
+  it 'registers an offense for a bad path with multiple describe for instance methods' do
+    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+      describe MyClass, '#foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+      describe MyClass, '#bar' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*bar*_spec.rb`.
+    RUBY
+  end
+
+  it 'registers an offense for a bad path with multiple describe for class methods' do
+    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+      describe MyClass, '.foo' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
+      describe MyClass, '.bar' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*bar*_spec.rb`.
+    RUBY
+  end
+
   it 'ignores shared examples' do
     expect_no_offenses(<<-RUBY, 'spec/models/user.rb')
       shared_examples_for 'foo' do; end


### PR DESCRIPTION
Fix #1106 

RSpec/FilePath does not register offenses when the spec file has multiple `describe`, such as the following code.

```
describe MyClass, '#foo' do
end

describe MyClass, '#bar' do
end
```

But the spec file has a single ‘describe’, registers offenses.

```
describe MyClass, '#foo' do
^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
end
```

I think this is a false negative, so could you please approve this PR?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
