### PR TITLE
Fix RSpec/SpecFilePathFormat false positives when CustomTransform maps a namespace to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false positives for `RSpec/SpecFilePathFormat` when `CustomTransform` maps a namespace to an empty string. ([@sakuro])
+
 ## 3.10.1 (2026-06-05)
 
 - Add `Strict` option to `RSpec/SharedContext` to flag `shared_context` whenever it contains examples, even alongside setup code. ([@Darhazer])

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -159,8 +159,9 @@ module RuboCop
           constants = namespace(constant) + constant.const_name.split('::')
 
           File.join(
-            constants.map do |name|
-              custom_transform.fetch(name) { camel_to_snake_case(name) }
+            constants.filter_map do |name|
+              path = custom_transform.fetch(name) { camel_to_snake_case(name) }
+              path unless path.empty?
             end
           )
         end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -286,6 +286,23 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     end
   end
 
+  context 'when configured with `CustomTransform: { "MyApp" => "" }`' do
+    let(:cop_config) { { 'CustomTransform' => { 'MyApp' => '' } } }
+
+    it 'does not register an offense when namespace maps to empty string' do
+      expect_no_offenses(<<~RUBY, 'actions/api/auth/current_spec.rb')
+        describe MyApp::Actions::API::Auth::Current do; end
+      RUBY
+    end
+
+    it 'registers an offense when path does not match' do
+      expect_offense(<<~RUBY, 'wrong/path_spec.rb')
+        describe MyApp::Actions::API::Auth::Current do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `actions/api/auth/current*_spec.rb`.
+      RUBY
+    end
+  end
+
   context 'when configured with `IgnoreMethods: false`' do
     let(:cop_config) { { 'IgnoreMethods' => false } }
     let(:suffix) { 'my_class*look_here_a_method*_spec.rb' }


### PR DESCRIPTION
Fixes #2187.

When `CustomTransform` maps a namespace to `""`, `File.join` receives
an empty string element and produces a leading `/` in the expected
path. The `(?:\A|/)` anchor introduced in 3.10.0 then causes the
regex to never match real file paths, producing false positives for
all spec files in affected projects.

Fix: use `filter_map` to drop empty-string results before `File.join`.

> **Note on CI failures**: The `Edge RuboCop` jobs fail due to a pre-existing
> offense in `lib/rubocop/cop/rspec/empty_metadata.rb` (`Lint/SafeNavigationWithEmpty`)
> that is unrelated to this PR and should be fixed separately.

---

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).