### PR TITLE
Fix false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata (e.g., skip messages). ([@ydah])
+
 ## 3.8.0 (2025-11-12)
 
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3474,6 +3474,13 @@ it "#{attribute} is persisted" do
   expectations
 end
 
+# good - when variable is used only in example metadata
+skip_message = 'not yet implemented'
+
+it 'does something', skip: skip_message do
+  expectations
+end
+
 # good - when variable is used only to include other examples
 examples = foo ? 'some examples' : 'other examples'
 

--- a/spec/rubocop/cop/rspec/leaky_local_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/leaky_local_variable_spec.rb
@@ -316,4 +316,44 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyLocalVariable, :config do
       end
     RUBY
   end
+
+  it 'does not register an offense when variable is used only in skip ' \
+     'metadata' do
+    expect_no_offenses(<<~RUBY)
+      describe SomeClass do
+        skip_message = 'not yet implemented'
+
+        it 'does something', skip: skip_message do
+          expect(1 + 2).to eq(3)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when variable is used only in pending ' \
+     'metadata' do
+    expect_no_offenses(<<~RUBY)
+      describe SomeClass do
+        pending_message = 'work in progress'
+
+        it 'does something', pending: pending_message do
+          expect(1 + 2).to eq(3)
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when variable is used in skip metadata and in ' \
+     'block body' do
+    expect_offense(<<~RUBY)
+      describe SomeClass do
+        skip_message = 'not yet implemented'
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use local variables defined outside of examples inside of them.
+
+        it 'does something', skip: skip_message do
+          puts skip_message
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes: #2141

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
