### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: disable
   Exclude:
     - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Drop Ruby 2.5 support. ([@ydah][])
+
 ## 2.10.0 (2022-04-19)
 
 * Fix a false positive for `RSpec/EmptyExampleGroup` when expectations in case statement. ([@ydah][])

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -24,7 +24,7 @@ module RuboCop
           # rubocop:disable InternalAffairs/NodeDestructuring
           variable_name, _rhs = *node
           # rubocop:enable InternalAffairs/NodeDestructuring
-          name = variable_name[1..-1]
+          name = variable_name[1..]
           return unless name.eql?('stdout') || name.eql?('stderr')
 
           add_offense(node.loc.name, message: format(MSG, name: name))

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -47,7 +47,7 @@ module RuboCop
         def correct_variable(variable)
           case variable.type
           when :dsym
-            variable.source[1..-1]
+            variable.source[1..]
           when :sym
             variable.value.to_s.inspect
           else

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10577

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
~* [ ] Updated documentation.~
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

~* [ ] Added the new cop to `config/default.yml`.~
~* [ ] The cop is configured as `Enabled: pending~` in `config/default.yml`.~
~* [ ] The cop documents examples of good and bad code.~
~* [ ] The tests assert both that bad code is reported and that good code is not reported.~
~* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.~

If you have modified an existing cop's configuration options:

~* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.~
