### PR TITLE
Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
+
 ## 3.10.2 (2026-06-06)
 
 - Fix false positives for `RSpec/SpecFilePathFormat` when `CustomTransform` maps a namespace to an empty string. ([@sakuro])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -6257,6 +6257,7 @@ my_class_spec.rb         # describe MyClass, '#method'
 my_class_spec.rb         # describe MyClass
 my_class_method_spec.rb  # describe MyClass, '#method'
 my_class/method_spec.rb  # describe MyClass, '#method'
+my_class/_partial_spec.rb # describe MyClass
 ----
 
 [#_customtransform_-_rubocop__rubocop_-rspec__rspec__-_default_-rspecspecfilepathformat]

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -14,6 +14,7 @@ module RuboCop
       #   my_class_spec.rb         # describe MyClass
       #   my_class_method_spec.rb  # describe MyClass, '#method'
       #   my_class/method_spec.rb  # describe MyClass, '#method'
+      #   my_class/_partial_spec.rb # describe MyClass
       #
       # @example `CustomTransform: {RuboCop=>rubocop, RSpec=>rspec}` (default)
       #   # good
@@ -45,6 +46,7 @@ module RuboCop
 
         MSG = 'Spec path should end with `%<suffix>s`.'
         PATH_NAME_BOUNDARY = '(?![[:alnum:]])'
+        PARTIAL_SPEC_FILE = %r{/(_[^/]*_spec\.rb)\z}.freeze
 
         # @!method example_group_arguments(node)
         def_node_matcher :example_group_arguments, <<~PATTERN
@@ -183,7 +185,11 @@ module RuboCop
         end
 
         def filename_ends_with?(pattern)
-          expanded_file_path.match?(%r{(?:\A|/)#{pattern}$})
+          file_path_for_matching.match?(%r{(?:\A|/)#{pattern}$})
+        end
+
+        def file_path_for_matching
+          expanded_file_path.sub(PARTIAL_SPEC_FILE, '\1')
         end
       end
     end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -141,6 +141,28 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     RUBY
   end
 
+  it 'does not register an offense when a spec partial starts with ' \
+     'an underscore' do
+    expect_no_offenses(<<~RUBY, 'spec/models/user/_authentication_spec.rb')
+      describe User do; end
+    RUBY
+  end
+
+  it 'does not register an offense when a namespaced spec partial starts ' \
+     'with an underscore' do
+    expect_no_offenses(<<~RUBY, 'spec/models/api/user/_authentication_spec.rb')
+      describe API::User do; end
+    RUBY
+  end
+
+  it 'registers an offense when the spec partial parent directory does not ' \
+     'match the class name' do
+    expect_offense(<<~RUBY, 'spec/models/userx/_authentication_spec.rb')
+      describe User do; end
+      ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
+    RUBY
+  end
+
   it 'does not register an offense when instance methods' do
     expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end


### PR DESCRIPTION
Fixes #2159.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).