### PR TITLE
Support Ruby 3.4 itblock/numblock across RSpec cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix `RSpec/LeadingSubject` to not crash on `itblock`/`numblock` example groups with Ruby 3.4 and Prism. ([@pcbeingused333])
 
 ## 3.10.2 (2026-06-06)
 
@@ -1095,6 +1096,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@oshiro3]: https://github.com/oshiro3
 [@patrickomatic]: https://github.com/patrickomatic
 [@paydaylight]: https://github.com/paydaylight
+[@pcbeingused333]: https://github.com/pcbeingused333
 [@philcoggins]: https://github.com/PhilCoggins
 [@pirj]: https://github.com/pirj
 [@pocke]: https://github.com/pocke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix multiple cops silently ignoring examples and example groups that parse as `itblock`/`numblock` under Ruby 3.4, i.e. a bare `it` pending example or numbered parameters. ([@pcbeingused333])
 - Fix false positives for `RSpec/Pending` when using SimpleCov 1.x `skip` filters. ([@gee-forr])
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])

--- a/lib/rubocop/cop/rspec/discarded_matcher.rb
+++ b/lib/rubocop/cop/rspec/discarded_matcher.rb
@@ -66,7 +66,9 @@ module RuboCop
 
         def example_with_matcher_expectation?(node)
           example_node =
-            node.each_ancestor(:block).find { |ancestor| example?(ancestor) }
+            node.each_ancestor(:any_block).find do |ancestor|
+              example?(ancestor)
+            end
 
           example_node.each_descendant(:send).any? do |send_node|
             expectation_with_matcher?(send_node)
@@ -82,7 +84,7 @@ module RuboCop
 
         def void_value?(node)
           case node.parent.type
-          when :block
+          when :block, :numblock, :itblock
             example?(node.parent)
           when :begin, :case, :when
             void_value?(node.parent)

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -48,7 +48,7 @@ module RuboCop
 
         def nearest_subject(node)
           node
-            .each_ancestor(:block)
+            .each_ancestor(:any_block)
             .lazy
             .select { |block_node| multi_statement_example_group?(block_node) }
             .map { |block_node| find_subject(block_node) }

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def parent(node)
-          node.each_ancestor(:block).first.body
+          node.each_ancestor(:any_block).first.body
         end
 
         def autocorrect(corrector, node, sibling)

--- a/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
+++ b/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
@@ -122,7 +122,9 @@ module RuboCop
         private
 
         def inside_describe_block?(node)
-          node.each_ancestor(:block).any? { |ancestor| spec_group?(ancestor) }
+          node.each_ancestor(:any_block).any? do |ancestor|
+            spec_group?(ancestor)
+          end
         end
 
         def explicit_namespace?(namespace)

--- a/lib/rubocop/cop/rspec/leaky_local_variable.rb
+++ b/lib/rubocop/cop/rspec/leaky_local_variable.rb
@@ -148,7 +148,9 @@ module RuboCop
         end
 
         def inside_describe_block?(node)
-          node.each_ancestor(:block).any? { |ancestor| spec_group?(ancestor) }
+          node.each_ancestor(:any_block).any? do |ancestor|
+            spec_group?(ancestor)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -42,7 +42,7 @@ module RuboCop
 
         # @!method example_or_shared_group_or_including?(node)
         def_node_matcher :example_or_shared_group_or_including?, <<~PATTERN
-          (block {
+          (any_block {
             (send #rspec? {#SharedGroups.all #ExampleGroups.all} ...)
             (send nil? #Includes.all ...)
           } ...)
@@ -59,13 +59,15 @@ module RuboCop
         # @!method method_called?(node)
         def_node_search :method_called?, '(send nil? %)'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler, InternalAffairs/ItblockHandler
+        def on_block(node)
           return unless example_or_shared_group_or_including?(node)
 
           unused_let_bang(node) do |let|
             add_offense(let)
           end
         end
+        alias on_numblock on_block
+        alias on_itblock on_block
 
         private
 
@@ -84,7 +86,7 @@ module RuboCop
         end
 
         def overrides_outer_let_bang?(node, method_name)
-          node.each_ancestor(:block).any? do |ancestor|
+          node.each_ancestor(:any_block).any? do |ancestor|
             next unless example_or_shared_group_or_including?(ancestor)
 
             outer_let_bang?(ancestor, method_name)

--- a/lib/rubocop/cop/rspec/mixin/inside_example.rb
+++ b/lib/rubocop/cop/rspec/mixin/inside_example.rb
@@ -8,7 +8,7 @@ module RuboCop
         private
 
         def inside_example?(node)
-          node.each_ancestor(:block).any? { |ancestor| example?(ancestor) }
+          node.each_ancestor(:any_block).any? { |ancestor| example?(ancestor) }
         end
       end
     end

--- a/lib/rubocop/cop/rspec/repeated_subject_call.rb
+++ b/lib/rubocop/cop/rspec/repeated_subject_call.rb
@@ -79,7 +79,7 @@ module RuboCop
         end
 
         def expect_block(node)
-          node.each_ancestor(:block).find { |block| block.method?(:expect) }
+          node.each_ancestor(:any_block).find { |block| block.method?(:expect) }
         end
 
         def detect_offenses_in_block(node, subject_names = [])
@@ -89,7 +89,8 @@ module RuboCop
             return detect_offenses_in_example(node, subject_names)
           end
 
-          node.each_child_node(:send, :def, :block, :begin) do |child|
+          node.each_child_node(:send, :def, :any_block,
+                               :begin) do |child|
             detect_offenses_in_block(child, subject_names)
           end
         end
@@ -109,9 +110,9 @@ module RuboCop
         end
 
         def detect_subjects_in_scope(node)
-          node.each_descendant(:block).with_object({}) do |child, h|
+          node.each_descendant(:any_block).with_object({}) do |child, h|
             subject?(child) do |name|
-              outer_example_group = child.each_ancestor(:block).find do |a|
+              outer_example_group = child.each_ancestor(:any_block).find do |a|
                 example_group?(a)
               end
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -124,11 +124,11 @@ module RuboCop
         private
 
         def find_all_explicit(node)
-          node.each_descendant(:block).with_object({}) do |child, h|
+          node.each_descendant(:any_block).with_object({}) do |child, h|
             name = yield(child)
             next unless name
 
-            outer_example_group = child.each_ancestor(:block).find do |a|
+            outer_example_group = child.each_ancestor(:any_block).find do |a|
               example_group?(a)
             end
 
@@ -145,7 +145,8 @@ module RuboCop
           expectation_detected = message_expectation?(node, names)
           return yield(node) if expectation_detected
 
-          node.each_child_node(:send, :def, :block, :begin) do |child|
+          node.each_child_node(:send, :def, :any_block,
+                               :begin) do |child|
             find_subject_expectations(child, subject_names, &block)
           end
         end

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -31,7 +31,7 @@ module RuboCop
 
       # @!method shared_group?(node)
       def_node_matcher :shared_group?,
-                       '(block (send #rspec? #SharedGroups.all ...) ...)'
+                       '(any_block (send #rspec? #SharedGroups.all ...) ...)'
 
       # @!method spec_group?(node)
       def_node_matcher :spec_group?, <<~PATTERN
@@ -42,11 +42,12 @@ module RuboCop
 
       # @!method example_group_with_body?(node)
       def_node_matcher :example_group_with_body?, <<~PATTERN
-        (block (send #rspec? #ExampleGroups.all ...) args !nil?)
+        (any_block (send #rspec? #ExampleGroups.all ...) _ !nil?)
       PATTERN
 
       # @!method example?(node)
-      def_node_matcher :example?, '(block (send nil? #Examples.all ...) ...)'
+      def_node_matcher :example?,
+                       '(any_block (send nil? #Examples.all ...) ...)'
 
       # @!method hook?(node)
       def_node_matcher :hook?, <<~PATTERN

--- a/spec/rubocop/cop/rspec/discarded_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/discarded_matcher_spec.rb
@@ -318,4 +318,18 @@ RSpec.describe RuboCop::Cop::RSpec::DiscardedMatcher do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags a discarded matcher inside an `itblock` example' do
+      expect_offense(<<~RUBY)
+        specify do
+          it
+          expect { result }.to \\
+            change { obj.foo }.from(1).to(2)
+            change { obj.bar }.from(3).to(4)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The result of `change` is not used. Did you mean to chain it with `.and`?
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
@@ -130,4 +130,17 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
       end
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags an implicit block expectation in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        describe do
+          subject { -> { boom } }
+          it { is_expected.to change { something }.to(new_value) }
+               ^^^^^^^^^^^ Avoid implicit block expectations.
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -289,4 +289,15 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'does not crash when the example group is an `itblock`' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe User do
+          subject { described_class.new }
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
+++ b/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
@@ -168,4 +168,16 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
       RUBY
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags a constant declared in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        describe SomeClass do
+          CONSTANT = "Accessible as ::CONSTANT".freeze
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Stub constant instead of declaring explicitly.
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/leaky_local_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/leaky_local_variable_spec.rb
@@ -356,4 +356,18 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyLocalVariable, :config do
       end
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags a leaked local variable in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        describe SomeClass do
+          user = create(:user)
+          ^^^^^^^^^^^^^^^^^^^^ Do not use local variables defined outside of examples inside of them.
+
+          before { user.update(admin: true) }
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -257,4 +257,20 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
       end
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags an unused `let!` in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          let!(:foo) { bar }
+          ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+          it 'does not use foo' do
+            expect(baz).to eq(qux)
+          end
+          it
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
@@ -155,4 +155,21 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
       subject
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags a repeated subject call in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        RSpec.describe Foo do
+          context 'ctx' do
+            it do
+              subject
+              expect { subject }.to not_change { Foo.count }
+              ^^^^^^^^^^^^^^^^^^ Calls to subject are memoized, this block is misleading
+            end
+            it
+          end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -453,4 +453,26 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       end
     end
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'flags stubbing the subject in an `itblock` example group' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          context 'ctx' do
+            subject(:foo) { described_class.new }
+
+            before do
+              allow(foo).to receive(:bar).and_return(baz)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+            end
+
+            it 'uses expect twice' do
+              expect(foo.bar).to eq(baz)
+            end
+            it
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to the spot check discussed in #2209.

Under Ruby 3.4 / Prism, a bare `it` (pending example) or a numbered
parameter makes the enclosing block parse as an `itblock`/`numblock`
instead of a `block`. Several cops assume `:block` and so silently stop
flagging (and in a couple of cases risk a false positive) when an example
or example group takes that form.

This makes block-type handling uniform across five spots:

1. **Traversal** — `each_ancestor(:block)` / `each_descendant(:block)` → `:any_block`.
2. **Node patterns** — `example?`, `example_group_with_body?` (also relaxing its fixed `args` child, which an `itblock`/`numblock` doesn't have), `shared_group?`, and per-cop matchers → `any_block`.
3. **`each_child_node(…, :block, …)`** → `:any_block`.
4. **Callback registration** — `on_block`-only cops → add `on_numblock`/`on_itblock` (following `AroundBlock`/`IteratedExpectation`).
5. **Type dispatch** — `case node.parent.type; when :block` in `DiscardedMatcher#void_value?`.

Adds `:ruby34` regression specs to each affected cop. Full suite is green locally (2466 examples, 0 failures); `bundle exec rake internal_investigation` is clean.

Opening as a **draft**: it touches shared `Language` patterns and several cops, so I'm happy to split/stage it however you prefer (cf. #2209).
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [ ] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
