### PR TITLE
Improve `RSpec/ScatteredLet` doc examples to be more realistic

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5716,11 +5716,11 @@ end
 
 # good
 describe Foo do
-  subject { Foo }
-  before { prepare }
   let(:foo) { 1 }
   let(:bar) { 2 }
   let!(:baz) { 3 }
+  subject { Foo }
+  before { prepare }
 end
 ----
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -19,11 +19,11 @@ module RuboCop
       #
       #   # good
       #   describe Foo do
-      #     subject { Foo }
-      #     before { prepare }
       #     let(:foo) { 1 }
       #     let(:bar) { 2 }
       #     let!(:baz) { 3 }
+      #     subject { Foo }
+      #     before { prepare }
       #   end
       #
       class ScatteredLet < Base


### PR DESCRIPTION
This cop does not enforce a rule stating that `let` should come before or after `subject` or `before` blocks. In fact, running autocorrect does not change that specific order. However, in the existing examples, it appeared somewhat as if the order changed between "bad" and "good."

Therefore, I have made improvements so that the examples align with the actual results of the autocorrect. 

Additionally, there was previously an issue where the order of individual `let` statements would change, but this has been resolved in the following pull request, so it is no longer a concern 😃 

- https://github.com/rubocop/rubocop-rspec/pull/2156

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~~Added tests.~~
- [x] Updated documentation.
- [ ] ~~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~~
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
