### PR TITLE
Ignore interpolation in MatchWithSimpleRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 3.10.1 (2026-06-05)
+
 - Add `Strict` option to `RSpec/SharedContext` to flag `shared_context` whenever it contains examples, even alongside setup code. ([@Darhazer])
 - Add `NegatedMatcher` configuration option `RSpec/ExpectChange`. ([@Darhazer])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore regular expressions with interpolations. ([@bquorning])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `Strict` option to `RSpec/SharedContext` to flag `shared_context` whenever it contains examples, even alongside setup code. ([@Darhazer])
 - Add `NegatedMatcher` configuration option `RSpec/ExpectChange`. ([@Darhazer])
+- Fix `RSpec/MatchWithSimpleRegex` to ignore regular expressions with interpolations. ([@bquorning])
 
 ## 3.10.0 (2026-06-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -460,7 +460,7 @@ RSpec/ExpectChange:
     - block
   SafeAutoCorrect: false
   VersionAdded: '1.22'
-  VersionChanged: "<<next>>"
+  VersionChanged: '3.10'
   NegatedMatcher: ~
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
@@ -918,7 +918,7 @@ RSpec/SharedContext:
   Enabled: true
   Strict: false
   VersionAdded: '1.13'
-  VersionChanged: "<<next>>"
+  VersionChanged: '3.10'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2209,7 +2209,7 @@ expect("user").to be_present
 | Yes
 | Always (Unsafe)
 | 1.22
-| <<next>>
+| 3.10
 |===
 
 Checks for consistent style of change matcher.
@@ -5930,7 +5930,7 @@ end
 | Yes
 | Always
 | 1.13
-| <<next>>
+| 3.10
 |===
 
 Checks for proper shared_context and shared_examples usage.

--- a/lib/rubocop/cop/rspec/match_with_simple_regex.rb
+++ b/lib/rubocop/cop/rspec/match_with_simple_regex.rb
@@ -54,6 +54,8 @@ module RuboCop
         private
 
         def simple_regexp?(node)
+          return false if node.interpolation?
+
           parsed = Regexp::Parser.parse(node.content)
           parsed.expressions.all? { |expr| simple_expression?(expr) }
         end

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '3.10.0'
+      STRING = '3.10.1'
     end
   end
 end

--- a/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
+++ b/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe RuboCop::Cop::RSpec::MatchWithSimpleRegex, :config do
     RUBY
   end
 
+  it 'does not register an offense when using match with interpolation' do
+    expect_no_offenses(<<~'RUBY')
+      expect('foobar').to match(/foo-#{bar}/)
+    RUBY
+  end
+
   it 'does not register an offense when using match with string ' \
      'instead of regex' do
     expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
The cop should not register an offense when the regexp literal contains interpolation.

Fixes #2182.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
