### PR TITLE
Run EmptyLineAfterFinalLet checks inside include_examples blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false negative for `RSpec/EmptyLineAfterFinalLet` inside `shared_examples` / `include_examples` / `it_behaves_like` blocks. ([@Darhazer])
+
 ## 3.9.0 (2026-01-07)
 
 - Fix a false positive for `RSpec/LeakyLocalVariable` when variables are used only in example metadata (e.g., skip messages). ([@ydah])

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -23,8 +23,13 @@ module RuboCop
 
         MSG = 'Add an empty line after the last `%<let>s`.'
 
+        # @!method example_group_or_include?(node)
+        def_node_matcher :example_group_or_include?, <<~PATTERN
+          (block (send #rspec? {#SharedGroups.all #ExampleGroups.all #Includes.all} ...) args $_)
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example_group_with_body?(node)
+          return unless example_group_or_include?(node)
 
           final_let = node.body.child_nodes.reverse.find { |child| let?(child) }
 

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -21,6 +21,55 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
+  it 'registers an offense for empty line after last let in shared examples' do
+    expect_offense(<<~RUBY)
+      RSpec.describe User do
+        shared_examples_for 'some shared behavior' do
+          let(:a) { a }
+          let(:b) { b }
+          ^^^^^^^^^^^^^ Add an empty line after the last `let`.
+          it { expect(a).to eq(b) }
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe User do
+        shared_examples_for 'some shared behavior' do
+          let(:a) { a }
+          let(:b) { b }
+
+          it { expect(a).to eq(b) }
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for empty line after last let in' \
+     'included examples' do
+    expect_offense(<<~RUBY)
+      RSpec.describe User do
+        it_behaves_like 'some shared behavior' do
+          let(:a) { a }
+          let(:b) { b }
+          ^^^^^^^^^^^^^ Add an empty line after the last `let`.
+          it { expect(a).to eq(b) }
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe User do
+        it_behaves_like 'some shared behavior' do
+          let(:a) { a }
+          let(:b) { b }
+
+          it { expect(a).to eq(b) }
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense for empty line after the last `let!`' do
     expect_offense(<<~RUBY)
       RSpec.describe User do


### PR DESCRIPTION
Fixes #2040 

Note
I was about to change the definition of `example_group_with_body?` but I don't think the change make sense to all the cops that rely on this, specifically it would count
```
context 'foo' do
  it { works }
end

it_behaves_like 'bar' do
  it { works }
end
```
as duplicate, which is not true
So I decided to just update the specific cop instead.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] ~Updated documentation.~
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).


