### PR TITLE
Fix false negatives for `RSpec/SpecFilePathFormat` when the expected class path only partially matches a path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `RSpec/ScatteredLet` now preserves the order of `let`s during auto-correction. ([@Darhazer])
 - Fix a false negative for `RSpec/EmptyLineAfterFinalLet` inside `shared_examples` / `include_examples` / `it_behaves_like` blocks. ([@Darhazer])
 - Add autocorrect support for `RSpec/SubjectDeclaration`. ([@eugeneius])
+- Fix false negatives for `RSpec/SpecFilePathFormat` when the expected class path only partially matches a path segment. ([@ydah])
 
 ## 3.9.0 (2026-01-07)
 

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -44,6 +44,7 @@ module RuboCop
         include FileHelp
 
         MSG = 'Spec path should end with `%<suffix>s`.'
+        PATH_NAME_BOUNDARY = '(?![[:alnum:]])'
 
         # @!method example_group_arguments(node)
         def_node_matcher :example_group_arguments, <<~PATTERN
@@ -119,7 +120,11 @@ module RuboCop
           # For the suffix shown in the offense message, modify the regular
           # expression pattern to resemble a glob pattern for clearer error
           # messages.
-          suffix = pattern.sub('.*', '*').sub('[^/]*', '*').sub('\.', '.')
+          suffix = pattern
+            .sub(PATH_NAME_BOUNDARY, '')
+            .sub('.*', '*')
+            .sub('[^/]*', '*')
+            .sub('\.', '.')
           add_offense(send_node, message: format(MSG, suffix: suffix))
         end
 
@@ -132,19 +137,21 @@ module RuboCop
         end
 
         def correct_path_pattern(class_name, arguments)
-          path = [expected_path(class_name)]
-          path << '.*' unless ignore?(arguments.first)
-          path << [name_pattern(arguments.first), '[^/]*_spec\.rb']
-          path.join
+          [
+            expected_path(class_name),
+            PATH_NAME_BOUNDARY,
+            method_name_pattern(arguments.first),
+            '[^/]*_spec\.rb'
+          ].join
         end
 
-        def name_pattern(method_name)
-          return if ignore?(method_name)
+        def method_name_pattern(method_name)
+          return if ignore_method_name?(method_name)
 
-          method_name.str_content.gsub(/\s/, '_').gsub(/\W/, '')
+          ".*#{method_name.str_content.gsub(/\s/, '_').gsub(/\W/, '')}"
         end
 
-        def ignore?(method_name)
+        def ignore_method_name?(method_name)
           !method_name&.str_type? || ignore_methods?
         end
 
@@ -175,7 +182,7 @@ module RuboCop
         end
 
         def filename_ends_with?(pattern)
-          expanded_file_path.match?("#{pattern}$")
+          expanded_file_path.match?(%r{(?:\A|/)#{pattern}$})
         end
       end
     end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -36,6 +36,28 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     RUBY
   end
 
+  it 'registers an offense when the class name is only a file name prefix' do
+    expect_offense(<<~RUBY, 'spec/models/random/userx_spec.rb')
+      RSpec.describe User, type: :model do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
+    RUBY
+  end
+
+  it 'registers an offense when the class name is only a file name suffix' do
+    expect_offense(<<~RUBY, 'spec/models/my_user_spec.rb')
+      describe User do; end
+      ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
+    RUBY
+  end
+
+  it 'registers an offense when namespaced class name is only a ' \
+     'file name prefix' do
+    expect_offense(<<~RUBY, 'some/classy_spec.rb')
+      describe Some::Class do; end
+      ^^^^^^^^^^^^^^^^^^^^ Spec path should end with `some/class*_spec.rb`.
+    RUBY
+  end
+
   it 'registers an offense when wrong top-level class name' do
     expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe ::MyClass do; end
@@ -113,9 +135,23 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     RUBY
   end
 
+  it 'does not register an offense when the class name has a suffix' do
+    expect_no_offenses(<<~RUBY, 'user_validations_spec.rb')
+      describe User do; end
+    RUBY
+  end
+
   it 'does not register an offense when instance methods' do
     expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
+    RUBY
+  end
+
+  it 'registers an offense when the method path uses only a class name ' \
+     'prefix' do
+    expect_offense(<<~RUBY, 'some/classx/inst_spec.rb')
+      describe Some::Class, '#inst' do; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `some/class*inst*_spec.rb`.
     RUBY
   end
 
@@ -402,7 +438,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
         allow(described_class::ActiveSupportInflector).to receive(:require)
           .with(cop_config['InflectorPath'])
         allow(ActiveSupport::Inflector).to receive(:underscore)
-          .and_return('')
+          .with('HTTPClient').and_return('http_client')
       end
 
       it 'reads the InflectorPath configuration correctly and does not ' \


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2167

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
