### PR TITLE
Use simplecov v1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ $ mdformat . --number
 
 ### Test Coverage - Line and Branch
 
-We are using [Simplecov](https://github.com/colszowka/simplecov) to track test coverage.
+We are using [Simplecov](https://github.com/simplecov-ruby/simplecov) to track test coverage.
 
 It is included and reported when you run `bundle exec rake` or `bundle exec rspec`.
 
@@ -65,20 +65,19 @@ E.g. on macOS:
 $ open coverage/index.html
 ```
 
-If you have unreachable lines, you can add `# :nocov` around those lines. The code itself or a comment should explain why the line is unreachable.
+If you have unreachable lines, you can add `# simplecov:disable`/`# simplecov:enable` around those lines. The code itself or a comment should explain why the line is unreachable.
 
 Example:
 
 ```ruby
-# :nocov:
+# simplecov:disable
 raise ArgumentError("Unsupported style :#{style}")
-# :nocov:
+# simplecov:enable
 ```
 
 This can happen for a few reasons, including:
 
-1. When you handle config with a case statement and there is no else block.
-2. When matching with a node pattern even when you handle all cases: all other node types will be excluded before reaching your handler, because the node pattern will not match them.
+- When matching with a node pattern even when you handle all cases: all other node types will be excluded before reaching your handler, because the node pattern will not match them.
 
 You will need full line and branch coverage to merge. This helps detect edge cases and prevent errors.
 

--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-SimpleCov.start do
-  enable_coverage :branch
-  minimum_coverage line: 100, branch: 100
-  add_filter '/spec/'
-  add_filter '/vendor/bundle/'
-end
+SimpleCov.enable_coverage :branch
+SimpleCov.minimum_coverage line: 100, branch: 100
+SimpleCov.ignore_branches :implicit_else
+SimpleCov.skip '/spec/'
+SimpleCov.skip '/vendor/bundle/'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rake'
 gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.24'
 gem 'rubocop-rake', '~> 0.7'
-gem 'simplecov', '>= 0.19'
+gem 'simplecov', '~> 1' if RUBY_VERSION >= '3.2'
 gem 'yard'
 
 # FIXME: Remove when the next prism version is released.

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -48,10 +48,6 @@ module RuboCop
             check_be_style(node)
           when :be_nil
             check_be_nil_style(node)
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
 

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -107,10 +107,6 @@ module RuboCop
             corrector.replace(node.location.selector, 'expect(subject).to')
           when :should_not
             corrector.replace(node.location.selector, 'expect(subject).not_to')
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
 
@@ -133,10 +129,6 @@ module RuboCop
             implicit_subject_in_non_its_and_non_single_line?(node)
           when :single_statement_only
             implicit_subject_in_non_its_and_non_single_statement?(node)
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
 

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -80,10 +80,6 @@ module RuboCop
             MSG_RECEIVE
           when :have_received
             format(MSG_HAVE_RECEIVED, source: receiver.source)
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
       end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -116,10 +116,6 @@ module RuboCop
                      true
                    when :be_falsey, :be_falsy, :a_falsey_value, :a_falsy_value
                      false
-                   else
-                     # :nocov:
-                     :noop
-                     # :nocov:
                    end
           to_symbol == :to ? result : !result
         end
@@ -333,10 +329,6 @@ module RuboCop
             check_inflected(node)
           when :explicit
             check_explicit(node)
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
 

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -108,10 +108,6 @@ module RuboCop
             ActiveSupportInflector
           when 'default'
             DefaultInflector
-          else
-            # :nocov:
-            :noop
-            # :nocov:
           end
         end
 

--- a/lib/rubocop/rspec/plugin.rb
+++ b/lib/rubocop/rspec/plugin.rb
@@ -6,7 +6,7 @@ module RuboCop
   module RSpec
     # A plugin that integrates RuboCop RSpec with RuboCop's plugin system.
     class Plugin < LintRoller::Plugin
-      # :nocov:
+      # simplecov:disable
       def about
         LintRoller::About.new(
           name: 'rubocop-rspec',
@@ -15,7 +15,7 @@ module RuboCop
           description: 'Code style checking for RSpec files.'
         )
       end
-      # :nocov:
+      # simplecov:enable
 
       def supported?(context)
         context.engine == :rubocop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@
 require 'rubocop'
 require 'rubocop/rspec/support'
 
-require 'simplecov' unless ENV['NO_COVERAGE']
+unless ENV['NO_COVERAGE'] || RUBY_VERSION < '3.1'
+  require 'simplecov'
+  SimpleCov.start
+end
 
 module SpecHelper
   ROOT = Pathname.new(__dir__).parent.freeze


### PR DESCRIPTION
The major new feature (for our purposes) is that Simplecov can now be configured to ignore the "implicit else" branches that previously needed 1. to exist and 2. have their no-op contents wrapped with a `:nocov:` comment.