### PR TITLE
Remove test for safety configuration of cops documented with `@safety` YARD tag

### DIFF
--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -102,18 +102,4 @@ RSpec.describe 'config/default.yml' do
       )
     end
   end
-
-  it 'is expected that all cops documented with `@safety` are `Safe: false` ' \
-     'or `SafeAutoCorrect: false`' do
-    unsafe_cop_names.each do |cop_name|
-      unsafe = default_config[cop_name]['Safe'] == false ||
-        default_config[cop_name]['SafeAutoCorrect'] == false
-      expect(unsafe).to(
-        be(true),
-        "`#{cop_name}` cop should be set `Safe: false` or " \
-        '`SafeAutoCorrect: false` because `@safety` YARD tag exists.'
-      )
-      YARD::Registry.clear
-    end
-  end
 end


### PR DESCRIPTION
This is because in some cases, even when a safety tag is present, `safe` may be `false` or `set_autocorrect` may be `true`.
- https://github.com/rubocop/rubocop-rspec/blob/e63ee9a79c17be296d41ac36dc006d94d6d12069/lib/rubocop/cop/rspec/example_wording.rb#L13-L25

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
