### PR TITLE
Catch argumentless matchers in `RSpec/ExpectActual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix a false positive for `RSpec/ContainExactly` when `contain_exactly` has multiple splat arguments. ([@ydah])
 - Add autocorrect support for `RSpec/SubjectDeclaration`. ([@eugeneius])
 - Fix false negatives for `RSpec/SpecFilePathFormat` when the expected class path only partially matches a path segment. ([@ydah])
+- Fix a false negative for `RSpec/ExpectActual` when the matcher takes no arguments (e.g. `expect("foo").to be_present`, `expect(1).to be`). ([@cvx])
 
 ## 3.9.0 (2026-01-07)
 
@@ -997,6 +998,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@composerinteralia]: https://github.com/composerinteralia
 [@corsonknowles]: https://github.com/corsonknowles
 [@corydiamand]: https://github.com/corydiamand
+[@cvx]: https://github.com/cvx
 [@d4rky-pl]: https://github.com/d4rky-pl
 [@darhazer]: https://github.com/Darhazer
 [@daveworth]: https://github.com/daveworth

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2178,7 +2178,9 @@ expect(pattern).to eq(/foo/)
 expect(name).to eq("John")
 
 # bad (not supported autocorrection)
+expect(42).to be_even
 expect(false).to eq(true)
+expect("user").to be_present
 ----
 
 [#configurable-attributes-rspecexpectactual]

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -19,12 +19,15 @@ module RuboCop
       #   expect(name).to eq("John")
       #
       #   # bad (not supported autocorrection)
+      #   expect(42).to be_even
       #   expect(false).to eq(true)
+      #   expect("user").to be_present
       #
       class ExpectActual < Base
         extend AutoCorrector
 
         MSG = 'Provide the actual value you are testing to `expect(...)`.'
+        MSG_NO_ARG = 'Test a non-literal value with `expect(...)`.'
 
         RESTRICT_ON_SEND = Runners.all
 
@@ -65,9 +68,21 @@ module RuboCop
           )
         PATTERN
 
+        # @!method expect_literal_no_arg(node)
+        def_node_matcher :expect_literal_no_arg, <<~PATTERN
+          (send
+            (send nil? :expect $#literal?)
+            #Runners.all
+            $(send nil? $_)
+          )
+        PATTERN
+
         def on_send(node)
           expect_literal(node) do |actual, send_node, matcher, expected|
             register_offense(actual, send_node, matcher, expected)
+          end
+          expect_literal_no_arg(node) do |actual, send_node, matcher|
+            register_offense(actual, send_node, matcher, nil)
           end
         end
 
@@ -76,9 +91,10 @@ module RuboCop
         def register_offense(actual, send_node, matcher, expected)
           return if SKIPPED_MATCHERS.include?(matcher)
 
-          add_offense(actual) do |corrector|
+          message = expected.nil? ? MSG_NO_ARG : MSG
+          add_offense(actual, message: message) do |corrector|
             next unless CORRECTABLE_MATCHERS.include?(matcher)
-            next if literal?(expected)
+            next if expected.nil? || literal?(expected)
 
             corrector.replace(actual, expected.source)
             if matcher == :be

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -67,23 +67,27 @@ module RuboCop
 
         def on_send(node)
           expect_literal(node) do |actual, send_node, matcher, expected|
-            next if SKIPPED_MATCHERS.include?(matcher)
-
-            add_offense(actual) do |corrector|
-              next unless CORRECTABLE_MATCHERS.include?(matcher)
-              next if literal?(expected)
-
-              corrector.replace(actual, expected.source)
-              if matcher == :be
-                corrector.replace(expected, actual.source)
-              else
-                corrector.replace(send_node, "#{matcher}(#{actual.source})")
-              end
-            end
+            register_offense(actual, send_node, matcher, expected)
           end
         end
 
         private
+
+        def register_offense(actual, send_node, matcher, expected)
+          return if SKIPPED_MATCHERS.include?(matcher)
+
+          add_offense(actual) do |corrector|
+            next unless CORRECTABLE_MATCHERS.include?(matcher)
+            next if literal?(expected)
+
+            corrector.replace(actual, expected.source)
+            if matcher == :be
+              corrector.replace(expected, actual.source)
+            else
+              corrector.replace(send_node, "#{matcher}(#{actual.source})")
+            end
+          end
+        end
 
         # This is not implemented using a NodePattern because it seems
         # to not be able to match against an explicit (nil) sexp

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -227,14 +227,17 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
     RUBY
   end
 
-  it 'ignores `be` with no argument' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags `be` with no argument' do
+    expect_offense(<<~RUBY)
       describe Foo do
-        it 'uses expect legitimately' do
+        it 'uses expect incorrectly' do
           expect(1).to be
+                 ^ Test a non-literal value with `expect(...)`.
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'flags `be` with an argument' do
@@ -332,6 +335,21 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
         it 'uses expect incorrectly' do
           expect([1,2,3]).to eq([1, 2, 3])
                  ^^^^^^^ Provide the actual value you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'flags literal values with argumentless predicate matchers' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect("user").to be_present
+                 ^^^^^^ Test a non-literal value with `expect(...)`.
+          expect([]).to be_empty
+                 ^^ Test a non-literal value with `expect(...)`.
         end
       end
     RUBY


### PR DESCRIPTION
Flags e.g. `expect(".foo").to be_present` and `expect(1).to be`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).