### PR TITLE
Add NegatedMatcher support to RSpec/ExpectChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add `Strict` option to `RSpec/SharedContext` to flag `shared_context` whenever it contains examples, even alongside setup code. ([@Darhazer])
+- Add `NegatedMatcher` configuration option `RSpec/ExpectChange`. ([@Darhazer])
 
 ## 3.10.0 (2026-06-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -460,7 +460,8 @@ RSpec/ExpectChange:
     - block
   SafeAutoCorrect: false
   VersionAdded: '1.22'
-  VersionChanged: '2.5'
+  VersionChanged: "<<next>>"
+  NegatedMatcher: ~
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2209,7 +2209,7 @@ expect("user").to be_present
 | Yes
 | Always (Unsafe)
 | 1.22
-| 2.5
+| <<next>>
 |===
 
 Checks for consistent style of change matcher.
@@ -2218,6 +2218,10 @@ Enforces either passing a receiver and message as method arguments,
 or a block.
 
 This cop can be configured using the `EnforcedStyle` option.
+
+When using compound expectations with `change` and a negated matcher
+(e.g., `not_change`), you can configure the `NegatedMatcher` option
+to ensure consistent style enforcement across both matchers.
 
 [#safety-rspecexpectchange]
 === Safety
@@ -2272,6 +2276,18 @@ expect { run }.to change(Foo, :bar)
 expect { run }.to change { Foo.bar }
 ----
 
+[#_negatedmatcher_-not_change_-_with-compound-expectations_-rspecexpectchange]
+==== `NegatedMatcher: not_change` (with compound expectations)
+
+[source,ruby]
+----
+# bad
+expect { run }.to change(Foo, :bar).and not_change { Foo.baz }
+
+# good
+expect { run }.to change(Foo, :bar).and not_change(Foo, :baz)
+----
+
 [#configurable-attributes-rspecexpectchange]
 === Configurable attributes
 
@@ -2281,6 +2297,10 @@ expect { run }.to change { Foo.bar }
 | EnforcedStyle
 | `method_call`
 | `method_call`, `block`
+
+| NegatedMatcher
+| `<none>`
+| 
 |===
 
 [#references-rspecexpectchange]

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -10,6 +10,10 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option.
       #
+      # When using compound expectations with `change` and a negated matcher
+      # (e.g., `not_change`), you can configure the `NegatedMatcher` option
+      # to ensure consistent style enforcement across both matchers.
+      #
       # @safety
       #   Autocorrection is unsafe because `method_call` style calls the
       #   receiver *once* and sends the message to it before and after
@@ -48,23 +52,29 @@ module RuboCop
       #   # good
       #   expect { run }.to change { Foo.bar }
       #
+      # @example `NegatedMatcher: not_change` (with compound expectations)
+      #   # bad
+      #   expect { run }.to change(Foo, :bar).and not_change { Foo.baz }
+      #
+      #   # good
+      #   expect { run }.to change(Foo, :bar).and not_change(Foo, :baz)
+      #
       class ExpectChange < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
 
-        MSG_BLOCK = 'Prefer `change(%<obj>s, :%<attr>s)`.'
-        MSG_CALL = 'Prefer `change { %<obj>s.%<attr>s }`.'
-        RESTRICT_ON_SEND = %i[change].freeze
+        MSG_BLOCK = 'Prefer `%<matcher>s(%<obj>s, :%<attr>s)`.'
+        MSG_CALL = 'Prefer `%<matcher>s { %<obj>s.%<attr>s }`.'
 
-        # @!method expect_change_with_arguments(node)
-        def_node_matcher :expect_change_with_arguments, <<~PATTERN
-          (send nil? :change $_ ({sym str} $_))
+        # @!method expect_matcher_with_arguments(node)
+        def_node_matcher :expect_matcher_with_arguments, <<~PATTERN
+          (send nil? _ $_ ({sym str} $_))
         PATTERN
 
-        # @!method expect_change_with_block(node)
-        def_node_matcher :expect_change_with_block, <<~PATTERN
+        # @!method expect_matcher_with_block(node)
+        def_node_matcher :expect_matcher_with_block, <<~PATTERN
           (block
-            (send nil? :change)
+            (send nil? _)
             (args)
             (send
               ${
@@ -78,11 +88,14 @@ module RuboCop
 
         def on_send(node)
           return unless style == :block
+          return unless matcher_method?(node.method_name)
 
-          expect_change_with_arguments(node) do |receiver, message|
-            msg = format(MSG_CALL, obj: receiver.source, attr: message)
+          expect_matcher_with_arguments(node) do |receiver, message|
+            matcher_name = node.method_name.to_s
+            msg = format(MSG_CALL, matcher: matcher_name,
+                                   obj: receiver.source, attr: message)
             add_offense(node, message: msg) do |corrector|
-              replacement = "change { #{receiver.source}.#{message} }"
+              replacement = "#{matcher_name} { #{receiver.source}.#{message} }"
               corrector.replace(node, replacement)
             end
           end
@@ -90,14 +103,31 @@ module RuboCop
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
           return unless style == :method_call
+          return unless matcher_method?(node.method_name)
 
-          expect_change_with_block(node) do |receiver, message|
-            msg = format(MSG_BLOCK, obj: receiver.source, attr: message)
+          expect_matcher_with_block(node) do |receiver, message|
+            matcher_name = node.method_name.to_s
+            msg = format(MSG_BLOCK, matcher: matcher_name,
+                                    obj: receiver.source, attr: message)
             add_offense(node, message: msg) do |corrector|
-              replacement = "change(#{receiver.source}, :#{message})"
+              replacement = "#{matcher_name}(#{receiver.source}, :#{message})"
               corrector.replace(node, replacement)
             end
           end
+        end
+
+        private
+
+        def matcher_method_names
+          [:change, negated_matcher&.to_sym].compact
+        end
+
+        def matcher_method?(method_name)
+          matcher_method_names.include?(method_name)
+        end
+
+        def negated_matcher
+          cop_config['NegatedMatcher']
         end
       end
     end


### PR DESCRIPTION
Fixes #813 
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
