### PR TITLE
Normalize line-wrapped descriptions in DescriptionExtractor

### DIFF
--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -50,7 +50,7 @@ module RuboCop
         end
 
         def description
-          yardoc.docstring.split("\n\n").first.to_s
+          yardoc.docstring.split("\n\n").first.to_s.tr("\n", ' ')
         end
 
         def rspec_cop_namespace?

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
         def bar
         end
       end
+
+      # Checks bar with a description that wraps across
+      # multiple lines
+      #
+      # @note only works with bar
+      class RuboCop::Cop::RSpec::Bar < RuboCop::Cop::RSpec::Base
+      end
     RUBY
 
     YARD::Registry.all(:class)
@@ -60,12 +67,17 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
   before do
     stub_cop_const('Foo')
     stub_cop_const('Undocumented')
+    stub_cop_const('Bar')
   end
 
   it 'builds a hash of descriptions' do
     expect(described_class.new(yardocs).to_h).to eql(
       'RSpec/Foo'          => { 'Description' => 'Checks foo' },
-      'RSpec/Undocumented' => { 'Description' => ''           }
+      'RSpec/Undocumented' => { 'Description' => '' },
+      'RSpec/Bar'          => {
+        'Description' => 'Checks bar with a description that wraps across ' \
+                         'multiple lines'
+      }
     )
   end
 end


### PR DESCRIPTION
Fix bug where cop descriptions that span multiple lines in YARD comments would contain literal newline characters in config/default.yml.

Single newlines in YARD docstrings are just line wraps for 80-char limit compliance, not semantic paragraph breaks, so they should be converted to spaces in the extracted description.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
