### PR TITLE
Support `itblock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Add support for `itblock` from Ruby 3.4. ([@earlopain])
+
 ## 3.7.0 (2025-09-01)
 
 - Mark `RSpec/IncludeExamples` as `SafeAutoCorrect: false`. ([@yujideveloper])

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -68,6 +68,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -38,6 +38,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -89,6 +89,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -38,13 +38,11 @@ module RuboCop
           }
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
           check_hooks(node.body) if multiline_block?(node.body)
         end
-
-        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -38,6 +38,13 @@ module RuboCop
           )
         PATTERN
 
+        # @!method each_itblock?(node)
+        def_node_matcher :each_itblock?, <<~PATTERN
+          (itblock
+            (send ... :each) _ (...)
+          )
+        PATTERN
+
         # @!method expectation?(node)
         def_node_matcher :expectation?, <<~PATTERN
           (send (send nil? :expect (lvar %)) :to ...)
@@ -52,6 +59,12 @@ module RuboCop
         def on_numblock(node)
           each_numblock?(node) do
             check_offense(node, :_1)
+          end
+        end
+
+        def on_itblock(node)
+          each_itblock?(node) do
+            check_offense(node, :it)
           end
         end
 

--- a/lib/rubocop/cop/rspec/mixin/metadata.rb
+++ b/lib/rubocop/cop/rspec/mixin/metadata.rb
@@ -27,7 +27,7 @@ module RuboCop
           (send (lvar %) #Hooks.all _ $...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           rspec_configure(node) do |block_var|
             metadata_in_block(node, block_var) do |metadata_arguments|
               on_metadata_arguments(metadata_arguments)
@@ -38,7 +38,6 @@ module RuboCop
             on_metadata_arguments(metadata_arguments)
           end
         end
-        alias on_numblock on_block
 
         def on_metadata(_symbols, _hash)
           raise ::NotImplementedError

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -96,6 +96,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/rspec/redundant_around.rb
+++ b/lib/rubocop/cop/rspec/redundant_around.rb
@@ -28,6 +28,7 @@ module RuboCop
           end
         end
         alias on_numblock on_block
+        alias on_itblock on_block
 
         def on_send(node)
           return unless match_redundant_around_hook_send?(node)

--- a/lib/rubocop/cop/rspec/skip_block_inside_example.rb
+++ b/lib/rubocop/cop/rspec/skip_block_inside_example.rb
@@ -34,6 +34,7 @@ module RuboCop
         end
 
         alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
+  spec.add_dependency 'rubocop', '~> 1.75'
 end

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -178,4 +178,66 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
       end
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    context 'when the yielded value is unused' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          around { it }
+                   ^^ You should call `it.call` or `it.run`.
+        RUBY
+      end
+    end
+
+    context 'when a method other than #run or #call is called' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          around do
+            it.inspect
+            ^^^^^^^^^^ You should call `it.call` or `it.run`.
+          end
+        RUBY
+      end
+    end
+
+    context 'when #run is called' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          around do
+            it.run
+          end
+        RUBY
+      end
+    end
+
+    context 'when #call is called' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          around do
+            it.call
+          end
+        RUBY
+      end
+    end
+
+    context 'when used as a block arg' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          around do
+            1.times(&it)
+          end
+        RUBY
+      end
+    end
+
+    context 'when passed to another method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          around do
+            something_that_might_run_test(it, another_arg)
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -483,5 +483,37 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         RUBY
       end
     end
+
+    context 'when Ruby 3.4', :ruby34 do
+      it 'registers an offense for empty line after `around` hook' do
+        expect_offense(<<~RUBY)
+          RSpec.describe User do
+            around { it.run }
+            ^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
+            it { does_something }
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          RSpec.describe User do
+            around { it.run }
+
+            it { does_something }
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiline `around` block' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe User do
+            around do
+              it.run
+            end
+
+            it { does_something }
+          end
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -90,4 +90,20 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'adds an offense for `expect` in `around` hook' do
+      expect_offense(<<~RUBY)
+        around do
+          expect(something).to eq('foo')
+          ^^^^^^ Do not use `expect` in `around` hook
+          is_expected(something).to eq('foo')
+          ^^^^^^^^^^^ Do not use `is_expected` in `around` hook
+          expect_any_instance_of(Something).to receive(:foo)
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `around` hook
+          it.run
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -262,29 +262,59 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     context 'when Ruby 2.7', :ruby27 do
       it 'does not flag :example for hooks' do
         expect_no_offenses(<<~RUBY)
-          around(:example) { _1 }
+          around(:example) { _1.run }
         RUBY
       end
 
       it 'detects :each for hooks' do
         expect_offense(<<~RUBY)
-          around(:each) { _1 }
+          around(:each) { _1.run }
           ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
         RUBY
 
         expect_correction(<<~RUBY)
-          around(:example) { _1 }
+          around(:example) { _1.run }
         RUBY
       end
 
       it 'detects hooks without default scopes' do
         expect_offense(<<~RUBY)
-          around { _1 }
+          around { _1.run }
           ^^^^^^ Use `:example` for RSpec hooks.
         RUBY
 
         expect_correction(<<~RUBY)
-          around(:example) { _1 }
+          around(:example) { _1.run }
+        RUBY
+      end
+    end
+
+    context 'when Ruby 3.4', :ruby34 do
+      it 'does not flag :example for hooks' do
+        expect_no_offenses(<<~RUBY)
+          around(:example) { it.run }
+        RUBY
+      end
+
+      it 'detects :each for hooks' do
+        expect_offense(<<~RUBY)
+          around(:each) { it.run }
+          ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          around(:example) { it.run }
+        RUBY
+      end
+
+      it 'detects hooks without default scopes' do
+        expect_offense(<<~RUBY)
+          around { it.run }
+          ^^^^^^ Use `:example` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          around(:example) { it.run }
         RUBY
       end
     end

--- a/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
@@ -227,4 +227,65 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags `around` after `it`' do
+      expect_offense(<<~RUBY)
+        RSpec.describe User do
+          it { is_expected.to be_after_around_hook }
+          around { it }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe User do
+          around { it }
+          it { is_expected.to be_after_around_hook }
+        end
+      RUBY
+    end
+
+    it 'flags `around` after `context`' do
+      expect_offense(<<~RUBY)
+        RSpec.describe User do
+          context 'a context' do
+            it { is_expected.to be_after_around_hook }
+          end
+
+          around { it }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe User do
+          around { it }
+          context 'a context' do
+            it { is_expected.to be_after_around_hook }
+          end
+
+        end
+      RUBY
+    end
+
+    it 'flags `around` after `include_examples`' do
+      expect_offense(<<~RUBY)
+        RSpec.describe User do
+          include_examples('should be after around-hook')
+
+          around { it }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe User do
+          around { it }
+          include_examples('should be after around-hook')
+
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -215,4 +215,97 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags `each` with an expectation' do
+      expect_offense(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each { expect(it).to be_valid }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'validates users' do
+          expect([user1, user2, user3]).to all(be_valid)
+        end
+      RUBY
+    end
+
+    it 'flags `each` when expectation calls method with arguments' do
+      expect_offense(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each { expect(it).to be_a(User) }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'validates users' do
+          expect([user1, user2, user3]).to all(be_a(User))
+        end
+      RUBY
+    end
+
+    it 'ignores `each` without expectation' do
+      expect_no_offenses(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each { allow(it).to receive(:method) }
+        end
+      RUBY
+    end
+
+    it 'flags `each` with multiple expectations' do
+      expect_offense(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
+            expect(it).to receive(:method)
+            expect(it).to receive(:other_method)
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'ignore `each` when the body does not contain only expectations' do
+      expect_no_offenses(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each do
+            allow(Something).to receive(:method).and_return(it)
+            expect(it).to receive(:method)
+            expect(it).to receive(:other_method)
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores `each` with expectation on property' do
+      expect_no_offenses(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each { expect(it.name).to be }
+        end
+      RUBY
+    end
+
+    it 'ignores assignments in the iteration' do
+      expect_no_offenses(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each { array = array.concat(it) }
+        end
+      RUBY
+    end
+
+    it 'ignores `each` when there is a negative expectation' do
+      expect_no_offenses(<<~RUBY)
+        it 'validates users' do
+          [user1, user2, user3].each do
+            expect(it).not_to receive(:method)
+            expect(it).to receive(:other_method)
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -238,4 +238,19 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
       end
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    context 'with no expectation example with it' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            it { it }
+            ^^^^^^^^^ No expectation found in this example.
+
+            it { expect(baz).to be_truthy }
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/redundant_around_spec.rb
+++ b/spec/rubocop/cop/rspec/redundant_around_spec.rb
@@ -107,4 +107,33 @@ RSpec.describe RuboCop::Cop::RSpec::RedundantAround, :ruby27 do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    context 'with another node in itblock `around`' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          around do
+            it.run
+
+            foo
+          end
+        RUBY
+      end
+    end
+
+    context 'with redundant itblock `around`' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          around do
+          ^^^^^^^^^ Remove redundant `around` hook.
+            it.run
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/skip_block_inside_example_spec.rb
+++ b/spec/rubocop/cop/rspec/skip_block_inside_example_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe RuboCop::Cop::RSpec::SkipBlockInsideExample do
     RUBY
   end
 
+  it 'registers an offense when using `skip` with an itblock', :ruby34 do
+    expect_offense(<<~RUBY)
+      it 'does something' do
+        skip 'not yet implemented' do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't pass a block to `skip` inside examples.
+          it
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using `skip` without a block' do
     expect_no_offenses(<<~RUBY)
       it 'does something' do


### PR DESCRIPTION
All cops that handle numblock now also handle itblock. `itblock` is relatively new and the required `rubocop-ast` version is required via RuboCop 1.75

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).