### PR TITLE
Fix incorrect autocorrection for RSpec/ExampleWording with percent literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
+- Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
 
 ## 3.10.2 (2026-06-06)
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -106,6 +106,12 @@ module RuboCop
         end
 
         def docstring(node)
+          return source_without_outer_chars(node) unless delimited_string?(node)
+
+          node.loc.begin.end.join(node.loc.end.begin)
+        end
+
+        def source_without_outer_chars(node)
           expr = node.source_range
 
           Parser::Source::Range.new(
@@ -116,7 +122,7 @@ module RuboCop
         end
 
         def replacement_text(node)
-          text = text(node)
+          text = replacement_source(node)
 
           if text.match?(SHOULD_PREFIX) || text.match?(WILL_PREFIX)
             RuboCop::RSpec::Wording.new(
@@ -127,6 +133,12 @@ module RuboCop
           else
             text.sub(IT_PREFIX, '')
           end
+        end
+
+        def replacement_source(node)
+          return text(node) unless delimited_string?(node)
+
+          docstring(node).source
         end
 
         # Recursive processing is required to process nested dstr nodes
@@ -148,6 +160,10 @@ module RuboCop
 
         def ignored_words
           cop_config.fetch('IgnoredWords', [])
+        end
+
+        def delimited_string?(node)
+          !node.heredoc? && node.loc.begin && node.loc.end
         end
 
         def insufficient_docstring?(description_node)

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -18,6 +18,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     RUBY
   end
 
+  it 'finds percent literal descriptions with `should` at the beginning' do
+    expect_offense(<<~RUBY)
+      it %q[should do something] do
+            ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      it %q[does something] do
+      end
+    RUBY
+  end
+
   it 'finds interpolated description with `should` at the beginning' do
     expect_offense(<<~'RUBY')
       it "should do #{:stuff}" do
@@ -27,6 +40,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
 
     expect_correction(<<~'RUBY')
       it "does #{:stuff}" do
+      end
+    RUBY
+  end
+
+  it 'preserves escapes in descriptions with `should` at the beginning' do
+    expect_offense(<<~'RUBY')
+      it "should include \"quotes\"" do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      it "includes \"quotes\"" do
       end
     RUBY
   end
@@ -261,6 +287,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
 
     expect_correction(<<~'RUBY')
       it "does #{action}" do
+      end
+    RUBY
+  end
+
+  it 'finds leading it in percent literal interpolated descriptions' do
+    expect_offense(<<~'RUBY')
+      it %Q[it does #{action}] do
+            ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      it %Q[does #{action}] do
       end
     RUBY
   end


### PR DESCRIPTION
Fix incorrect autocorrection for `RSpec/ExampleWording` when rewriting example descriptions that use percent literals or escaped string content.

Before this change, the cop calculated the docstring range by trimming one character from each side of `source_range`. For `%q[should do something]`, that included the `%q[` opener in the offense and replacement range. For escaped strings, autocorrection used the decoded string value, which could drop required escapes.

```ruby
it %q[should do something] do
end

it "should include \"quotes\"" do
end
```

After this change, delimited strings use parser delimiter locations for the docstring range, and replacements use the original source between delimiters when available. Existing fallback behavior is kept for heredocs and backslash-concatenated strings.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).