### PR TITLE
Change exclude_limit specs

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.81'
+  spec.add_dependency 'rubocop', '~> 1.86', '>= 1.86.2'
 end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
+  include_context 'with exclude limit tracking'
+
   context 'without configuration' do
     let(:cop_config) { {} }
 
@@ -254,6 +256,6 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       end
     RUBY
 
-    expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 3)
+    expect(read_exclude_limit(cop)).to eq('Max' => 3)
   end
 end

--- a/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers do
+  include_context 'with exclude limit tracking'
+
   let(:cop_config) { { 'Max' => 1 } }
 
   it 'flags excessive `#let`' do
@@ -157,6 +159,6 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers do
       end
     RUBY
 
-    expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 4)
+    expect(read_exclude_limit(cop)).to eq('Max' => 4)
   end
 end

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
+  include_context 'with exclude limit tracking'
+
   it 'flags nested example groups defined inside `describe`' do
     expect_offense(<<~RUBY)
       describe MyClass do
@@ -62,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
       end
     RUBY
 
-    expect(cop.config_to_allow_offenses[:exclude_limit]).to eq('Max' => 4)
+    expect(read_exclude_limit(cop)).to eq('Max' => 4)
   end
 
   it 'flags example groups wrapped in classes' do


### PR DESCRIPTION
RuboCop changed in https://github.com/rubocop/rubocop/pull/15007 and https://github.com/rubocop/rubocop/pull/15151 how we should check for changes to the exclude limits (the `Max` values which are set in .rubocop_todo.yml).

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
