### PR TITLE
Add autocorrect support for `RSpec/MultipleExpectations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata (e.g., skip messages). ([@ydah])
+- Add autocorrect support for `RSpec/MultipleExpectations`. ([@gildesmarais])
 
 ## 3.8.0 (2025-11-12)
 
@@ -1006,6 +1007,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@franzliedke]: https://github.com/franzliedke
 [@g-rath]: https://github.com/G-Rath
 [@geniou]: https://github.com/geniou
+[@gildesmarais]: https://github.com/gildesmarais
 [@gsamokovarov]: https://github.com/gsamokovarov
 [@harry-graham]: https://github.com/harry-graham
 [@harrylewis]: https://github.com/harrylewis


### PR DESCRIPTION
Adds autocorrect support for `RSpec/MultipleExpectations` cop, handling hash or :symbol example metadata.

<details>
<summary>Rake fails due to apparently unrelated changes</summary>

```
rspec ./spec/rubocop/cop/rspec/mixin/top_level_group_spec.rb:19 # RuboCop::Cop::RSpec::TopLevelGroup#top_level_group? warns because it is deprecated
rspec ./spec/rubocop/cop/rspec/nested_groups_spec.rb:122 # RuboCop::Cop::RSpec::NestedGroups when configured with MaxNesting emits a deprecation warning
```
If that's related to the changes, I'd appreciate a pointer where to fix them. Thank you. :) 
</details>

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
