### PR TITLE
Fix an error when running `rake new_cop`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,10 +76,15 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  github_user = `git config github.user`.chop
-  github_user = 'your_id' if github_user.empty?
-
-  generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+  # FIXME: Remove the condition when requiring RuboCop 1.22 or higher.
+  #        See: https://github.com/rubocop/rubocop/pull/10109
+  if RuboCop::Version::STRING >= '1.22.0'
+    generator = RuboCop::Cop::Generator.new(cop_name)
+  else
+    github_user = `git config github.user`.chop
+    github_user = 'your_id' if github_user.empty?
+    generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+  end
 
   generator.write_source
   generator.write_spec


### PR DESCRIPTION
Follow up to rubocop/rubocop#10109.

This commit fixes the following error.

```console
% bundle exec rake new_cop\[Department/CustomCop\]
rake aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
/Users/koic/src/github.com/rubocop/rubocop-rspec/Rakefile:82:in `new'
/Users/koic/src/github.com/rubocop/rubocop-rspec/Rakefile:82:in `block in <top (required)>'
/Users/koic/.rbenv/versions/3.0.2/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/3.0.2/bin/bundle:23:in `<main>'
Tasks: TOP => new_cop
(See full trace by running task with --trace)
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
