### PR TITLE
Improve release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -32,7 +33,9 @@ jobs:
           if ! git diff --exit-code docs/antora.yml; then
             git config user.name "${GITHUB_ACTOR}"
             git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git checkout -b switch-docs-version
             git add docs/antora.yml
             git commit -m "Switch docs version back"
-            git push
+            git push -u origin switch-docs-version
+            gh pr create --fill --head switch-docs-version
           fi


### PR DESCRIPTION
This PR improves the release workflow.
It turns out that being able to push directly to the default branch is quite difficult. That's because if GitHub actions can push to a protected branch, all you have to do is code a workflow that creates a branch and pushes it to other branches, and any collaborator in the repository can push whatever code they want to any branch.
https://github.com/orgs/community/discussions/25305#discussioncomment-3247401

That last one step might be a pain, but I think it's better to automate it to the point where you create a PR that switches back versions.
After the release workflow, a PR is created that switches back, so we should just merge it.

Note that this requires the following settings to be checked on:
![](https://github.com/rubocop/rubocop-rspec/assets/13041216/a465de11-487a-42cc-b6cb-1c5bf4b7122b)


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
