### PR TITLE
Fix a false positive for `RSpec/ScatteredSetup` when the hook is defined inside a class method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata (e.g., skip messages). ([@ydah])
+- Fix a false positive for `RSpec/ScatteredSetup` when the hook is defined inside a class method. ([@d4rky-pl])
 
 ## 3.8.0 (2025-11-12)
 
@@ -984,6 +985,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@composerinteralia]: https://github.com/composerinteralia
 [@corsonknowles]: https://github.com/corsonknowles
 [@corydiamand]: https://github.com/corydiamand
+[@d4rky-pl]: https://github.com/d4rky-pl
 [@darhazer]: https://github.com/Darhazer
 [@daveworth]: https://github.com/daveworth
 [@dduugg]: https://github.com/dduugg

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5747,6 +5747,7 @@ Checks for setup scattered across multiple hooks in an example group.
 Unify `before` and `after` hooks when possible.
 However, `around` hooks are allowed to be defined multiple times,
 as unifying them would typically make the code harder to read.
+Hooks defined in class methods are also ignored.
 
 [#examples-rspecscatteredsetup]
 === Examples
@@ -5771,6 +5772,14 @@ end
 describe Foo do
   around { |example| before1; example.call; after1 }
   around { |example| before2; example.call; after2 }
+end
+
+# good
+describe Foo do
+  before { setup1 }
+  def self.setup
+    before { setup2 }
+  end
 end
 ----
 

--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -25,6 +25,13 @@ module RuboCop
         scope.equal?(:each)
       end
 
+      def inside_class_method? # rubocop:disable Metrics/CyclomaticComplexity
+        parent = node.parent
+        return false unless parent
+
+        parent.defs_type? || (parent.def_type? && inside_class_self?(parent))
+      end
+
       def scope
         return :each if scope_argument&.hash_type?
 
@@ -75,6 +82,12 @@ module RuboCop
 
       def scope_argument
         node.send_node.first_argument
+      end
+
+      def inside_class_self?(node)
+        node.parent&.sclass_type? ||
+          (node.parent&.begin_type? && node.parent.parent&.sclass_type?) ||
+          false
       end
     end
   end

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -202,4 +202,29 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
       end
     RUBY
   end
+
+  it 'ignores blocks defined inside class methods' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        before { bar }
+        def self.setup
+          before { baz }
+        end
+        setup
+      end
+    RUBY
+  end
+
+  it 'ignores blocks defined in class << self' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        before { bar }
+        class << self
+          def setup
+            before { baz }
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR fixes a false positive in `RSpec/ScatteredSetup` by ignoring the hooks defined inside class methods.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

