### PR TITLE
Fix a false positive for `RSpec/ContainExactly` when `contain_exactly` has multiple splat arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for `itblock` nodes. ([@Darhazer])
 - `RSpec/ScatteredLet` now preserves the order of `let`s during auto-correction. ([@Darhazer])
 - Fix a false negative for `RSpec/EmptyLineAfterFinalLet` inside `shared_examples` / `include_examples` / `it_behaves_like` blocks. ([@Darhazer])
+- Fix a false positive for `RSpec/ContainExactly` when `contain_exactly` has multiple splat arguments. ([@ydah])
 - Add autocorrect support for `RSpec/SubjectDeclaration`. ([@eugeneius])
 
 ## 3.9.0 (2026-01-07)

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -642,10 +642,13 @@ This cop checks for the following:
 [source,ruby]
 ----
 # bad
-it { is_expected.to contain_exactly(*array1, *array2) }
+it { is_expected.to contain_exactly(*array) }
 
 # good
-it { is_expected.to match_array(array1 + array2) }
+it { is_expected.to match_array(array) }
+
+# good
+it { is_expected.to contain_exactly(*array1, *array2) }
 
 # good
 it { is_expected.to contain_exactly(content, *array) }

--- a/lib/rubocop/cop/rspec/contain_exactly.rb
+++ b/lib/rubocop/cop/rspec/contain_exactly.rb
@@ -12,10 +12,13 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   it { is_expected.to contain_exactly(*array1, *array2) }
+      #   it { is_expected.to contain_exactly(*array) }
       #
       #   # good
-      #   it { is_expected.to match_array(array1 + array2) }
+      #   it { is_expected.to match_array(array) }
+      #
+      #   # good
+      #   it { is_expected.to contain_exactly(*array1, *array2) }
       #
       #   # good
       #   it { is_expected.to contain_exactly(content, *array) }
@@ -27,29 +30,12 @@ module RuboCop
         RESTRICT_ON_SEND = %i[contain_exactly].freeze
 
         def on_send(node)
-          return if node.arguments.empty?
-
-          check_populated_collection(node)
-        end
-
-        private
-
-        def check_populated_collection(node)
-          return unless node.each_child_node.all?(&:splat_type?)
+          return unless node.arguments.one? && node.first_argument.splat_type?
 
           add_offense(node) do |corrector|
-            autocorrect_for_populated_array(node, corrector)
+            array = node.first_argument.children.first
+            corrector.replace(node, "match_array(#{array.source})")
           end
-        end
-
-        def autocorrect_for_populated_array(node, corrector)
-          arrays = node.arguments.map do |splat_node|
-            splat_node.children.first
-          end
-          corrector.replace(
-            node,
-            "match_array(#{arrays.map(&:source).join(' + ')})"
-          )
         end
       end
     end

--- a/spec/rubocop/cop/rspec/contain_exactly_spec.rb
+++ b/spec/rubocop/cop/rspec/contain_exactly_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
-  it 'flags `contain_exactly` with only splat arguments' do
+  it 'flags `contain_exactly` with a single splat argument' do
     expect_offense(<<~RUBY)
-      it { is_expected.to contain_exactly(*array1, *array2) }
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `match_array` when matching array values.
       it { is_expected.to contain_exactly(*[1,2,3]) }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `match_array` when matching array values.
       it { is_expected.to contain_exactly(*a.merge(b)) }
@@ -14,7 +12,6 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
     RUBY
 
     expect_correction(<<~RUBY)
-      it { is_expected.to match_array(array1 + array2) }
       it { is_expected.to match_array([1,2,3]) }
       it { is_expected.to match_array(a.merge(b)) }
       it { is_expected.to match_array((a + b)) }
@@ -42,6 +39,13 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
     expect_no_offenses(<<~RUBY)
       it { is_expected.to contain_exactly(content, *array) }
       it { is_expected.to contain_exactly(*array, content) }
+    RUBY
+  end
+
+  it 'does not flag `contain_exactly` with multiple splat arguments' do
+    expect_no_offenses(<<~RUBY)
+      it { is_expected.to contain_exactly(*array1, *array2) }
+      it { is_expected.to contain_exactly(*0..9, *100..109, *200..209) }
     RUBY
   end
 


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2173

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
