### PR TITLE
Fix incorrect autocorrection for RSpec/DescribedClass in nested describes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
+- Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 
 ## 3.10.2 (2026-06-06)
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -111,38 +111,41 @@ module RuboCop
                         '(send nil? :described_class)'
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
-          # In case the explicit style is used, we need to remember what's
-          # being described.
-          @described_class, body = described_constant(node)
+          described_class, body = described_constant(node)
 
           return unless body
 
-          find_usage(body) do |match|
-            msg = message(match.const_name)
+          find_usage(body, described_class) do |match, current_described_class|
+            msg = message(match.const_name, current_described_class)
             add_offense(match, message: msg) do |corrector|
-              autocorrect(corrector, match)
+              autocorrect(corrector, match, current_described_class)
             end
           end
         end
 
         private
 
-        def autocorrect(corrector, match)
+        def autocorrect(corrector, match, described_class)
           replacement = if style == :described_class
                           DESCRIBED_CLASS
                         else
-                          @described_class.const_name
+                          described_class.const_name
                         end
 
           corrector.replace(match, replacement)
         end
 
-        def find_usage(node, &block)
-          yield(node) if offensive?(node)
+        def find_usage(node, described_class, &block)
+          current_described_class =
+            described_constant(node)&.first || described_class
+
+          yield(node, current_described_class) if offensive?(
+            node, current_described_class
+          )
           return if scope_change?(node) || allowed?(node)
 
           node.each_child_node do |child|
-            find_usage(child, &block)
+            find_usage(child, current_described_class, &block)
           end
         end
 
@@ -150,11 +153,11 @@ module RuboCop
           node.const_type? && only_static_constants?
         end
 
-        def message(offense)
+        def message(offense, described_class)
           if style == :described_class
             format(MSG, replacement: DESCRIBED_CLASS, src: offense)
           else
-            format(MSG, replacement: @described_class.const_name,
+            format(MSG, replacement: described_class.const_name,
                         src: DESCRIBED_CLASS)
           end
         end
@@ -175,26 +178,23 @@ module RuboCop
           cop_config.fetch('OnlyStaticConstants', true)
         end
 
-        def offensive?(node)
+        def offensive?(node, described_class)
           if style == :described_class
-            offensive_described_class?(node)
+            offensive_described_class?(node, described_class)
           else
             node.send_type? && node.method?(:described_class)
           end
         end
 
-        def offensive_described_class?(node)
+        def offensive_described_class?(node, described_class)
           return false unless node.const_type?
 
           # E.g. `described_class::CONSTANT`
           return false if contains_described_class?(node)
 
-          nearest_described_class, = node.each_ancestor(:block)
-            .map { |ancestor| described_constant(ancestor) }.find(&:itself)
+          return false if described_class.equal?(node)
 
-          return false if nearest_described_class.equal?(node)
-
-          full_const_name(nearest_described_class) == full_const_name(node)
+          full_const_name(described_class) == full_const_name(node)
         end
 
         def full_const_name(node)

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -547,5 +547,24 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         describe(Bar) { include Bar }
       RUBY
     end
+
+    it 'takes class from innermost describe' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          describe Bar do
+            subject { described_class }
+                      ^^^^^^^^^^^^^^^ Use `Bar` instead of `described_class`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe Foo do
+          describe Bar do
+            subject { Bar }
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Previously, the cop reused the outer described class while recursively inspecting the inner example group body. As a result, `described_class` inside a nested `describe Bar` could be autocorrected to the outer `Foo` instead of `Bar`.

```ruby
describe Foo do
  describe Bar do
    subject { described_class }
  end
end
```

Before this change, the autocorrection produced:

```ruby
describe Foo do
  describe Bar do
    subject { Foo }
  end
end
```

After this change, the innermost described class is used:

```ruby
describe Foo do
  describe Bar do
    subject { Bar }
  end
end
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
