### PR TITLE
Don't register `RSpec/DescribedClass` offenses within `Data.define` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Mark `RSpec/IncludeExamples` as `SafeAutoCorrect: false`. ([@yujideveloper])
 - Fix a false positive for `RSpec/LeakyConstantDeclaration` when defining constants in explicit namespaces. ([@naveg])
 - Add support for error matchers (`raise_exception` and `raise_error`) to `RSpec/Dialect`. ([@lovro-bikic])
+- Don't register offenses for `RSpec/DescribedClass` within `Data.define` blocks. ([@lovro-bikic])
 
 ## 3.6.0 (2025-04-18)
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -83,7 +83,13 @@ module RuboCop
 
         # @!method common_instance_exec_closure?(node)
         def_node_matcher :common_instance_exec_closure?, <<~PATTERN
-          (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
+          (block
+            {
+              (send (const nil? {:Class :Module :Struct}) :new ...)
+              (send (const nil? :Data) :define ...)
+            }
+            ...
+          )
         PATTERN
 
         # @!method rspec_block?(node)

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
           Class.new  { foo = MyClass }
           Module.new { bar = MyClass }
           Struct.new { lol = MyClass }
+          Data.define { dat = MyClass }
 
           def method
             include MyClass


### PR DESCRIPTION
Fixes #2086.

Changes `RSpec/DescribedClass` so it doesn't register offenses within a `Data.define` block. Previously, this:
```ruby
RSpec.describe Demo do
  let(:data) { Data.define(:foo) { include Demo } }
end
```
would have been an offense (with autocorrection to `include described_class`, which would raise an error because `described_class` isn't available within that block). With the patch, this code no longer produces an offense.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
