### PR TITLE
Fix RSpec/DescribedClass to ignore *_eval and *_exec blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata (e.g., skip messages). ([@ydah])
 - Fix a false positive for `RSpec/ScatteredSetup` when the hook is defined inside a class method. ([@d4rky-pl])
+- Fix a false positive for `RSpec/DescribedClass` inside dynamically evaluated blocks (`class_eval`, `module_eval`, `instance_eval`, `class_exec`, `module_exec`, `instance_exec`). ([@sucicfilip])
 
 ## 3.8.0 (2025-11-12)
 
@@ -1083,6 +1084,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@smcgivern]: https://github.com/smcgivern
 [@splattael]: https://github.com/splattael
 [@stephannv]: https://github.com/stephannv
+[@sucicfilip]: https://github.com/sucicfilip
 [@swelther]: https://github.com/swelther
 [@t3h2mas]: https://github.com/t3h2mas
 [@tdeo]: https://github.com/tdeo

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -87,6 +87,8 @@ module RuboCop
             {
               (send (const nil? {:Class :Module :Struct}) :new ...)
               (send (const nil? :Data) :define ...)
+              (send _ {:class_eval :module_eval :instance_eval} ...)
+              (send _ {:class_exec :module_exec :instance_exec} ...)
             }
             ...
           )

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -195,6 +195,34 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
+    it 'ignores class inside *_eval and *_exec blocks' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Foo do
+          before do
+            stub_const('Dummy', Class.new).class_eval do
+              Foo.new
+            end
+
+            stub_const('Dummy', Class.new).module_eval do
+              Foo.new
+            end
+
+            stub_const('Dummy', Class.new).instance_eval do
+              Foo.new
+            end
+
+            stub_const('Dummy', Class.new).class_exec do
+              Foo.new
+            end
+
+            stub_const('Dummy', Class.new).module_exec do
+              Foo.new
+            end
+          end
+        end
+      RUBY
+    end
+
     it 'takes class from innermost describe' do
       expect_offense(<<~RUBY)
         describe MyClass do


### PR DESCRIPTION
Fix false positives for RSpec/DescribedClass inside eval blocks

`RSpec/DescribedClass` currently registers offenses for constant instantiations inside `class_eval` / `module_eval` / `instance_eval` blocks.

In such contexts, `described_class` is not available nor semantically correct, as the code is defining or operating on dynamically evaluated classes/modules.

This PR makes the cop ignore nodes inside eval blocks, preventing false positives and removing the need to disable the cop in valid RSpec setups.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
