### PR TITLE
CI: Add JRuby 10.0 and 10.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
           - "4.0"
           - ruby-head
           - jruby-9.4
+          - jruby-10.0
+          - jruby-10.1
         task:
           - internal_investigation
           - spec

--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,13 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump'
-gem 'irb' # undeclared dependency of yard
 gem 'rack'
 gem 'rake'
 gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.24'
 gem 'rubocop-rake', '~> 0.7'
 gem 'simplecov', '~> 1' if RUBY_VERSION >= '3.2'
-gem 'yard'
+gem 'yard', '>= 0.9.39'
 
 # FIXME: Remove when the next prism version is released.
 if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby'


### PR DESCRIPTION
Should we add JRuby 10.0 and 10.1 to the CI matrix?

JRuby 10.0 targets CRuby 3.4 support, and 10.1 targets CRuby 4.0 support.